### PR TITLE
Fix user.letters to return a list of letters

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -172,7 +172,7 @@ def key(m) -> str:
 
 @ctx.capture(rule='{self.letter}+')
 def letters(m):
-    return m.letter
+    return m.letter_list
 
 @mod.action_class
 class Actions:


### PR DESCRIPTION
Previously it was returning only one letter, so saying "uppercase <some
letters here>" would only insert the first letter spoken