### PR TITLE
Update switcher.py for reals

### DIFF
--- a/code/switcher.py
+++ b/code/switcher.py
@@ -2,32 +2,28 @@ import os
 import re
 import time
 
-from talon import Context, Module, app, imgui, ui
-from talon.voice import Capture
+from talon import Context, Module, app, imgui, ui, fs
 
 # Construct at startup a list of overides for application names (similar to how homophone list is managed)
 # ie for a given talon recognition word set  `one note`, recognized this in these switcher functions as `ONENOTE`
 # the list is a comma seperated `<Recognized Words>, <Overide>`
 # TODO: Consider put list csv's (homophones.csv, app_name_overrides.csv) files together in a seperate directory,`knausj_talon/lists`
 cwd = os.path.dirname(os.path.realpath(__file__))
-overrides_file = os.path.join(
-    cwd, "app_names", f"app_name_overrides.{app.platform}.csv"
-)
-overrides = {}
-with open(overrides_file, "r") as f:
-    for line in f:
-        line = line.rstrip()
-        line = line.split(",")
-        overrides[line[0].lower()] = line[1].strip()
-
-# print(f"knausj_talon.switcher------------ app name overrides:{overrides}")
-
-app_cache = {}
+overrides_directory = os.path.join(cwd, "app_names")
+override_file_name = f"app_name_overrides.{app.platform}.csv"
+override_file_path = os.path.join(overrides_directory, override_file_name)
 
 
 mod = Module()
 mod.list("running", desc="all running applications")
 mod.list("launch", desc="all launchable applications")
+ctx = Context()
+
+# a list of the current overrides
+overrides = {}
+
+# a list of the currently running application names
+running_application_dict = {}
 
 
 @mod.capture
@@ -36,11 +32,8 @@ def running_applications(m) -> str:
 
 
 @mod.capture
-def launch_applications(m) -> Capture:
+def launch_applications(m) -> str:
     "Returns a single application name"
-
-
-ctx = Context()
 
 
 @ctx.capture(rule="({self.running} | <user.text>)")
@@ -68,22 +61,101 @@ def get_words(name):
     return out
 
 
+def update_lists():
+    global running_application_dict
+    running_application_dict = {}
+    running = {}
+    launch = {}
+    for cur_app in ui.apps(background=False):
+        name = cur_app.name
+
+        if name.endswith(".exe"):
+            name = name.rsplit(".", 1)[0]
+
+        words = get_words(name)
+        for word in words:
+            if word and word not in running:
+                running[word.lower()] = cur_app.name
+
+        running[name.lower()] = cur_app.name
+        running_application_dict[cur_app.name] = True
+
+    for override in overrides:
+        running[override] = overrides[override]
+
+    if app.platform == "mac":
+        for base in "/Applications", "/Applications/Utilities":
+            for name in os.listdir(base):
+                path = os.path.join(base, name)
+                name = name.rsplit(".", 1)[0].lower()
+                launch[name] = path
+                words = name.split(" ")
+                for word in words:
+                    if word and word not in launch:
+                        if len(name) > 6 and len(word) < 3:
+                            continue
+                        launch[word] = path
+
+    lists = {
+        "self.running": running,
+        "self.launch": launch,
+    }
+
+    # batch update lists
+    ctx.lists.update(lists)
+
+
+def update_overrides(name, flags):
+    """Updates the overrides list"""
+    global overrides
+    overrides = {}
+
+    if name is None or name == override_file_path:
+        print("update_overrides")
+        with open(override_file_path, "r") as f:
+            for line in f:
+                line = line.rstrip()
+                line = line.split(",")
+                if len(line) == 2:
+                    overrides[line[0].lower()] = line[1].strip()
+
+        update_lists()
+
+
+update_overrides(None, None)
+fs.watch(overrides_directory, update_overrides)
+
+
 @mod.action_class
 class Actions:
     def switcher_focus(name: str):
         """Focus a new application by  name"""
-        running = ctx.lists["self.running"]
-        wanted_app = None
 
-        # todo: fix this for windows properly
-        name = name.replace(".exe", "")
-        for running_name in running.keys():
+        wanted_app = name
 
-            if running_name == name or running_name.lower().startswith(name.lower()):
-                wanted_app = running[running_name]
-                break
-        if wanted_app is None:
-            return
+        # we should use the capture result directly if it's already in the
+        # list of running applications
+        # otherwise, name is from <user.text> and we can be a bit fuzzier
+        if name not in running_application_dict:
+
+            # don't process silly things like "focus i"
+            if len(name) < 3:
+                print("switcher_focus skipped: len({}) < 3".format(name))
+                return
+
+            running = ctx.lists["self.running"]
+            wanted_app = None
+
+            for running_name in running.keys():
+
+                if running_name == name or running_name.lower().startswith(
+                    name.lower()
+                ):
+                    wanted_app = running[running_name]
+                    break
+
+            if wanted_app is None:
+                return
 
         for cur_app in ui.apps():
             if cur_app.name == wanted_app and not cur_app.background:
@@ -111,47 +183,6 @@ def gui(gui: imgui.GUI):
         gui.text(line)
 
 
-def update_lists():
-    running = {}
-    launch = {}
-
-    for cur_app in ui.apps(background=False):
-        name = cur_app.name
-
-        if name.endswith(".exe"):
-            name = name.rsplit(".", 1)[0]
-
-        words = get_words(name)
-        for word in words:
-            if word and word not in running:
-                running[word.lower()] = cur_app.name
-
-        running[name.lower()] = cur_app.name
-    for override in overrides:
-        running[override] = overrides[override]
-
-    if app.platform == "mac":
-        for base in "/Applications", "/Applications/Utilities":
-            for name in os.listdir(base):
-                path = os.path.join(base, name)
-                name = name.rsplit(".", 1)[0].lower()
-                launch[name] = path
-                words = name.split(" ")
-                for word in words:
-                    if word and word not in launch:
-                        if len(name) > 6 and len(word) < 3:
-                            continue
-                        launch[word] = path
-
-    lists = {
-        "self.running": running,
-        "self.launch": launch,
-    }
-
-    # batch update lists
-    ctx.lists.update(lists)
-
-
 def ui_event(event, arg):
     if event in ("app_activate", "app_launch", "app_close", "win_open", "win_close"):
         # print(f'------------------ event:{event}  arg:{arg}')
@@ -159,4 +190,3 @@ def ui_event(event, arg):
 
 
 ui.register("", ui_event)
-update_lists()


### PR DESCRIPTION
- Since the <user.running_applications> capture provides the actual app.name for switching purpose, we only need to do the fuzzier matching if the name isn't already in the list of running apps. In that case, the input is coming from <user.text> in practice. Ugly code, but working.
- For <user.text> input, ignore input < 3 characters
- Add watcher to update overrides when the override file changes. Old overrides appear to stick around for 1 or 2 focus command sometimes, but take affect thereafter.
- Add length check to the CSV processing to prevent silly crashes.