### PR TITLE
Fixed default "select" functionality.

### DIFF
--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -48,7 +48,7 @@ go page up:
     edit.page_up()
 
 # selecting
-select line:
+select [line]:
     edit.line_start()
     edit.extend_line_end()
 


### PR DESCRIPTION
This fixes an issue where the command `select` would map to `select all` by default. Selecting a single line is far less destructive, as selecting all will move the cursor to the end of the document.

This is using 0.0.8.29 and the current stable version of w2l.

I am able to reproduce it consistently if i revert this line. I am open to other solutions!z

Duplicate of #149 because I had to fix my git history. 