### PR TITLE
Updates to 1Password: make it more consistent with their published keyboard shortcuts

### DIFF
--- a/apps/mac/password_manager.talon
+++ b/apps/mac/password_manager.talon
@@ -20,5 +20,5 @@ action(user.password_edit):
 	key(cmd-e)
 	
 action(user.password_delete):
-	key(cmd-delete)
+	key(cmd-backspace)
 

--- a/apps/mac/password_manager.talon
+++ b/apps/mac/password_manager.talon
@@ -5,14 +5,10 @@ os: mac
 #the below are for 1password, redefine as needed
 -
 action(user.password_fill):
-	user.password_show()
-	sleep(300ms)
-	key(enter)
-	sleep(300ms)
-	key(enter)
+	key(cmd-\)
 
 action(user.password_show):
-	key(cmd-shift-x)
+	key(cmd-alt-\)
 	
 action(user.password_new):
 	key(cmd-i)

--- a/misc/1password.talon
+++ b/misc/1password.talon
@@ -2,6 +2,7 @@ app: 1Password.exe
 app: 1Password for Windows desktop
 app: com.agilebits.onepassword7
 -
-password dup: user.password_show()
+password new: user.password_new()
+password dup: user.password_duplicate()
 password edit: user.password_edit()
 password delete: user.password_delete()

--- a/misc/1password.talon
+++ b/misc/1password.talon
@@ -1,6 +1,6 @@
 app: 1Password.exe
 app: 1Password for Windows desktop
-app: 1Password7
+app: com.agilebits.onepassword7
 -
 password dup: user.password_show()
 password edit: user.password_edit()

--- a/misc/1password_global.talon
+++ b/misc/1password_global.talon
@@ -1,6 +1,4 @@
 #todo: tags
 -
 password fill: user.password_fill()
-password duplicate: user.password_duplicate()
-password new: user.password_new()
 password show: user.password_show()


### PR DESCRIPTION
A few changes to bring 1Password more consistent with their published keyboard shortcut documentation:
* 1Password has a keyboard shortcut to fill the password. We can use that rather than implementing ourselves.
* Use shortcut provided by the docs for "password show". I'm not sure where `cmd-shift-x` came from... it doesn't work for me, but maybe @mkandalf can comment on the intent if I'm missing something? IMO, seems best to use the shortcuts provided in the docs unless there's a good reason.
* Use app.bundle() for the context scope as 1Password7 didn't seem to work (I checked "help context" with 1Password in focus and the context wasn't active).
* Only global commands should be in global context and move others to app scoped context. These are grouped based on the 1Password keyboard shortcut documentation that lives here: https://support.1password.com/keyboard-shortcuts/