### PR TITLE
fix next/last window not working on mac

### DIFF
--- a/apps/mac/app.talon
+++ b/apps/mac/app.talon
@@ -31,10 +31,10 @@ action(app.window_hide_others):
 	key(cmd-option-h)
 	
 action(app.window_next):
-	key(cmd-~)
+	key(cmd-`)
 
 action(app.window_open):
 	key(cmd-n)
 	
 action(app.window_previous):
-	key(cmd-shift-~)
+	key(cmd-shift-`)


### PR DESCRIPTION
I think this broke for some reason after the latest update. This fixed it for me and wanted to share.