### PR TITLE
Terminal navigation/control

### DIFF
--- a/apps/linux/terminal.talon
+++ b/apps/linux/terminal.talon
@@ -1,0 +1,26 @@
+os: linux
+app: /.*terminal/
+-
+action(app.tab_open):
+  key(ctrl-shift-t)
+action(app.tab_close):
+  key(ctrl-shift-w)
+action(app.tab_next):
+  key(ctrl-pagedown)
+action(app.tab_previous):
+  key(ctrl-pageup)
+go tab <number>:
+  user.knausj_talon.code.formatters.modifier_number("alt", number)
+run last:
+  key(up)
+  key(enter)
+kill all:
+  key(ctrl-c)
+action(edit.page_down):
+  key(shift-pagedown)
+action(edit.page_up):
+  key(shift-pageup)
+action(edit.paste):
+  key(ctrl-shift-v)
+action(edit.copy):
+  key(ctrl-shift-c)

--- a/apps/mac/terminal.talon
+++ b/apps/mac/terminal.talon
@@ -1,0 +1,20 @@
+os: mac
+app: Terminal
+-
+action(app.tab_open):
+  key(cmd-t)
+action(app.tab_close):
+  key(cmd-w)
+action(app.tab_next):
+  key(ctrl-tab)
+action(app.tab_previous):
+  key(ctrl-shift-tab)
+run last:
+    key(up)
+    key(enter)
+kill all:
+      key(ctrl-c)
+action(edit.page_down):
+  key(command-pagedown)
+action(edit.page_up):
+  key(command-pageup)

--- a/apps/win/terminal.talon
+++ b/apps/win/terminal.talon
@@ -1,0 +1,10 @@
+os: mac
+app: Terminal
+-
+run last:
+  key(up)
+  key(enter)
+kill all:
+  key(ctrl-c)
+  insert("y")
+  key(enter)

--- a/misc/tabs.talon
+++ b/misc/tabs.talon
@@ -7,7 +7,8 @@ app: Notepad++ : a free (GNU) source code editor
 app: Microsoft Edge
 app: MicrosoftEdge.exe
 app: Safari
-app: Code 
+app: Code
+app: /.*terminal/
 -
 open tab: app.tab_open()
 last tab: app.tab_previous()

--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -41,6 +41,12 @@ go way down:
 go way up: 
 	edit.file_start()
 
+go page down:
+	edit.page_down()
+
+go page up:
+	edit.page_up()
+
 # selecting
 select line: 
 	edit.line_start()


### PR DESCRIPTION
Add page up/down to allow scrolling in editors
Windows doesn't have tabs so nothing for those
Followed https://support.apple.com/en-gb/guide/terminal/trmlshtcts/mac for shortcuts for mac

It'd be better if "go tab" was part of the generic_browser but I'm not sure how to pass along the number the user says so did it this way for now