### PR TITLE
click on pop fix

### DIFF
--- a/code/mouse.py
+++ b/code/mouse.py
@@ -190,7 +190,7 @@ def on_pop(active):
     if (gaze_job or scroll_job):
         if settings.get("user.mouse_enable_pop_stops_scroll") >= 1:
             stop_scroll()
-    elif not eye_zoom_mouse.zoom_mouse.enabled and eye_mouse.mouse.attached_tracker is not None:
+    if not eye_zoom_mouse.zoom_mouse.enabled and eye_mouse.mouse.attached_tracker is not None:
         if settings.get("user.mouse_enable_pop_click") >= 1:
             ctrl.mouse_click(button=0, hold=16000)
 


### PR DESCRIPTION
Literally only a 2 letter PR :) 
Not sure if this is a bug or intended behaviour:
Right now if the user specifies that pop should click and it should not end the gaze_wheel, it does not click on pop when gaze_wheel is active.
The behaviour that I think is logical is that it does click under these circumstances. Am I the only one? 
