### PR TITLE
Add port mapping for android studio on linux

### DIFF
--- a/code/jetbrains.py
+++ b/code/jetbrains.py
@@ -42,6 +42,7 @@ port_mapping = {
     "jetbrains-pycharm-ce": 8658,
     "jetbrains-rider": 8660,
     "jetbrains-rubymine": 8661,
+    "jetbrains-studio": 8652,
     "jetbrains-webstorm": 8663,
     "google-android-studio": 8652,
 


### PR DESCRIPTION
On ubuntu, I found the name of the app to be jetbrains-studio, without which no commands would work.