### PR TITLE
better integration of digits and numbers

### DIFF
--- a/code/numbers.py
+++ b/code/numbers.py
@@ -180,7 +180,7 @@ def number_scaled(m):
 # Example: " one one five            " == 115
 #          " one fifteen             " == 115
 #          " one hundred and fifteen " == 115
-@ctx.capture("number", rule=f"(<digits> | [<digits>] <user.number_scaled>)$")
+@ctx.capture("number", rule=f"(<digits> | [<digits>] <user.number_scaled>)")
 def number(m):
     return "".join(str(i) for i in list(m))
 

--- a/code/numbers.py
+++ b/code/numbers.py
@@ -182,7 +182,7 @@ def number_scaled(m):
 #          " one hundred and fifteen " == 115
 @ctx.capture("number", rule=f"(<digits> | [<digits>] <user.number_scaled>)")
 def number(m):
-    return "".join(str(i) for i in list(m))
+    return int("".join(str(i) for i in list(m)))
 
 
 @ctx.capture("number_signed", rule=f"[negative] <number>")

--- a/code/numbers.py
+++ b/code/numbers.py
@@ -1,22 +1,66 @@
 from talon import Context, Module, actions
 
-digits = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']
-teens = ['eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen']
-tens = ['ten', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety']
-scales = ['hundred', 'thousand', 'million', 'billion', 'trillion', 'quadrillion', 'quintillion', 'sextillion', 'septillion', 'octillion', 'nonillion', 'decillion']
+digits = [
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+]
+teens = [
+    "eleven",
+    "twelve",
+    "thirteen",
+    "fourteen",
+    "fifteen",
+    "sixteen",
+    "seventeen",
+    "eighteen",
+    "nineteen",
+]
+tens = [
+    "ten",
+    "twenty",
+    "thirty",
+    "forty",
+    "fifty",
+    "sixty",
+    "seventy",
+    "eighty",
+    "ninety",
+]
+scales = [
+    "hundred",
+    "thousand",
+    "million",
+    "billion",
+    "trillion",
+    "quadrillion",
+    "quintillion",
+    "sextillion",
+    "septillion",
+    "octillion",
+    "nonillion",
+    "decillion",
+]
 
-digits_map = {n: i            for i, n in enumerate(digits)}
-teens_map  = {n: i + 11       for i, n in enumerate(teens)}
-tens_map   = {n: 10 * (i + 1) for i, n in enumerate(tens)}
-digits_map['oh'] = 0
+digits_map = {n: i for i, n in enumerate(digits)}
+teens_map = {n: i + 11 for i, n in enumerate(teens)}
+tens_map = {n: 10 * (i + 1) for i, n in enumerate(tens)}
+digits_map["oh"] = 0
 
 scales_map = {scales[0]: 100}
 scales_map.update({n: 10 ** ((i + 1) * 3) for i, n in enumerate(scales[1:])})
 
-alt_digits = '(' + ('|'.join( digits_map.keys())) + ')'
-alt_teens  = '(' + ('|'.join( teens_map.keys()))  + ')'
-alt_tens   = '(' + ('|'.join( tens_map.keys()))   + ')'
-alt_scales = '(' + ('|'.join( scales_map.keys())) + ')'
+alt_digits = "(" + ("|".join(digits_map.keys())) + ")"
+alt_teens = "(" + ("|".join(teens_map.keys())) + ")"
+alt_tens = "(" + ("|".join(tens_map.keys())) + ")"
+alt_scales = "(" + ("|".join(scales_map.keys())) + ")"
 
 # fuse scales (hundred, thousand) leftward onto numbers (one, twelve, twenty, etc)
 def fuse_scale(words, limit=None):
@@ -30,7 +74,7 @@ def fuse_scale(words, limit=None):
         elif w in scales_map and (limit is None or scales_map[w] < limit):
             scale *= scales_map[w]
             continue
-        elif w == 'and':
+        elif w == "and":
             continue
 
         if n is not None:
@@ -46,6 +90,7 @@ def fuse_scale(words, limit=None):
     if n is not None:
         ret.append(n * scale)
     return ret
+
 
 # fuse small numbers leftward onto larger numbers
 def fuse_num(words):
@@ -77,7 +122,8 @@ def fuse_num(words):
         ret.append(acc)
     return ret
 
-'''
+
+"""
 def test_num(n):
     print('testing', n)
     step1 = fuse_scale(list(n), 1000)
@@ -96,15 +142,19 @@ assert(test_num([1, 'million', 5, 'hundred', 1, 'thousand']) == 1501000)
 assert(test_num([1, 'million', 5, 'hundred', 'and', 1, 'thousand', 1, 'hundred', 'and', 6]) == 1501106)
 assert(test_num([1, 'million', 1, 1]) == 10000011)
 assert(test_num([1, 'million', 10, 10]) == 100001010)
-'''
+"""
 
 ctx = Context()
 
-@ctx.capture('digits', rule=f'{alt_digits}+')
-def digits(m):
-    return int(''.join([str(digits_map[n]) for n in m]))
 
-@ctx.capture('number_small', rule=f'({alt_digits} | {alt_teens} | {alt_tens} [{alt_digits}])')
+@ctx.capture("digits", rule=f"{alt_digits}+")
+def digits(m):
+    return int("".join([str(digits_map[n]) for n in m]))
+
+
+@ctx.capture(
+    "number_small", rule=f"({alt_digits} | {alt_teens} | {alt_tens} [{alt_digits}])"
+)
 def number_small(m):
     result = 0
     for word in m:
@@ -116,28 +166,38 @@ def number_small(m):
             result += teens_map[word]
     return result
 
-@ctx.capture('self.number_scaled', rule=f'(<digits> | [<digits>] <number_small> [{alt_scales} ([and] (<number_small> | {alt_scales} | <number_small> {alt_scales}))*])')
+
+@ctx.capture(
+    "self.number_scaled",
+    rule=f"<number_small> [{alt_scales} ([and] (<number_small> | {alt_scales} | <number_small> {alt_scales}))*]",
+)
 def number_scaled(m):
     return fuse_num(fuse_scale(fuse_num(fuse_scale(list(m), 3))))[0]
+
 
 # This rule offers more colloquial number speaking when combined with a command
 # like: "go to line <number>"
 # Example: " one one five            " == 115
 #          " one fifteen             " == 115
 #          " one hundred and fifteen " == 115
-@ctx.capture('number', rule=f'(<digits> | [<digits>] <user.number_scaled>)$')
+@ctx.capture("number", rule=f"(<digits> | [<digits>] <user.number_scaled>)$")
 def number(m):
     return "".join(str(i) for i in list(m))
 
-@ctx.capture('number_signed', rule=f'[negative] <number>')
+
+@ctx.capture("number_signed", rule=f"[negative] <number>")
 def number_signed(m):
     number = m[-1]
-    if m[0] == 'negative':
+    if m[0] == "negative":
         return -number
     return number
 
+
+# XXX - hack until i can figure out the proper way to integrate directly into
+# number
 mod = Module()
-mod.list('number_scaled',    desc='Mix of numbers and digits')
+mod.list("number_scaled", desc="Mix of numbers and digits")
+
 
 @mod.capture
 def number_scaled(m) -> str:

--- a/code/numbers.py
+++ b/code/numbers.py
@@ -193,8 +193,6 @@ def number_signed(m):
     return number
 
 
-# XXX - hack until i can figure out the proper way to integrate directly into
-# number
 mod = Module()
 mod.list("number_scaled", desc="Mix of numbers and digits")
 


### PR DESCRIPTION
this solves the problem described in the code comment. originally aegis proposed that i switch it so that the existing `number` rule contained the new `digits` references, but it seems like that is a problem because of the way the existing scaled function call is done, since we have no easy way to differentiate the `digits` digits and actual `number` digits passed in m. so i opted to change the existing `numbers` rule into a new name. i'm not sure how to create a name that isn't part of the `user.` object prefix, because trying new create one without it would always say that it wasn't defined, which is why it became `user.number_scaled` for now.

anyways i'm happy to change this if you have ideas but definitely way easier to use this number method than the existing one because you can speak numbers much more naturally