### PR TITLE
add signal messenger

### DIFF
--- a/apps/linux/signal.talon
+++ b/apps/linux/signal.talon
@@ -1,0 +1,45 @@
+os: linux
+app: signal
+app: Signal
+-
+show shortcuts: key("ctrl-/")
+
+# Note that the order below matches Keyboard Shortcuts listings
+
+# Navigation
+(next|nav|navigate) [by] (sec|section): key("ctrl-t")
+(prev|previous) (chat|conversation): key("alt-down")
+next (chat|conversation): key("alt-up")
+(prev|previous) unread: key("alt-shift-down")
+next unread: key("alt-shift-up")
+[open] (pref|preferences): key("ctrl-,")
+open conversation menu: key("ctrl-shift-l")
+search: key("ctrl-f")
+search chat: key("ctrl-shift-f")
+focus (chat|composer): key("ctrl-shift-t")
+open media: key("ctrl-shift-m")
+open emoji: key("ctrl-shift-j")
+open sticker: key("ctrl-shift-s")
+record [voice] message: key("ctrl-shift-v")
+archive chat: key("ctrl-shift-a")
+unarchive chat: key("ctrl-shift-u")
+(first|top) message: key("ctrl-up")
+(last|bottom) message: key("ctrl-down")
+close chat: key("ctrl-shift-c")
+
+# Messages
+send it: key("enter")
+message details: key("ctrl-d")
+reply [message]: key("ctrl-shift-r")
+react [message]: key("ctrl-shift-e")
+save attachment: key("ctrl-s")
+delete [message]: key("ctrl-shift-d")
+
+# Composer
+send message: key("ctrl-enter")
+expand chat: key("ctrl-shift-x")
+send message: key("ctrl-enter")
+attach [file]: key("ctrl-u")
+remove [link] preview: key("ctrl-p")
+remove [link] attachment: key("ctrl-shift-p")
+


### PR DESCRIPTION
support for the signal messenger on linux. i suspect the shortcuts might be the same on windows but i've never tried it. 