### PR TITLE
Fix errors for linux file manager

### DIFF
--- a/apps/file_manager.talon
+++ b/apps/file_manager.talon
@@ -9,6 +9,9 @@ app: com.apple.finder
 app: Terminal
 app: iTerm2
 app: com.apple.Terminal
+
+os: linux
+app: Caja
 -
 settings():
     # enable if you'd like the picker gui to automatically appear when explorer has focus

--- a/code/file_manager.py
+++ b/code/file_manager.py
@@ -31,6 +31,7 @@ file_selections = []
 is_windows = False
 is_mac = False
 is_terminal = False
+is_linux = False
 
 if "Windows-10" in platform:
     is_windows = True
@@ -71,6 +72,13 @@ elif "Darwin" in platform:
     ctx.lists['user.file_manager_directory_exclusions'] = {}
     supported_programs = ["com.apple.Terminal", "com.apple.finder"]
     terminal_programs = ["com.apple.Terminal",]
+
+elif "linux" in platform.lower():
+    is_linux = True
+    ctx.lists['user.file_manager_directory_remap'] = {}
+    ctx.lists['user.file_manager_directory_exclusions'] = {}
+    supported_programs = ['Caja']
+    terminal_programs = ['terminal']
 
 @mod.capture
 def file_manager_directories(m) -> str:
@@ -219,6 +227,10 @@ class Actions:
                 else:
                     actions.insert(path)
                 actions.key("enter")
+            elif is_linux:
+                actions.key("ctrl-l")
+                actions.insert(path)
+                actions.key("enter")
 
     def file_manager_select_directory(path: Union[str, int]):
         """selects the directory"""
@@ -267,6 +279,9 @@ def update_maps(window):
             if item in window.app.bundle:
                 is_terminal = True
                 break
+        elif is_linux:
+            if item in window.app.name:
+                is_terminal = True
 
     if not is_supported or title in registry.lists["user.file_manager_directory_exclusions"][0] or not title or title == "":
         ctx.lists["self.file_manager_directories"] = []


### PR DESCRIPTION
The below is triggered unless we setup some mapping on Linux.
Also allow "go pictures" etc to work on XFCE Caja

2020-04-06 15:10:10 ERROR cb error topic="win_focus" cb=<function update_maps at 0x7f05cc7bd710>
   20:             lib/python3.7/threading.py:890|
   19:             lib/python3.7/threading.py:926|
   18:             lib/python3.7/threading.py:870|
   17:                 talon/linux/xevents.py:130|
   16:                 talon/linux/xevents.py:94 |
   15:                 talon/linux/xevents.py:86 |
   14:            talon/scripting/dispatch.py:97 |
   13:            talon/scripting/dispatch.py:132|
   12:            talon/scripting/dispatch.py:123|
   11:                talon/scripting/rctx.py:174|
   10: ------------------------------------------# 'win_focus' main:_on_event()
    9:                      talon/linux/ui.py:68 |
    8:            talon/scripting/dispatch.py:97 |
    7:            talon/scripting/dispatch.py:132|
    6:            talon/scripting/dispatch.py:125|
    5:                talon/scripting/rctx.py:176|
    4: ------------------------------------------# 'win_focus' user.knausj_talon.code.file_manager:update_maps()
    3: ------------------------------------------# stack splice
    2:                talon/scripting/rctx.py:174|
    1: user/knausj_talon/code/file_manager.py:247| if title in registry.lists['user.file_manager_directory_remap'][0]:
KeyError: 'user.file_manager_directory_remap'