### PR TITLE
fix termite and vim terminal tag

### DIFF
--- a/apps/linux/termite.talon
+++ b/apps/linux/termite.talon
@@ -1,4 +1,6 @@
 app: termite
+and not win.title: /VIM/
+
 -
 tag(): user.terminal
 

--- a/code/application_matches.py
+++ b/code/application_matches.py
@@ -1,4 +1,4 @@
-from talon import Module, Context
+from talon import Context, Module
 
 mod = Module()
 
@@ -51,8 +51,7 @@ and app.name: signal
 
 apps.termite = """
 os: linux
-app.name: /termite/
-not win.title: /VIM/
+and app.name: /termite/
 """
 
 apps.windows_explorer = """
@@ -73,4 +72,3 @@ apps.windows_terminal = """
 os: windows
 and app.name: WindowsTerminal.exe 
 """
-


### PR DESCRIPTION
`and not win.title`  doesn't work within  the `apps.termite`  declaration stuff,  so just moved it back to the termite talon file.  otherwise terminal tag is alway set