### PR TITLE
fix formatted phrase history bug and clean up a little

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -56,16 +56,14 @@ def format_phrase(m: Union[str, Phrase], fmtrs: str):
 
 def format_phrase_no_history(word_list, fmtrs: str):
     fmtr_list = fmtrs.split(",")
-    tmp = []
+    words = []
     spaces = True
     for i, w in enumerate(word_list):
         for name in reversed(fmtr_list):
             smash, func = all_formatters[name]
             w = func(i, w, i == len(word_list) - 1)
             spaces = spaces and not smash
-        tmp.append(w)
-    words = tmp
-
+        words.append(w)
     sep = " " if spaces else ""
     return sep.join(words)
 

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -62,7 +62,7 @@ def format_text_helper(word_list, fmtrs: str, tracked: bool):
     if tracked:
         formatted_phrase_history.insert(0, result)
         formatted_phrase_history = formatted_phrase_history[
-            -formatted_phrase_history_length:
+            :formatted_phrase_history_length
         ]
 
     return result

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -66,12 +66,8 @@ def format_phrase_no_history(word_list, fmtrs: str):
         tmp.append(w)
     words = tmp
 
-    sep = " "
-    if not spaces:
-        sep = ""
-    result = sep.join(words)
-
-    return result
+    sep = " " if spaces else ""
+    return sep.join(words)
 
 
 NOSEP = True


### PR DESCRIPTION
I fixed a bug in formatters.py: rather than keeping the last N formatted phrases, it kept only the first N, and forgot any new entries after that. I also refactored the code a little while I was in there and added a few comments.