### PR TITLE
Add middle click "midclick"

### DIFF
--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -11,6 +11,7 @@ camera overlay: eye_mouse.camera_overlay.toggle()
 run calibration: user.mouse_calibrate()	
 touch: mouse_click(0)
 righty: mouse_click(1)
+midclick: mouse_click(2)
 
 #see keys.py for modifiers.
 #defaults


### PR DESCRIPTION
A modest proposal. I've been using this naming for a while now and have had no misrecognition concerns.
Tested on macOS but should be cross platform.