### PR TITLE
turn off pop to click when talon is asleep

### DIFF
--- a/modes/sleep_mode.talon
+++ b/modes/sleep_mode.talon
@@ -1,4 +1,9 @@
 mode: sleep
 -
+settings():
+    #stop continuous scroll/gaze scroll with a pop
+    user.mouse_enable_pop_stops_scroll = 0
+	  #enable pop click with 'control mouse' mode
+	  user.mouse_enable_pop_click = 0
 #this exists solely to prevent talon from walking up super easily in sleep mode at the moment with wav2letter
 <phrase>: skip()


### PR DESCRIPTION
this change will turn off pop to click when talon is asleep. When I was making the change to enable pop to click even when the eye tracker control mouse is not enabled as described [here](https://github.com/TalonCommunity/Wiki/blob/gh-pages/poptoclick.md) I discovered that pop to click continued to work even when talon was asleep. This fixes it. 