### PR TITLE
fix a bunch of operator/lang stuff

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -1,6 +1,7 @@
-from talon import Context, actions, ui, Module, settings, registry, imgui, fs
-import re
 import os
+import re
+
+from talon import Context, Module, actions, fs, imgui, registry, settings, ui
 
 ctx = Context()
 mod = Module()
@@ -29,15 +30,24 @@ mod.tag(
 key = actions.key
 function_list = []
 extension_lang_map = {
-    "py": "python",
-    "cs": "csharp",
+    "asm": "assembly",
+    "c": "c",
     "cpp": "cplusplus",
-    "h": "cplusplus",
-    "talon": "talon",
+    "cs": "csharp",
     "gdb": "gdb",
-    "md": "markdown",
-    "sh": "bash",
     "go": "go",
+    "h": "c",
+    "hpp": "cplusplus",
+    "lua": "lua",
+    "md": "markdown",
+    "pl": "perl",
+    "py": "python",
+    "rb": "ruby",
+    "s": "assembly",
+    "sh": "bash",
+    "snippets": "snippets",
+    "talon": "talon",
+    "vim": "vim",
     "js": "javascript",
     "ts": "typescript",
 }
@@ -97,7 +107,7 @@ class Actions:
         global forced_language
         actions.user.code_clear_language_mode()
         actions.mode.enable("user.{}".format(language))
-
+        # app.notify("Enabled {} mode".format(language))
         forced_language = True
 
     def code_clear_language_mode():
@@ -107,6 +117,7 @@ class Actions:
 
         for __, lang in extension_lang_map.items():
             actions.mode.disable("user.{}".format(lang))
+        # app.notify("Cleared language modes")
 
     def code_operator_indirection():
         """code_operator_indirection"""
@@ -114,8 +125,8 @@ class Actions:
     def code_operator_address_of():
         """code_operator_address_of (e.g., C++ & op)"""
 
-    def code_operator_structure_deference():
-        """code_operator_structure_deference (e.g., C++ -> op)"""
+    def code_operator_structure_dereference():
+        """code_operator_structure_dereference (e.g., C++ -> op)"""
 
     def code_operator_lambda():
         """code_operator_lambda"""
@@ -195,11 +206,11 @@ class Actions:
     def code_operator_bitwise_or_assignment():
         """code_operator_or_assignment"""
 
-    def code_operator_bitwise_exlcusive_or():
-        """code_operator_bitwise_exlcusive_or"""
+    def code_operator_bitwise_exclusive_or():
+        """code_operator_bitwise_exclusive_or"""
 
-    def code_operator_bitwise_exlcusive_or_assignment():
-        """code_operator_bitwise_exlcusive_or_assignment"""
+    def code_operator_bitwise_exclusive_or_assignment():
+        """code_operator_bitwise_exclusive_or_assignment"""
 
     def code_operator_bitwise_left_shift():
         """code_operator_bitwise_left_shift"""
@@ -338,6 +349,12 @@ class Actions:
     def code_block_comment():
         """Block comment"""
 
+    def code_block_comment_prefix():
+        """Block comment start syntax"""
+
+    def code_block_comment_suffix():
+        """Block comment end syntax"""
+
     def code_type_definition():
         """code_type_definition (typedef)"""
 
@@ -416,4 +433,3 @@ def commands_updated(_):
 
 
 registry.register("update_commands", commands_updated)
-

--- a/lang/block_comment.talon
+++ b/lang/block_comment.talon
@@ -1,0 +1,47 @@
+tag: user.code_block_comment
+-
+block comment: user.code_block_comment()
+block comment line:
+    #todo: this should probably be a single function once
+    #.talon supports implementing actions with parameters?
+	edit.line_start()
+    user.code_block_comment_prefix()
+    key(space)
+	edit.line_end()
+    key(space)
+    user.code_block_comment_suffix()
+#adds comment to the start of the line
+block comment line <user.text> over:
+    #todo: this should probably be a single function once
+    #.talon supports implementing actions with parameters?
+    edit.line_start()
+    user.code_block_comment()
+	insert(user.text)
+block comment <user.text> over:
+    #todo: this should probably be a single function once
+    #.talon supports implementing actions with parameters?
+	user.code_block_comment()
+    insert(user.text)
+block comment <user.text>$:
+    #todo: this should probably be a single function once
+    #.talon supports implementing actions with parameters?
+    user.code_block_comment()
+    insert(user.text)
+(line | inline) block comment <user.text> over:
+    #todo: this should probably be a single function once
+    #.talon supports implementing actions with parameters?
+	edit.line_end()
+   	user.code_block_comment_prefix()
+    key(space)
+    insert(user.text)
+    key(space)
+   	user.code_block_comment_suffix()
+(line | inline) block comment <user.text>$:
+    #todo: this should probably be a single function once
+    #.talon supports implementing actions with parameters?
+	edit.line_end()
+   	user.code_block_comment_prefix()
+    key(space)
+    insert(user.text)
+    key(space)
+   	user.code_block_comment_suffix()

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -1,5 +1,5 @@
-mode: user.csharp
-mode: command 
+code.language: csharp
+mode: command
 and code.language: csharp
 -
 tag(): user.code_operators
@@ -12,13 +12,14 @@ settings():
     user.code_private_variable_formatter = "PRIVATE_CAMEL_CASE"
     user.code_protected_variable_formatter = "PROTECTED_CAMEL_CASE"
     user.code_public_variable_formatter = "PROTECTED_CAMEL_CASE"
+
 action(user.code_operator_indirection): "*"
 action(user.code_operator_address_of): "&"
-action(user.code_operator_structure_deference): "->"
+action(user.code_operator_structure_dereference): "->"
 action(user.code_operator_lambda): "=>"
-action(user.code_operator_subscript): 		
-	insert("[]")
-	key(left)
+action(user.code_operator_subscript):
+    insert("[]")
+    key(left)
 action(user.code_operator_assignment): " = "
 action(user.code_operator_subtraction): " - "
 action(user.code_operator_subtraction_assignment): " -= "
@@ -40,11 +41,11 @@ action(user.code_operator_less_than_or_equal_to): " <= "
 action(user.code_operator_and): " && "
 action(user.code_operator_or): " || "
 action(user.code_operator_bitwise_and): " & "
-action(user.code_operator_bitwise_and_assignment): " &= " 
+action(user.code_operator_bitwise_and_assignment): " &= "
 action(user.code_operator_bitwise_or): " | "
 action(user.code_operator_bitwise_or_assignment): " |= "
-action(user.code_operator_bitwise_exlcusive_or): " ^ "
-action(user.code_operator_bitwise_exlcusive_or_assignment): " ^= "
+action(user.code_operator_bitwise_exclusive_or): " ^ "
+action(user.code_operator_bitwise_exclusive_or_assignment): " ^= "
 action(user.code_operator_bitwise_left_shift): " << "
 action(user.code_operator_bitwise_left_shift_assignment): " <<= "
 action(user.code_operator_bitwise_right_shift): " >> "
@@ -53,39 +54,39 @@ action(user.code_self): "this"
 action(user.code_null): "null"
 action(user.code_is_null): " == null "
 action(user.code_is_not_null): " != null"
-action(user.code_state_if): 
-	insert("if()")
-	key(left)
-action(user.code_state_else_if): 
-	insert("else if()")
-	key(left)
-action(user.code_state_else): 
-	insert("else\n{{\n}}\n")
-	key(up )
+action(user.code_state_if):
+    insert("if()")
+    key(left)
+action(user.code_state_else_if):
+    insert("else if()")
+    key(left)
+action(user.code_state_else):
+    insert("else\n{{\n}}\n")
+    key(up )
 action(user.code_state_switch):
-	insert("switch()") 
-	edit.left()
+    insert("switch()")
+    edit.left()
 action(user.code_state_case):
-	insert("case \nbreak;") 
-	edit.up()
+    insert("case \nbreak;")
+    edit.up()
 action(user.code_state_for): "for "
-action(user.code_state_for_each): 
-	insert("foreach() ")
-	key(left)
-	edit.word_left()
-	key(space) 
-	edit.left()
+action(user.code_state_for_each):
+    insert("foreach() ")
+    key(left)
+    edit.word_left()
+    key(space)
+    edit.left()
 action(user.code_state_go_to): "go to "
-action(user.code_state_while): 
-	insert("while()")
-	edit.left()
+action(user.code_state_while):
+    insert("while()")
+    edit.left()
 action(user.code_state_return): "return "
-#action(user.code_type_definition): "typedef "	
-#action(user.code_typedef_struct):	
-#	insert("typedef struct")
-#	insert("{{\n\n}}")
-#	edit.up()
-#	key(tab)
+#action(user.code_type_definition): "typedef "
+#action(user.code_typedef_struct):
+#    insert("typedef struct")
+#    insert("{{\n\n}}")
+#    edit.up()
+#    key(tab)
 action(user.code_type_class): "class "
 action(user.code_import): "using  "
 action(user.code_from_import): "using "
@@ -101,4 +102,3 @@ action(user.code_public_static_function): insert("public static void ")
 action(user.code_protected_function): insert("protected void ")
 action(user.code_protected_static_function): insert ("protected static void ")
 action(user.code_public_function): insert("public void ")
-

--- a/lang/go.talon
+++ b/lang/go.talon
@@ -8,42 +8,42 @@ logical or: " || "
 # Many of these add extra terrible spacing under the assumption that
 # gofmt/goimports will erase it.
 state comment: "// "
-[line] comment <phrase>:
+[line] comment <user.text>:
     key("cmd-right")
     insert(" // ")
-    insert(user.formatted_text(phrase, "sentence"))
+    insert(user.formatted_text(text, "sentence"))
 
-# "add comment <phrase> [over]:
+# "add comment <user.text> [over]:
 #     key("cmd-right")
 #     text_with_leading(" // ")
 # ]
 # "[state] context: insert("ctx")
 state (funk | func | fun): "func "
 function (Annette | init) [over]: "func init() {\n"
-function <phrase> [over]:
+function <user.text> [over]:
     insert("func ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
     insert("(")
     sleep(100ms)
 
-method <phrase> [over]:
+method <user.text> [over]:
     insert("meth ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
     sleep(100ms)
 
 state var: "var "
-variable [<phrase>] [over]:
+variable [<user.text>] [over]:
     insert("var ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
     # insert(" ")
     sleep(100ms)
 
-of type [<phrase>] [over]:
+of type [<user.text>] [over]:
     insert(" ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
-# "set <phrase> [over]:
-#     insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+# "set <user.text> [over]:
+#     insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 #     insert(" := ")
 #     sleep(100ms)
 # ]
@@ -51,83 +51,83 @@ state break: "break"
 state (chan | channel): " chan "
 state go: "go "
 state if: "if "
-if <phrase> [over]:
+if <user.text> [over]:
   insert("if ")
-  insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
-spawn <phrase> [over]:
+  insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
+spawn <user.text> [over]:
   insert("go ")
-  insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+  insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 state else if: " else if "
-else if <phrase> [over]:
+else if <user.text> [over]:
     insert(" else if ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state else: " else "
-else <phrase> [over]:
+else <user.text> [over]:
     insert(" else {")
     key("enter")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state while: "while "
-while <phrase> [over]:
+while <user.text> [over]:
     insert("while ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state for: "for "
-for <phrase> [over]:
+for <user.text> [over]:
     insert("for ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state for range: "forr "
-range <phrase> [over]:
+range <user.text> [over]:
     insert("forr ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state format: "fmt"
-format <phrase> [over]:
+format <user.text> [over]:
     insert("fmt.")
-    insert(user.formatted_text(phrase, "PUBLIC_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
 
 state switch: "switch "
-switch <phrase> [over]:
+switch <user.text> [over]:
     insert("switch ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state select: "select "
-# "select <phrase>:insert("select "), insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE")]
+# "select <user.text>:insert("select "), insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE")]
 state (const | constant): " const "
-constant <phrase> [over]:
+constant <user.text> [over]:
     insert("const ")
-    insert(user.formatted_text(phrase, "PUBLIC_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
 
 state case: " case "
 state default: " default:"
-case <phrase> [over]:
+case <user.text> [over]:
     insert("case ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state type: " type "
-type <phrase> [over]:
+type <user.text> [over]:
     insert("type ")
-    insert(user.formatted_text(phrase, "PUBLIC_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
 state true: " true "
 state false: " false "
 state (start | struct | struck):
   insert(" struct {")
   key("enter")
-(struct | struck) <phrase> [over]:
+(struct | struck) <user.text> [over]:
     insert(" struct {")
     key("enter")
-    insert(user.formatted_text(phrase, "PUBLIC_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
 
 [state] empty interface: " interface{} "
 state interface:
   insert(" interface {")
   key("enter")
-interface <phrase> [over]:
+interface <user.text> [over]:
     insert(" interface {")
     key("enter")
-    insert(user.formatted_text(phrase, "PUBLIC_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
 
 state string: " string "
 [state] (int | integer | ant): "int"
@@ -138,63 +138,63 @@ state (int | integer | ant) 64: " int64 "
 state tag:
   insert(" ``")
   key("left")
-field tag <phrase> [over]:
+field tag <user.text> [over]:
     insert(" ``")
     key("left")
     sleep(100ms)
-    insert(user.formatted_text(phrase, "snake"))
+    insert(user.formatted_text(text, "snake"))
     insert(" ")
     sleep(100ms)
 
 state return: " return "
-return  <phrase> [over]:
+return  <user.text> [over]:
     insert("return ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 map of string to string: " map[string]string "
-map of <phrase> [over]:
+map of <user.text> [over]:
     insert("map[")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
     key("right")
     sleep(100ms)
 
 receive: " <- "
 make: "make("
-loggers [<phrase>] [over]:
+loggers [<user.text>] [over]:
     insert("logrus.")
-    insert(user.formatted_text(phrase, "PUBLIC_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
 
-length <phrase> [over]:
+length <user.text> [over]:
     insert("len(")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
-append <phrase> [over]:
+append <user.text> [over]:
     insert("append(")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
 state (air | err): "err"
 error: " err "
-loop over [<phrase>] [over]:
+loop over [<user.text>] [over]:
     insert("forr ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
-item <phrase> [over]:
+item <user.text> [over]:
   insert(", ")
-  insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+  insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
-value <phrase> [over]:
+value <user.text> [over]:
     insert(": ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
-address of [<phrase>] [over]:
+address of [<user.text>] [over]:
     insert("&")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
-pointer to [<phrase>] [over]:
+pointer to [<user.text>] [over]:
     insert("*")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
 
-swipe [<phrase>] [over]:
+swipe [<user.text>] [over]:
     key("right")
     insert(", ")
-    insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE"))
+    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))

--- a/lang/javascript.talon
+++ b/lang/javascript.talon
@@ -1,5 +1,5 @@
 mode: user.javascript
-mode: command 
+mode: command
 and code.language: javascript
 -
 tag(): user.code_operators
@@ -32,7 +32,7 @@ action(user.code_state_else_if):
 
 action(user.code_state_else):
   insert(" else {}")
-  key(left enter) 
+  key(left enter)
 
 action(user.code_self): "this"
 
@@ -85,9 +85,9 @@ action(user.code_public_function): "function "
 
 action(user.code_operator_indirection): ""
 action(user.code_operator_address_of): ""
-action(user.code_operator_structure_deference): ""
+action(user.code_operator_structure_dereference): ""
 action(user.code_operator_lambda): " => "
-action(user.code_operator_subscript): 
+action(user.code_operator_subscript):
   insert("[]")
   key(left)
 action(user.code_operator_assignment): " = "
@@ -113,11 +113,11 @@ action(user.code_operator_less_than_or_equal_to): " <= "
 action(user.code_operator_and): " && "
 action(user.code_operator_or): " || "
 action(user.code_operator_bitwise_and): " & "
-action(user.code_operator_bitwise_and_assignment): " &= " 
+action(user.code_operator_bitwise_and_assignment): " &= "
 action(user.code_operator_bitwise_or): " | "
 action(user.code_operator_bitwise_or_assignment): " |= "
-action(user.code_operator_bitwise_exlcusive_or): " ^ "
-action(user.code_operator_bitwise_exlcusive_or_assignment): " ^= "
+action(user.code_operator_bitwise_exclusive_or): " ^ "
+action(user.code_operator_bitwise_exclusive_or_assignment): " ^= "
 action(user.code_operator_bitwise_left_shift): " << "
 action(user.code_operator_bitwise_left_shift_assignment): " <<= "
 action(user.code_operator_bitwise_right_shift): " >> "
@@ -136,11 +136,11 @@ state var: "var "
 state async: "async "
 
 state await: "await "
-  
+
 state map:
   insert(".map()")
   key(left)
-  
+
 state filter:
   insert(".filter()")
   key(left)

--- a/lang/operators.talon
+++ b/lang/operators.talon
@@ -1,21 +1,24 @@
-
 tag: user.code_operators
 -
 #pointer operators
-op deference: user.code_operator_indirection()
+op dereference: user.code_operator_indirection()
 op address of: user.code_operator_address_of()
-op arrow: user.code_operator_structure_deference()
-#lambda 
+op arrow: user.code_operator_structure_dereference()
+
+#lambda
 op lambda: user.code_operator_lambda()
+
 #subscript
 op subscript: user.code_operator_subscript()
+
 #assignment
 op (equals | assign): user.code_operator_assignment()
+
 #math operators
 op (minus | subtract): user.code_operator_subtraction()
 op (minus | subtract) equals: user.code_operator_subtraction_assignment()
 op (plus | add): user.code_operator_addition()
-op (plus | add) equals: user.code_operator_addition()
+op (plus | add) equals: user.code_operator_addition_assignment()
 op (times | multiply): user.code_operator_multiplication()
 op (times | multiply) equals: user.code_operator_multiplication_assignment()
 op divide: user.code_operator_division()
@@ -23,6 +26,7 @@ op divide equals: user.code_operator_division_assignment()
 op mod: user.code_operator_modulo()
 op mod equals: user.code_operator_modulo_assignment()
 (op (power | exponent) | to the power [of]): user.code_operator_exponent()
+
 #comparison operators
 (op | is) equal: user.code_operator_equal()
 (op | is) not equal: user.code_operator_not_equal()
@@ -31,18 +35,21 @@ op mod equals: user.code_operator_modulo_assignment()
 (op | is) greater [than] or equal: user.code_operator_greater_than_or_equal_to()
 (op | is) less [than] or equal: user.code_operator_less_than_or_equal_to()
 #logical operators
+
 (op | logical) and: user.code_operator_and()
 (op | logical) or: user.code_operator_or()
+
 #bitwise operators
-[op] bitwise and: user.code_bitwise_operator_and()
-(op | logical | bitwise) and equals: user.code_bitwise_operator_and_equals()
-[op] bitwise or: user.code_bitwise_operator_or()
-(op | logical | bitwise) or equals: user.code_bitwise_operator_or_equals()
-(op | logical | bitwise) (ex | exclusive) or: user.code_bitwise_operator_exlcusive_or()
-(op | logical | bitwise) (left shift | shift left): user.code_bitwise_operator_left_shift()
-(op | logical | bitwise) (right shift | shift right): user.code_bitwise_operator_right_shift()
-(op | logical | bitwise) (ex | exclusive) or equals: user.code_bitwise_operator_exlcusive_or_equals()
-[(op | logical | bitwise)] (left shift | shift left) equals: user.code_bitwise_operator_left_shift_equals()
-[(op | logical | bitwise)] (left right | shift right) equals: user.code_bitwise_operator_right_shift_equals()
+[op] bitwise and: user.code_operator_bitwise_and()
+(op | logical | bitwise) and equals: user.code_operator_bitwise_and_equals()
+[op] bitwise or: user.code_operator_bitwise_or()
+(op | logical | bitwise) or equals: user.code_operator_bitwise_or_equals()
+(op | logical | bitwise) (ex | exclusive) or: user.code_operator_bitwise_exclusive_or()
+(op | logical | bitwise) (left shift | shift left): user.code_operator_bitwise_left_shift()
+(op | logical | bitwise) (right shift | shift right): user.code_operator_bitwise_right_shift()
+(op | logical | bitwise) (ex | exclusive) or equals: user.code_operator_bitwise_exclusive_or_equals()
+[(op | logical | bitwise)] (left shift | shift left) equals: user.code_operator_bitwise_left_shift_equals()
+[(op | logical | bitwise)] (left right | shift right) equals: user.code_operator_bitwise_right_shift_equals()
+
 #tbd
 (op | pad) colon: " : "

--- a/lang/programming.talon
+++ b/lang/programming.talon
@@ -2,8 +2,8 @@ tag: user.code_generic
 -
 #todo should we have a keyword list? type list capture? stick with "word"?
 #state in: insert(" in ")
-is not none: user.code_is_not_null() 
-is none: user.code_is_null()
+is not (none|null): user.code_is_not_null()
+is (none|null): user.code_is_null()
 #todo: types?
 #word (dickt | dictionary): user.code_type_dictionary()
 state if: user.code_state_if()
@@ -12,7 +12,7 @@ state else: user.code_state_else()
 state self: user.code_self()
 #todo: this is valid for many languages,
 # but probably not all
-self dot: 
+self dot:
     user.code_self()
     insert(".")
 state while: user.code_state_while()
@@ -31,7 +31,7 @@ state include system: user.code_include_system()
 state include local: user.code_include_local()
 state type deaf: user.code_type_definition()
 state type deaf struct: user.code_typedef_struct()
-state (no | nil): user.code_null()
+state (no | nil | null): user.code_null()
 ^funky <user.text>$:
     #todo: once .talon action definitions can take parameters, combine these functions
     user.code_private_function()
@@ -50,7 +50,7 @@ state (no | nil): user.code_null()
 ^pub funky <user.text>$:
     #todo: once .talon action definitions can take parameters, combine these functions
     user.code_public_function()
-    user.code_public_function_formatter(user.text)	
+    user.code_public_function_formatter(user.text)
     sleep(50ms)
     insert("()")
 ^static funky <user.text>$:

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -1,5 +1,5 @@
 mode: user.python
-mode: command 
+mode: command
 and code.language: python
 -
 tag(): user.code_operators
@@ -14,11 +14,11 @@ settings():
     user.code_public_variable_formatter = "SNAKE_CASE"
 action(user.code_operator_indirection): ""
 action(user.code_operator_address_of): ""
-action(user.code_operator_structure_deference): ""
+action(user.code_operator_structure_dereference): ""
 action(user.code_operator_lambda): ""
-action(user.code_operator_subscript): 
-	insert("[]")
-	key(left)
+action(user.code_operator_subscript):
+    insert("[]")
+    key(left)
 action(user.code_operator_assignment): " = "
 action(user.code_operator_subtraction): " - "
 action(user.code_operator_subtraction_assignment): " -= "
@@ -40,11 +40,11 @@ action(user.code_operator_less_than_or_equal_to): " <= "
 action(user.code_operator_and): " and "
 action(user.code_operator_or): " or "
 action(user.code_operator_bitwise_and): " & "
-action(user.code_operator_bitwise_and_assignment): " &= " 
+action(user.code_operator_bitwise_and_assignment): " &= "
 action(user.code_operator_bitwise_or): " | "
 action(user.code_operator_bitwise_or_assignment): " |= "
-action(user.code_operator_bitwise_exlcusive_or): " ^ "
-action(user.code_operator_bitwise_exlcusive_or_assignment): " ^= "
+action(user.code_operator_bitwise_exclusive_or): " ^ "
+action(user.code_operator_bitwise_exclusive_or_assignment): " ^= "
 action(user.code_operator_bitwise_left_shift): " << "
 action(user.code_operator_bitwise_left_shift_assignment): " <<= "
 action(user.code_operator_bitwise_right_shift): " >> "
@@ -53,62 +53,49 @@ action(user.code_self): "self"
 action(user.code_null): "None"
 action(user.code_is_null): " is None"
 action(user.code_is_not_null): " is not None"
-action(user.code_state_if): 
-	insert("if :")
-	key(left)
-action(user.code_state_else_if): 
-	insert("elif :")
-	key(left)
-action(user.code_state_else): 
-	insert("else:")
-	key(enter)
+action(user.code_state_if):
+    insert("if :")
+    key(left)
+action(user.code_state_else_if):
+    insert("elif :")
+    key(left)
+action(user.code_state_else):
+    insert("else:")
+    key(enter)
 action(user.code_state_switch):
-	insert("switch ()") 
-	edit.left()
+    insert("switch ()")
+    edit.left()
 action(user.code_state_case):
-	insert("case \nbreak;") 
-	edit.up()
+    insert("case \nbreak;")
+    edit.up()
 action(user.code_state_for): "for "
-action(user.code_state_for_each): 
-	insert("for in ")
-	key(left)
-	edit.word_left()
-	key(space) 
-	edit.left()
-action(user.code_state_go_to): "go to "
-action(user.code_state_while): 
-	insert("while ()")
-	edit.left()
-action(user.code_type_definition): "typedef "	
-action(user.code_typedef_struct):	
-	insert("typedef struct")
-	insert("{{\n\n}}")
-	edit.up()
-	key(tab)
+action(user.code_state_for_each):
+    insert("for in ")
+    key(left)
+    edit.word_left()
+    key(space)
+    edit.left()
+action(user.code_state_while):
+    insert("while :")
+    edit.left()
 action(user.code_type_class): "class "
 action(user.code_import): "import "
 action(user.code_from_import):
-	insert("from import ")
-	key(left)
-	edit.word_left()
-	key(space) 
-	edit.left()
-action(user.code_include_system):
-	insert("#include <>")
-	edit.left()
-action(user.code_include_local):
-	insert('#include ""')
-	edit.left()
+    insert("from import ")
+    key(left)
+    edit.word_left()
+    key(space)
+    edit.left()
 action(user.code_comment): "#"
 action(user.code_private_function):
-	insert("def _")
+    insert("def _")
 action(user.code_protected_function):
     user.code_private_function()
 action(user.code_public_function):
 	insert("def ")
 action(user.code_state_return):
 	insert("return ")
-	
+
 #python-specicic grammars
 dunder in it: insert("__init__")
 state (def | deaf | deft): "def "

--- a/lang/typescript.talon
+++ b/lang/typescript.talon
@@ -1,5 +1,5 @@
 mode: user.typescript
-mode: command 
+mode: command
 and code.language: typescript
 -
 tag(): user.code_operators
@@ -32,7 +32,7 @@ action(user.code_state_else_if):
 
 action(user.code_state_else):
   insert(" else {}")
-  key(left enter) 
+  key(left enter)
 
 action(user.code_self): "this"
 
@@ -88,9 +88,9 @@ action(user.code_public_function): "public "
 
 action(user.code_operator_indirection): ""
 action(user.code_operator_address_of): ""
-action(user.code_operator_structure_deference): ""
+action(user.code_operator_structure_dereference): ""
 action(user.code_operator_lambda): " => "
-action(user.code_operator_subscript): 
+action(user.code_operator_subscript):
   insert("[]")
   key(left)
 action(user.code_operator_assignment): " = "
@@ -116,11 +116,11 @@ action(user.code_operator_less_than_or_equal_to): " <= "
 action(user.code_operator_and): " && "
 action(user.code_operator_or): " || "
 action(user.code_operator_bitwise_and): " & "
-action(user.code_operator_bitwise_and_assignment): " &= " 
+action(user.code_operator_bitwise_and_assignment): " &= "
 action(user.code_operator_bitwise_or): " | "
 action(user.code_operator_bitwise_or_assignment): " |= "
-action(user.code_operator_bitwise_exlcusive_or): " ^ "
-action(user.code_operator_bitwise_exlcusive_or_assignment): " ^= "
+action(user.code_operator_bitwise_exclusive_or): " ^ "
+action(user.code_operator_bitwise_exclusive_or_assignment): " ^= "
 action(user.code_operator_bitwise_left_shift): " << "
 action(user.code_operator_bitwise_left_shift_assignment): " <<= "
 action(user.code_operator_bitwise_right_shift): " >> "
@@ -139,11 +139,11 @@ state var: "var "
 state async: "async "
 
 state await: "await "
-  
+
 state map:
   insert(".map()")
   key(left)
-  
+
 state filter:
   insert(".filter()")
   key(left)


### PR DESCRIPTION
the main notable change here is typos in operators for dereference and exclusive, as well as fixing some bitwise operator typos unmixed up commands in various language files.

as a result of these changes touching files with some other things I hadn't scent pull requests for, I'm mixing a few other things together:

* `go` to use user.text
* block comments (used by c, but c stuff not PRed yet)
* more extension types
* whitespacing
* null addition for some commands (saying none is not intuitive when using C)