### PR TITLE
FIX: Documentation for Windows user path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Clone repo into `~/.talon/user`
     
 Alternatively, access the directory by right clicking the Talon icon in taskbar, and clicking `Scripting>Open ~/talon`, then navigating to `user`.
 
+On windows wherever the linux path `~/.talon` is displayed substitute it with the default windows home user directory which is `C:\Users\%username%\AppData\Roaming\talon`
+
 The folder structure should look like:
 
 `~/.talon/user/knausj_talon`
@@ -88,6 +90,8 @@ Note this is required for
 (2) the zoom mouse to appear over the start menu, and other applications with uiAccess; and
 
 (3) Talon to interact with User Account Control dialogs
+
+Talon configurations and customizations will usually be done in the default windows home user directory which is `C:\Users\%username%\AppData\Roaming\talon\user`
 
 ## .talon file
 


### PR DESCRIPTION
A small set of windows related clarifications. I initially made the mistake of creating .talon folder in the windows user directory not realizing it was already somewhere way down the `AppData` directory.

Talon and your .talon files are working great, I'm just still getting to grips with it and forget to see what I have included in my committing branch. thanks for your work in this awesome tool chain