### PR TITLE
add indentation voice hooks to generic editor

### DIFF
--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -82,6 +82,13 @@ select way up:
 select way down: 
 	edit.extend_file_end()
 
+# editing
+indent [more]:
+	edit.indent_more()
+
+(indent less | out dent):
+	edit.indent_less()
+
 # deleting
 clear line: 
 	edit.delete_line()


### PR DESCRIPTION
This PR adds voice command hooks for indentation to the generic editor. "indent" is pretty straightforward - wasn't sure what people would try for removing indentation, so I left a couple options "indent less" and "out dent". Happy to change the commands if there's feelings about what it should be.