### PR TITLE
keep more history, but only show the most recent ten lines by default

### DIFF
--- a/code/history.py
+++ b/code/history.py
@@ -1,6 +1,9 @@
 from talon import imgui, Module, speech_system, actions
 
-hist_len = 10
+# We keep hist_len lines of history, but by default display only hist_short_len of them.
+hist_len = 50
+hist_short_len = 10
+hist_more = False
 history = []
 
 
@@ -31,7 +34,7 @@ def gui(gui: imgui.GUI):
     global history
     gui.text("Command History")
     gui.line()
-    text = history[:]
+    text = history[:] if hist_more else history[-hist_short_len:]
     for line in text:
         gui.text(line)
 
@@ -55,3 +58,13 @@ class Actions:
         """Clear the history"""
         global history
         history = []
+
+    def history_more():
+        """Show more history"""
+        global hist_more
+        hist_more = True
+
+    def history_less():
+        """Show less history"""
+        global hist_more
+        hist_more = False

--- a/misc/history.talon
+++ b/misc/history.talon
@@ -1,3 +1,5 @@
 command history show: user.history_enable()
 command history hide: user.history_disable()
 command history clear: user.history_clear()
+command history less: user.history_less()
+command history more: user.history_more()


### PR DESCRIPTION
This is especially useful if you want to have the history always be displayed, in which case you may need to reduce the number of lines displayed to avoid colliding with other windows, which is what I do; this patch lets you reduce the number of lines displayed by default, while retaining a lot of history for debugging.