### PR TITLE
Allow Jetbrains to work on MacOS, Linux and Windows

### DIFF
--- a/code/jetbrains.py
+++ b/code/jetbrains.py
@@ -98,7 +98,8 @@ def _get_nonce(port):
 
 def send_idea_command(cmd):
     print("Sending {}".format(cmd))
-    bundle = ui.active_app().bundle
+    active_app = ui.active_app()
+    bundle = active_app.bundle or active_app.name
     port = port_mapping.get(bundle, None)
     nonce = _get_nonce(port)
     print(f"sending {bundle} {port} {nonce}")


### PR DESCRIPTION
bundle doesn't exist on Linux or Windows. Use it if it does (MacOS) but use name if it doesn't.

Be nice if we can just use name and update the name map to work for MacOS but I don't have a Mac to test with :(