### PR TITLE
linux firefox vimvixen support

### DIFF
--- a/apps/linux/vimvixen.talon
+++ b/apps/linux/vimvixen.talon
@@ -1,0 +1,126 @@
+os: linux
+tag: firefox
+-
+settings():
+    user.vimvixen_auto_focus = 1
+
+(page|tab) (previous|left):
+    user.vimvixen_key("K")
+(page|tab) (next|right):
+    user.vimvixen_key("J")
+(page|tab) (home|first):
+    user.vimvixen_key("g")
+    key(0)
+(page|tab) (end|last):
+    user.vimvixen_key("g")
+    key($)
+(page|tab) new:
+    user.vimvixen_key("ctrl-t")
+(page|tab) reopen:
+    user.vimvixen_key("ctrl-shift-t")
+(page|tab) close:
+    user.vimvixen_key("d")
+(page|tab) select:
+    user.vimvixen_key("b")
+last (page|tab):
+    user.vimvixen_key("ctrl-6")
+(page|tab) find:
+    user.vimvixen_key("b")
+    key(tab)
+(page|tab) find <phrase>:
+    user.vimvixen_key("b")
+    insert("{phrase}")
+(page|tab) open:
+    user.vimvixen_key("escape")
+    insert(":open ")
+    key(tab)
+(page|tab) open <phrase>:
+    user.vimvixen_focus()
+    insert(":open {phrase}")
+    key(tab)
+[(page|tab)] back:
+    user.vimvixen_key("H")
+[(page|tab)] forward:
+    user.vimvixen_key("L")
+[(page|tab)] refresh:
+    user.vimvixen_key("r")
+link:
+    user.vimvixen_key("f")
+link new:
+    user.vimvixen_key("shift-f")
+(address|Earl|link) bar:
+    user.vimvixen_key("ctrl-l")
+(address|Earl|link) copy:
+    user.vimvixen_key("y")
+copy (address|Earl|link):
+    user.vimvixen_key("y")
+add bookmark:
+    user.vimvixen_key("a")
+focus input:
+    user.vimvixen_key("g")
+    key("i")
+zoom in:
+    user.vimvixen_key("z")
+    key("i")
+zoom out:
+    user.vimvixen_key("z")
+    key("o")
+zoom reset:
+    user.vimvixen_key("z")
+    key(z)
+focus:
+    user.vimvixen_focus()
+search :
+    user.vimvixen_key("ctrl-k")
+search for <phrase>:
+    user.vimvixen_key("ctrl-k")
+    sleep(100ms)
+    insert("{phrase}")
+# If you use ddg by default
+# duckduckgo google mode
+google <phrase>:
+    user.vimvixen_key("ctrl-k")
+    sleep(100ms)
+    insert("!g {phrase}")
+# duckduckgo
+duck duck <phrase>:
+    user.vimvixen_key("ctrl-k")
+    sleep(100ms)
+    insert("{phrase}")
+
+#  Moving around
+(page|screen|scroll) down:
+    user.vimvixen_key("ctrl-f")
+half down:
+    user.vimvixen_key("ctrl-d")
+(page|screen|scroll) up:
+    user.vimvixen_key("ctrl-b")
+half up:
+    user.vimvixen_key("ctrl-u")
+top:
+    user.vimvixen_key("g")
+    key(g)
+bottom:
+    user.vimvixen_key("G")
+
+mark <user.letter>:
+    insert("m%({letter})s")
+go to mark <user.letter>':
+    insert("%({letter})s")
+#  Searching
+find <phrase>:
+    user.vimvixen_key("/")
+    insert("{phrase}")
+    user.vimvixen_key("enter")
+find:
+    user.vimvixen_key("/")
+next [result]:
+    user.vimvixen_key("n")
+(prev|previous) [result]:
+    user.vimvixen_key("N")
+(enable|disable) vixen:
+    user.vimvixen_key("shift-escape")
+open clipboard link:
+    user.vimvixen_key("p")
+open new clipboard link:
+    user.vimvixen_key("P")

--- a/code/vimvixen.py
+++ b/code/vimvixen.py
@@ -1,0 +1,54 @@
+import time
+
+from talon import Module, actions, settings
+
+mod = Module()
+mod.list("vimvixen", desc="Common vimvixen")
+mod.setting(
+    "vimvixen_auto_focus",
+    type=int,
+    default=0,
+    desc="Always attempt to focus vimvixen in a way from search, URL bar, etc",
+)
+
+
+class VimVixen:
+    def focus():
+        """
+        Implement a trick to cause vimvixen to focus correctly. This allows us
+        to run certain commands that wouldn't normally work, for instance if
+        you were already in the search bar, or the url bar, etc.
+        """
+        # highlight URL bar
+        actions.key("ctrl-l")
+        time.sleep(0.01)
+        # pop keyboard
+        actions.key("escape")
+        # trigger find (won't work unless we were in URL bar
+        actions.key("ctrl-f")
+        time.sleep(0.01)
+        # escape out of find window
+        actions.key("escape")
+        actions.key("escape")
+        # now have general focus
+
+
+@mod.action_class
+class Actions:
+    def vimvixen_focus():
+        "Expose VimVixen class method"
+        VimVixen.focus()
+
+    def vimvixen_key(key: str):
+        "Reguarly key prefixed with a focus. Helps keep the talon file clean"
+
+        if settings.get("user.vimvixen_auto_focus") >= 1:
+            VimVixen.focus()
+        actions.key(key)
+
+    def vimvixen_insert(text: str):
+        "Reguarly key prefixed with a focus. Helps keep the talon file clean"
+        # actions.user.focus_vimvixen()
+        if settings.get("user.vimvixen_auto_focus") >= 1:
+            VimVixen.focus()
+        actions.insert(text)

--- a/code/vimvixen.py
+++ b/code/vimvixen.py
@@ -40,15 +40,13 @@ class Actions:
         VimVixen.focus()
 
     def vimvixen_key(key: str):
-        "Reguarly key prefixed with a focus. Helps keep the talon file clean"
-
+        "Regular talon key() prefixed with an optional focus."
         if settings.get("user.vimvixen_auto_focus") >= 1:
             VimVixen.focus()
         actions.key(key)
 
     def vimvixen_insert(text: str):
-        "Reguarly key prefixed with a focus. Helps keep the talon file clean"
-        # actions.user.focus_vimvixen()
+        "Regular talon insert() prefixed with an optional focus."
         if settings.get("user.vimvixen_auto_focus") >= 1:
             VimVixen.focus()
         actions.insert(text)


### PR DESCRIPTION
Some of this in theory overlaps with commented out stuff in `apps/generic_browser.talon`, which I have never tried. 

Only tested on Linux. Also worth noting the setting for enabling a little hack to use vimvixen commands in annoying scenarios like when the URL bar is highlighted, etc. I chose to enable this by default, but we can change that if needed.