### PR TITLE
Update jetbrains app names + allow nicer app names

### DIFF
--- a/apps/jetbrains.talon
+++ b/apps/jetbrains.talon
@@ -3,8 +3,11 @@
 app: /jetbrains/
 
 app: IntelliJ IDEA
+app: idea64.exe
 app: PyCharm
 app: PyCharm64.exe
+app: pycharm64.exe
+app: webstorm64.exe
 # When tags are supported
 #tags: ide
 -

--- a/code/jetbrains.py
+++ b/code/jetbrains.py
@@ -46,7 +46,10 @@ port_mapping = {
     "google-android-studio": 8652,
 
     "IntelliJ IDEA": 8653,
-    "PyCharm": 8658
+    "idea64.exe": 8653,
+    "PyCharm": 8658,
+    "pycharm64.exe": 8658,
+    "webstorm64.exe": 8663
 }
 
 select_verbs_map = {

--- a/code/switcher.py
+++ b/code/switcher.py
@@ -7,8 +7,19 @@ import platform
 
 app_cache = {}
 overrides = {
-    'grip': 'DataGrip', 
-    'term': 'iTerm2'
+    'grip': 'DataGrip',
+    'term': 'iTerm2',
+    'lock': 'Slack'
+}
+
+# If you don't like an app name you can remap it here
+# key: name OS thinks app is
+# value: what you want to say
+friendly_names = {
+    'pycharm64': 'pycharm',
+    'idea64': 'idea',
+    'webstorm64': 'webstorm',
+    'outlook.exe': 'outlook'
 }
 
 mod = Module()
@@ -18,7 +29,7 @@ mod.list('launch', desc='all launchable applications')
 @mod.capture
 def running_applications(m) -> str:
     "Returns a single application name"
-    
+
 @mod.capture
 def launch_applications(m) -> Capture:
     "Returns a single application name"
@@ -27,11 +38,11 @@ ctx = Context()
 @ctx.capture(rule='{self.running}')
 def running_applications(m):
     return m.running
-    
+
 @ctx.capture(rule='{self.launch}')
 def launch_applications(m):
     return m.launch
-    
+
 def split_camel(word):
     return re.findall(r'[0-9A-Z]*[a-z]+(?=[A-Z]|$)', word)
 
@@ -86,8 +97,11 @@ def update_lists():
                 running[word.lower()] = cur_app.name
         running[name.lower()] = cur_app.name
     for override in overrides:
-        running[override] = overrides[override] 
-    
+        running[override] = overrides[override]
+
+    running = {(friendly_names.get(friendly_name) or friendly_name): app_name
+               for (friendly_name, app_name) in running.items()}
+
     if app.platform == "mac":
         for base in '/Applications', '/Applications/Utilities':
             for name in os.listdir(base):
@@ -100,13 +114,13 @@ def update_lists():
                         if len(name) > 6 and len(word) < 3:
                             continue
                         launch[word] = path
-    
+
     lists = {
         'self.running': running,
         'self.launch': launch,
     }
 
-    #batch update lists 
+    #batch update lists
     ctx.lists.update(lists)
 
 def ui_event(event, arg):

--- a/misc/ide.talon
+++ b/misc/ide.talon
@@ -1,9 +1,11 @@
 app: /jetbrains/
 
 app: IntelliJ IDEA
+app: idea64.exe
 app: PyCharm
 app: PyCharm64.exe
-
+app: pycharm64.exe
+app: webstorm64.exe
 # When tags are supported
 #tags: ide
 -


### PR DESCRIPTION
Outlook doesn't end with .exe so misses the filter
Also map lock to Slack as surely no one wants the lockapp to have focus (it's the lockscreen, but focusing it doesn't trigger the lockscreen)