### PR TITLE
Match open source Visual Studio Code on Linux

### DIFF
--- a/apps/linux/vscode.talon
+++ b/apps/linux/vscode.talon
@@ -3,6 +3,7 @@
 
 os: linux
 app: Code
+app: Code - OSS
 -
 
 action(user.ide_refactor):

--- a/apps/vscode.talon
+++ b/apps/vscode.talon
@@ -1,6 +1,7 @@
 
 os: linux
 app: Code
+app: Code - OSS
 
 os: mac
 app: Code


### PR DESCRIPTION
The window class is `Code - OSS` on some Linux distributions (I'm on Solus).