### PR TITLE
Add standard programming commands

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -5,11 +5,13 @@ ctx = Context()
 key = actions.key
 
 extension_lang_map = {
-"py"   : "python",
-"cs"   : "csharp",
-"cpp"  : "cplusplus",
-"h"    : "cplusplus",
-"talon": "talon",
+    "vue": "javascript",
+    "js": "javascript",
+    "py": "python",
+    "cs": "csharp",
+    "cpp": "cplusplus",
+    "h": "cplusplus",
+    "talon": "talon",
 }
 
 # The [^\\\/] is specifically to avoid matching something like a .talon folder

--- a/code/programming.py
+++ b/code/programming.py
@@ -1,0 +1,97 @@
+from talon import app, Context, Module
+from talon.engine import engine
+
+mod = Module()
+
+
+@mod.action_class
+class Actions:
+    def code_if():
+        """if"""
+
+    def code_else():
+        """else"""
+
+    def code_else_if():
+        """else_if"""
+
+    def code_switch():
+        """switch"""
+
+    def code_case():
+        """case"""
+
+    def code_do_loop():
+        """do_loop"""
+
+    def code_while_loop():
+        """while_loop"""
+
+    def code_for_loop():
+        """for_loop"""
+
+    def code_for_each_loop():
+        """for_each_loop"""
+
+    def code_to_integer():
+        """to_integer"""
+
+    def code_to_float():
+        """to_float"""
+
+    def code_to_string():
+        """to_string"""
+
+    def code_to_boolean():
+        """to_boolean"""
+
+    def code_and():
+        """and"""
+
+    def code_or():
+        """or"""
+
+    def code_not():
+        """not"""
+
+    def code_sysout():
+        """sysout"""
+
+    def code_import():
+        """import"""
+
+    def code_from():
+        """from"""
+
+    def code_block():
+        """block"""
+
+    def code_function():
+        """function"""
+
+    def code_lambda():
+        """lambda"""
+
+    def code_class():
+        """class"""
+
+    def code_docstring():
+        """docstring"""
+
+    def code_comment():
+        """comment"""
+
+    def code_long_comment():
+        """long comment"""
+
+    def code_return():
+        """return"""
+
+    def code_null():
+        """null"""
+
+    def code_true():
+        """true"""
+
+    def code_false():
+        """false"""

--- a/lang/javascript.talon
+++ b/lang/javascript.talon
@@ -1,0 +1,133 @@
+code.language: javascript
+-
+
+const:
+  insert("const ")
+let:
+  insert("let ")
+var:
+  insert("var ")
+async:
+  insert("async ")
+await:
+  insert("await ")
+
+action(user.code_if):
+  insert("if ()")
+  key(left)
+  
+action(user.code_else):
+  insert(" else {")
+  
+action(user.code_else_if):
+  insert(" else if ()")
+  key(left)
+  
+action(user.code_switch):
+  insert("switch ()")
+  key(left)
+  
+action(user.code_case):
+  insert("case :")
+  
+action(user.code_do_loop):
+  insert("do {")
+  key(enter)
+  
+action(user.code_while_loop):
+  insert("while ()")
+  key(left)")
+  
+action(user.code_for_loop):
+  insert("for ()")
+  key(left)
+  
+action(user.code_for_each_loop):
+  insert(".forEach()")
+  key(left)
+  
+action(user.code_to_integer):
+  insert("parseInt()")
+  key(left)
+  
+action(user.code_to_float):
+  insert("parseFloat()")
+  key(left)
+  
+action(user.code_to_string):
+  insert("String()")
+  key(left)
+
+action(user.code_to_boolean):
+  insert("Boolean()")
+  key(left)
+  
+action(user.code_and):
+  insert(" && ")
+  
+action(user.code_or):
+  insert(" || ")
+  
+action(user.code_not):
+  insert(" != ")
+  
+action(user.code_sysout):
+  insert("console.log()")
+  key(left)
+  
+action(user.code_import):
+  insert("import ")
+
+action(user.code_from):
+  insert(" from \"")
+  
+action(user.code_block):
+  insert(" {")
+  key(enter)
+
+action(user.code_function):
+  insert("function ()")
+  key(left:2)
+  
+action(user.code_lambda):
+  insert("() => ")
+  key(left:5)
+  
+action(user.code_class):
+  insert("class ")
+  
+action(user.code_docstring):
+  insert("/**  */")
+  key(left:3)
+
+action(user.code_comment):
+  insert("// ")
+    
+action(user.code_long_comment):
+  insert("/*  */")
+  key(left:3)
+  
+action(user.code_return):
+  insert("return ")
+  
+action(user.code_null):
+  insert("null")
+  
+action(user.code_true):
+  insert("true")
+  
+action(user.code_false):
+  insert("false")
+
+state reduce:
+  insert(".reduce()")
+  key(left)
+  
+state map:
+  insert(".map()")
+  key(left)
+  
+state filter:
+  insert(".filter()")
+  key(left)
+  

--- a/lang/programming.talon
+++ b/lang/programming.talon
@@ -1,0 +1,70 @@
+state if:
+  user.code_if()
+state else:
+  user.code_else()
+state else if:
+  user.code_else_if()
+
+states switch:
+  user.code_switch()
+state case:
+  user.code_case()
+
+loop do:
+  user.code_do_loop()
+loop while:
+  user.code_while_loop()
+loop for:
+  user.code_for_loop()
+loop each:
+  user.code_for_each_loop()
+
+to int:
+  user.code_to_integer()
+to float:
+  user.code_to_float()
+to string:
+  user.code_to_string()
+to bool:
+  user.code_to_boolean()
+
+logical and:
+  user.code_and()
+logical or:
+  user.code_or()
+logical not:
+  user.code_not()
+
+sys out:
+  user.code_sysout()
+
+state import:
+  user.code_import()
+state from:
+  user.code_from()
+
+state block:
+  user.code_block()
+state function:
+  user.code_function()
+state lambda:
+  user.code_lambda()
+state class:
+  user.code_class()
+
+docstring:
+  user.code_docstring()
+comment:
+  user.code_comment()
+long comment:
+  user.code_long_comment()
+
+state return:
+  user.code_return()
+
+value null:
+  user.code_null()
+value true:
+  user.code_true()
+value false:
+  user.code_false()

--- a/lang/python.talon
+++ b/lang/python.talon
@@ -1,64 +1,151 @@
 code.language: python
 -
-logical and: " and "
-logical or: " or "
-state in: " in "
-is not none: " is not None"
-is none: "  None"
+
+action(user.code_if):
+  insert("if :")
+  key(left)
+  
+action(user.code_else):
+  insert("else:")
+  
+action(user.code_else_if):
+  insert("elif :")
+  key(left)
+  
+action(user.code_switch):
+  insert("switch :")
+  key(left)
+
+action(user.code_case):
+  insert("case \nbreak;")
+  edit.up()
+  
+action(user.code_do_loop):
+  insert("while True:")
+  key(enter)
+  
+action(user.code_while_loop):
+  insert("while :")
+  key(left)
+  
+action(user.code_for_loop):
+  insert("for :")
+  key(left)
+  
+action(user.code_for_each_loop):
+  user.code_for_loop()
+  
+action(user.code_to_integer):
+  insert("int(")
+  
+action(user.code_to_float):
+  insert("float(")
+  
+action(user.code_to_string):
+  insert("str(")
+
+action(user.code_to_boolean):
+  insert("bool(")
+  
+action(user.code_and):
+  insert(" and ")
+  
+action(user.code_or):
+  insert(" or ")
+  
+action(user.code_not):
+  insert(" != ")
+  
+action(user.code_sysout):
+  insert("print(")
+  
+action(user.code_import):
+  insert("import ")
+
+action(user.code_from):
+  insert("from ")
+  
+# action(user.code_block):
+
+action(user.code_function):
+  insert("def ():")
+  key(left:2)
+  
+action(user.code_lambda):
+  insert("lambda :")
+  key(left)
+  
+action(user.code_class):
+  insert("class :")
+  
+action(user.code_docstring):
+  insert("\"\"\"\"\"\"")
+  key(left:3)
+
+action(user.code_comment):
+  insert("# ")
+  
+action(user.code_long_comment):
+  insert("\"\"\"\"\"\"")
+  key(left:3)
+  
+action(user.code_return):
+  insert("return ")
+  
+action(user.code_null):
+  insert("None")
+  
+action(user.code_true):
+  insert("True")
+  
+action(user.code_false):
+  insert("False")
+
+in:
+  insert(" in ")
+
+is:
+  insert(" is ")
+
+is not:
+  insert(" is not ")
+
+not:
+  insert(" not ")
+
 empty dict: "{}"
+
 word (dickt | dictionary): "dict"
-state (def | deaf | deft): "def "
-state else if: "elif "
-state if: "if "
-state else: "else:"
-state self: "self"
-state while:
-	insert("while ()")
-	edit.left()
-state for: "for "
-state switch:
-	insert("switch ()")
-	edit.left()
-state case:
-	insert("case \nbreak;")
-	edit.up()
-state goto:
-	insert("goto ")
-state import:
-	insert("import ")
-state class: "class "
+
 state include: "#include "
+
 state include system:
-	insert("#include <>")
-	edit.left()
+  insert("#include <>")
+  edit.left()
+
 state include local:
-	insert('#include ""')
-	edit.left()
+  insert('#include ""')
+  edit.left()
+
 state type deaf: "typedef "
+
 state type deaf struct:
-	insert("typedef struct")
-	insert("{{\n\n}}")
-	edit.up()
-	key(tab)
-comment py: "# "
+  insert("typedef struct")
+  insert("{{\n\n}}")
+  edit.up()
+  key(tab)
+
 dunder in it: "__init__"
+
 self taught: "self."
+
 from import:
-	insert("from import ")
-	key(left)
-	edit.word_left()
-	key(space)
-	edit.left()
+  insert("from  import ")
+  key(left:8)
+
 for in:
-	insert("for in ")
-	key(left)
-	edit.word_left()
-	key(space)
-	edit.left()
-dock string:
-    insert("\"\"\"")
-    insert("\"\"\"")
-    edit.left()
-    edit.left()
-    edit.left()
+  insert("for  in ")
+  key(left:4)
+
 pie test: "pytest"
+  


### PR DESCRIPTION
Hi, I wonder if there's any interest in incorporating this pattern of a standard programming command interface.

This idea is taken from [Caster](https://github.com/dictation-toolbox/Caster/blob/master/castervoice/rules/ccr/standard.py). It defines a common set of programming commands for languages to implement. I think it makes it more straightforward to start adding a new language, and makes it easier to switch between languages as a user.

I added a JavaScript implementation and adapted the existing Python one. When adapting the Python file, I attempted to keep any commands that weren't covered by the standard ones. I did not change Go because it makes use of dictation.

More commands, (or even dictation commands, like the Go implementation?), could be added.

Thanks, I appreciate the amount of work that goes into this repository.
