### PR TITLE
add support for protonmail web application

### DIFF
--- a/apps/linux/protonmail.talon
+++ b/apps/linux/protonmail.talon
@@ -1,0 +1,82 @@
+app: firefox
+app: Firefox
+win.title: /ProtonMail/
+-
+# General
+## Application
+open help: key(?)
+[focus] search: key(/)
+confirm active: key(enter)
+close active: key(escape)
+open command [palette]: key(shift-space)
+
+## Composer
+new message: key(c)
+send message: key(ctrl-enter)
+save message: key(ctrl-s)
+
+# Mail
+## Jumping
+(go|jump) [to] inbox:
+    key(g)
+    key(i)
+(go|jump) [to] draft:
+    key(g)
+    key(d)
+(go|jump) [to] sent:
+    key(g)
+    key(s)
+(go|jump) [to] starred:
+    key(g)
+    key(.)
+(go|jump) [to] archive:
+    key(g)
+    key(a)
+(go|jump) [to] spam:
+    key(g)
+    key(x)
+(go|jump) [to] trash:
+    key(g)
+    key(t)
+
+## Navigation
+(prev|previous) message: key(up)
+next message: key(down)
+exit message: key(left)
+enter message: key(right)
+(show|display) newer [message]: key(k)
+(show|display) older [message]: key(j)
+open message: key(enter)
+go back: key(escape)
+
+## Threadlist
+select all:
+    key(*)
+    key(a)
+(deselect|unselect) all:
+    key(*)
+    key(n)
+select [the] (message|conversation): key(x)
+mark [as] read: key(r)
+mark [as] unread: key(u)
+star (message|conversation): key(.)
+move to inbox: key(i)
+move to trash: key(t)
+move to archive: key(a)
+move to spam: key(s)
+
+## Actions
+reply to (message|conversation): key(shift-r)
+reply all [to] (message|conversation): key(shift-a)
+forward (message|conversation): key(shift-f)
+
+# Contacts
+## Contact List
+(prev|previous) contact: key(up)
+next contact: key(down)
+enter contact: key(right)
+delete contact: key(t)
+
+## Contact Details
+exit contact: key(left)
+save contact: key(ctrl-s)

--- a/apps/linux/protonmail.talon
+++ b/apps/linux/protonmail.talon
@@ -1,5 +1,5 @@
-app: firefox
-app: Firefox
+os:linux
+tag: browser
 win.title: /ProtonMail/
 -
 # General


### PR DESCRIPTION
i originally had this in its own web/ directory on my fork rather than apps since its technically a website and so the short cuts should roughly match for every system, but i guess the problem is that on mac the control keys will end up being command key. but i think for stuff like this it would be better to have some sort of setting where we say on mac use command key and on everything else use control key and then just have talon figure it out on the fly?