### PR TITLE
add docstrings for window resizing actions

### DIFF
--- a/code/ide.py
+++ b/code/ide.py
@@ -450,13 +450,13 @@ class Actions:
         """Continue running from current statement"""
 
     def ide_resize_window_right():
-        """"""
+        """Resize window right"""
 
     def ide_resize_window_left():
-        """"""
+        """Resize window left"""
 
     def ide_resize_window_up():
-        """"""
+        """Resize window up"""
 
     def ide_resize_window_down():
-        """"""
+        """Resize window down"""


### PR DESCRIPTION
Fixes `actions.list()`.

Before:

```
>>> actions.list()
....
user.ide_rename_file()
  Trigger rename file of IDE
user.ide_resize_window_down()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "talon/scripting/actions.py", line 78, in list
TypeError: can only concatenate str (not "NoneType") to str
>>> 
```

After:
```
>>> actions.list()
....
user.ide_toggle_whitespace()
  Hide/Show whitespaces
user.ide_toggle_windowed()
  Change windowed mode of view
user.ide_toggle_wrap()
  Enable/disable word wrap
user.ide_up_cursor()
  Add a cursor above current cursors
>>> 
```