### PR TITLE
change code.language matching so it also works on Linux terminals

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -12,27 +12,25 @@ extension_lang_map = {
 "talon": "talon",
 }
 
-regex_ext = re.compile("\.(\S*)\s*")
- 
+# The [^\\/] is specifically to avoid matching something like a .talon folder
+# that would otherwise cause the .talon file action to load
+regex_ext = re.compile("[^\\/]\.(\S*)\s*")
+
 @ctx.action_class('code')
 class CodeActions:
     def language(): 
         title = ui.active_window().title
         #print(str(ui.active_app()))
-        #workaround for VS Code on Mac. The title is "", 
-        #but the doc is correct. we will assume the last split
-        #has the extension. this may need to be implemented per-app
-        #this is necesary for things in e.g. .talon
+        #workaround for VS Code on Mac. The title is "",
+        #but the doc is correct.
         if title == "":
             title = ui.active_window().doc
-
-        title = title.split(os.path.sep)[-1]
 
         m = regex_ext.search(title)
         if m:
             extension = m.group(1)
             if extension in extension_lang_map:
-                
+
                 return extension_lang_map[extension]
             else:
                 return extension


### PR DESCRIPTION
Test on Linux in termite running VIM where the titles are something like `code.py (~/.talon/user/fidget/code) - VIM` which causes the old code not to match correctly.

Confirmed that the `.talon` `code.language` context won't load when editing `code.py` despite `.talon` being in the path, but editing an actual `.talon` file will load it correctly.