### PR TITLE
Fix issue where some vocab words aren't transcribed correctly

### DIFF
--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -10,15 +10,17 @@ simple_vocabulary = [
     "minecraft",
 ]
 
-mapping_vocabulary = {
+mapping_vocabulary = dict(zip(simple_vocabulary, simple_vocabulary))
+
+mapping_vocabulary.update({
     "i": "I",
     "i'm": "I'm",
     "i've": "I've",
     "i'll": "I'll",
     "i'd": "I'd",
-}
+})
 
-mapping_vocabulary.update(dict(zip(simple_vocabulary, simple_vocabulary)))
+mapping_vocabulary = dict((k.lower(), v) for k, v in mapping_vocabulary.iteritems())
 
 mod = Module()
 


### PR DESCRIPTION
Due to [https://github.com/talonvoice/beta/issues/88].

For example, saying "dee en ess" results in “@dns” instead of “DNS". Changing the keys to lowercase fixes the problem for now.

Also, made it so that the dictionary is created first with simple vocabulary so that the things defined later override the things defined earlier.