### PR TITLE
modified code.py file suffix identification regex

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -1,28 +1,35 @@
 from talon import Context, actions, ui, Module
 import re
-import os 
+
 ctx = Context()
 key = actions.key
 
 extension_lang_map = {
-"py"   : "python",
-"cs"   : "csharp",
-"cpp"  : "cplusplus",
-"h"    : "cplusplus",
-"talon": "talon",
+    "py": "python",
+    "cs": "csharp",
+    "cpp": "cplusplus",
+    "h": "cplusplus",
+    "talon": "talon",
+    "gdb": "gdb",
+    "md": "markdown",
+    "sh": "bash",
 }
 
 # The [^\\\/] is specifically to avoid matching something like a .talon folder
 # that would otherwise cause the .talon file action to load
-regex_ext = re.compile("[^\\\/]\.(\S*)\s*")
+# This fails if a filename has something like: foo.95.py
+# regex_ext = re.compile("[^\\\/]\.(\S*)\s*")
+# Below seems to  solve the above problem. Works by matching the last dot
+# followed by non doot characters and then a space or end of line
+regex_ext = re.compile("\.([^.]*)[ \$]")
 
 @ctx.action_class('code')
 class CodeActions:
-    def language(): 
+    def language():
         title = ui.active_window().title
-        #print(str(ui.active_app()))
-        #workaround for VS Code on Mac. The title is "",
-        #but the doc is correct.
+        # print(str(ui.active_app()))
+        # workaround for VS Code on Mac. The title is "",
+        # but the doc is correct.
         if title == "":
             title = ui.active_window().doc
 
@@ -30,7 +37,6 @@ class CodeActions:
         if m:
             extension = m.group(1)
             if extension in extension_lang_map:
-
                 return extension_lang_map[extension]
             else:
                 return extension


### PR DESCRIPTION
this adds a few additional languages, a few minor pep8-related tweaks, but most importantly I modified the regex because a file naming convention I was using was causing problems. the modified regex seems to work fine for me across the board so far (been a couple weeks?), but I suspect it might run into problems on mac or windows, so I'm just posting a pull request so you can test it out on your end