### PR TITLE
Remove duplicate commands

### DIFF
--- a/apps/linux/signal.talon
+++ b/apps/linux/signal.talon
@@ -38,7 +38,6 @@ delete [message]: key("ctrl-shift-d")
 # Composer
 send message: key("ctrl-enter")
 expand chat: key("ctrl-shift-x")
-send message: key("ctrl-enter")
 attach [file]: key("ctrl-u")
 remove [link] preview: key("ctrl-p")
 remove [link] attachment: key("ctrl-shift-p")

--- a/apps/mac/terminal.talon
+++ b/apps/mac/terminal.talon
@@ -23,8 +23,6 @@ rerun search:
 run last:
   key(up)
   key(enter)
-kill all:
-  key(ctrl-c)
 action(edit.page_down):
   key(command-pagedown)
 action(edit.page_up):


### PR DESCRIPTION
This removes duplicate commands as detected from build 1328 on.