### PR TITLE
Switcher app name overides as user defined lists

### DIFF
--- a/code/app_name_overrides.csv
+++ b/code/app_name_overrides.csv
@@ -1,0 +1,3 @@
+grip, DataGrip 
+term, iTerm2
+one note, ONENOTE

--- a/code/switcher.py
+++ b/code/switcher.py
@@ -3,7 +3,10 @@ from talon.voice import Capture
 import re
 import time
 import os
-
+# Construct at startup a list of overides for application names (similar to how homophone list is managed)
+# ie for a given talon recognition word set  `one note`, recognized this in these switcher functions as `ONENOTE`
+# the list is a comma seperated `<Recognized Words>, <Overide>`
+#TODO: Consider put list csv's (homophones.csv, app_name_overrides.csv) files together in a seperate directory,`knausj_talon/lists`
 cwd = os.path.dirname(os.path.realpath(__file__))
 overrides_file = os.path.join(cwd, "app_name_overrides.csv")
 overrides ={}

--- a/code/switcher.py
+++ b/code/switcher.py
@@ -4,11 +4,19 @@ import re
 import time
 import os
 
+cwd = os.path.dirname(os.path.realpath(__file__))
+overrides_file = os.path.join(cwd, "app_name_overrides.csv")
+overrides ={}
+with open(overrides_file, "r") as f:
+    for line in f:
+        line = line.rstrip()
+        line = line.split(",")
+        overrides[line[0].lower()] = line[1].strip()
+
+print(f'knausj_talon.switcher------------ app name overrides:{overrides}')
+
 app_cache = {}
-overrides = {
-    'grip': 'DataGrip', 
-    'term': 'iTerm2'
-}
+
 
 mod = Module()
 mod.list('running', desc='all running applications')
@@ -46,9 +54,8 @@ class Actions:
     def switcher_focus(name: str):
         """Focus a new application by  name"""
         for app in ui.apps():
-            #print("app.name:" + app.name)
-            #print("app.bundler: " + app.bundle)
-            if app.name == name and not app.background:
+            # print(f"--------- app.name:{app.name}  app.bundler:{app.bundle}")
+            if name in app.name and not app.background:
                 app.focus()
                 break
 
@@ -110,6 +117,7 @@ def update_lists():
 
 def ui_event(event, arg):
     if event in ('app_activate', 'app_launch', 'app_close', 'win_open', 'win_close'):
+        # print(f'------------------ event:{event}  arg:{arg}')
         update_lists()
 
 ui.register('', ui_event)


### PR DESCRIPTION
Expands on  the  recognized words to the system  app names overrides that enables focus switching .   By this PR the overides  list is now maintained in a user definable csv file and imported on Talon startup ( In the style of homophones.csv) 

The following TODO is also put in for consideration
**#TODO:** Consider put list csv's (homophones.csv, app_name_overrides.csv) files together in a separate directory,`knausj_talon/lists`