### PR TITLE
Add help search

### DIFF
--- a/code/help.py
+++ b/code/help.py
@@ -73,7 +73,7 @@ def format_context_title(context_name: str) -> str:
     global cached_active_contexts_list
     return "{} [{}]".format(
         context_name, 
-        "ACTIVE" if context_map[context_name] in cached_active_contexts_list else "INACTIVE"
+        "ACTIVE" if context_map.get(context_name, None) in cached_active_contexts_list else "INACTIVE"
     )
 
 
@@ -419,14 +419,14 @@ class Actions:
         gui_context_help.show()
         register_events(True)      
 
-    def help_search(phrase: Union[str, Phrase]):
+    def help_search(phrase: str):
         """Display command info for search phrase"""
         global is_context_help_showing
         global search_phrase
         is_context_help_showing = True
 
         reset()
-        search_phrase = str(phrase)
+        search_phrase = phrase
         refresh_context_command_map()
         gui_alphabet.hide()
         gui_context_help.show()

--- a/misc/help.talon
+++ b/misc/help.talon
@@ -1,6 +1,7 @@
 help alphabet: user.help_alphabet(user.get_alphabet())
 help context$: user.help_context()
 help active$: user.help_context_enabled()
+help search <phrase>$: user.help_search(phrase)
 help refresh$: user.help_refresh()
 help next$: user.help_next()
 help previous$: user.help_previous()

--- a/misc/help.talon
+++ b/misc/help.talon
@@ -1,7 +1,7 @@
 help alphabet: user.help_alphabet(user.get_alphabet())
 help context$: user.help_context()
 help active$: user.help_context_enabled()
-help search <phrase>$: user.help_search(phrase)
+help search <user.text>$: user.help_search(text)
 help refresh$: user.help_refresh()
 help next$: user.help_next()
 help previous$: user.help_previous()


### PR DESCRIPTION
Adds help search.

The search matches against literal worlds (not captures) in rules. The semantics are AND for all terms, ignoring order.

This also refactors pagination to produce a consistent number of lines for showing commands (either in a context or search view).

<img width="400" alt="Screen Shot 2020-06-01 at 5 12 47 PM" src="https://user-images.githubusercontent.com/567000/83459225-f3de3400-a431-11ea-9b81-dd6c538c8670.png">
