### PR TITLE
[draft] some convenient scripts for typescript

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -9,6 +9,8 @@ setting_public_function_formatter    = mod.setting('code_public_function_formatt
 setting_private_variable_formatter   = mod.setting('code_private_variable_formatter', str)
 setting_protected_variable_formatter = mod.setting('code_protected_variable_formatter', str)
 setting_public_variable_formatter    = mod.setting('code_public_variable_formatter', str)
+setting_type_formatter               = mod.setting('code_type_formatter', str)
+setting_interface_formatter          = mod.setting('code_interface_formatter', str)
 
 mod.tag("code_comment", desc='Tag for enabling generic comment commands')
 mod.tag("code_operators", desc='Tag for enabling generic operator commands')
@@ -276,6 +278,14 @@ class Actions:
     def code_public_variable_formatter(name: str):
         """inserts properly formatted private function name"""
         actions.insert(actions.user.formatted_text(name, settings.get("user.code_public_variable_formatter")))
+    
+    def code_type_formatter(name: str):
+        """inserts properly formatted type name"""
+        actions.insert(actions.user.formatted_text(name, settings.get("user.code_type_formatter")))
+    
+    def code_interface_formatter(name: str):
+        """inserts properly formatted interface name"""
+        actions.insert(actions.user.formatted_text(name, settings.get("user.code_interface_formatter")))
 
     def code_comment():
         """Inserts comment at current cursor location"""

--- a/lang/typescript.talon
+++ b/lang/typescript.talon
@@ -13,6 +13,8 @@ settings():
     user.code_private_variable_formatter = "PRIVATE_CAMEL_CASE"
     user.code_protected_variable_formatter = "PRIVATE_CAMEL_CASE"
     user.code_public_variable_formatter = "PRIVATE_CAMEL_CASE"
+    user.code_type_formatter = "PUBLIC_CAMEL_CASE"
+    user.code_interface_formatter = "PUBLIC_CAMEL_CASE"
 
 action(user.code_is_not_null): " !== null"
 
@@ -23,38 +25,72 @@ action(user.code_type_dictionary):
   key(left)
 
 action(user.code_state_if):
-  insert("if ()")
-  key(left)
+  insert("if () {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left left)
 
 action(user.code_state_else_if):
-  insert(" else if ()")
-  key(left)
+  insert(" else if () {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left left)
 
 action(user.code_state_else):
-  insert(" else {}")
-  key(left enter) 
+  insert(" else () {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left left)
 
 action(user.code_self): "this"
 
 action(user.code_state_while):
-  insert("while ()")
-  key(left)
+  insert("while () {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left left)
 
 action(user.code_state_do):
-  insert("do ")
+  insert("do {}")
+  edit.left()
+  key(enter)
+  edit.down()
+  edit.line_end()
+  insert(" while()")
+  edit.left()
 
 action(user.code_state_return):
   insert("return ")
 
 action(user.code_state_for):
-  insert("for ()")
-  key(left)
+  insert("for () {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left left)
 
 action(user.code_state_switch):
-  insert("switch ()")
-  key(left)
+  insert("switch () {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left left)
 
-action(user.code_state_case): "case :"
+action(user.code_state_case):
+  "case :\n\tbreak;"
+  edit.up()
+  edit.line_end()
+  edit.left()
 
 action(user.code_state_go_to): ""
 
@@ -64,7 +100,14 @@ action(user.code_from_import):
   insert(" from  \"\"")
   key(left)
 
-action(user.code_type_class): "class "
+action(user.code_type_class):
+  insert("class  {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  edit.left()
+  edit.left()
 
 action(user.code_include): ""
 
@@ -82,9 +125,29 @@ action(user.code_state_for_each):
 
 action(user.code_null): "null"
 
-action(user.code_private_function): "private "
-action(user.code_protected_function): "protected "
-action(user.code_public_function): "public "
+action(user.code_private_function):
+  insert("private  {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left)
+
+action(user.code_protected_function):
+  insert("protected  {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left)
+
+action(user.code_public_function):
+  insert("public  {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left)
 
 action(user.code_operator_indirection): ""
 action(user.code_operator_address_of): ""
@@ -126,6 +189,10 @@ action(user.code_operator_bitwise_left_shift_assignment): " <<= "
 action(user.code_operator_bitwise_right_shift): " >> "
 action(user.code_operator_bitwise_right_shift_assignment): " >>= "
 
+state inline block:
+  insert("{{  }}")
+  key(left left)
+
 state block:
   insert("{}")
   key(left enter)
@@ -153,3 +220,39 @@ state reduce:
   key(left)
 
 state spread: "..."
+
+^state export class <user.text>$:
+  insert("export class  {}")
+  edit.left()
+  key(enter)
+  edit.up()
+  edit.line_end()
+  key(left left)
+  user.code_type_formatter(user.text)
+
+^state extends <user.text>$:
+  insert(" extends ")
+  user.code_type_formatter(user.text)
+
+^state implements <user.text>$:
+  insert(" implements I")
+  user.code_interface_formatter(user.text)
+
+^state param <user.text>$:
+  user.code_private_variable_formatter(user.text)
+  insert(": ")
+
+^state next param <user.text>$:
+  insert(", ")
+  user.code_private_variable_formatter(user.text)
+  insert(": ")
+
+state return default:
+  edit.right()
+  insert(": ")
+  insert("void")
+
+^state return type <user.text>$:
+  edit.right()
+  insert(": ")
+  user.code_type_formatter(user.text)


### PR DESCRIPTION
@knausj85 I stubbed out some quick scripts for what we were discussing in #155 to discuss your opinion of the ideal implementation. It works almost perfectly, the caveat that `state class` does not take a type.

In a previous version of this code, I had the following. It worked, but this would fail in languages that are not typed. I see now why aegis prefers not abstracting code.

_programming.talon_
```
^state class <user.text>$:
    user.code_type_class()
    user.code_type_formatter(user.text)
```