### PR TITLE
adjust vocabulary.py to separate word_map from user.vocabulary

### DIFF
--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -1,30 +1,67 @@
 from talon import Context, Module, actions, grammar
 
-
-simple_vocabulary = [
-    "nmap",
-    "admin",
-    "Cisco",
-    "Citrix",
-    "VPN",
-    "DNS",
-    "minecraft",
+# Add single words here if Talon recognizes them, but they need to have their
+# capitalization adjusted.
+capitalize = [
+    "I",
+    "I'm",
+    "I've",
+    "I'll",
+    "I'd",
+    "Monday",
+    "Mondays",
+    "Tuesday",
+    "Tuesdays",
+    "Wednesday",
+    "Wednesdays",
+    "Thursday",
+    "Thursdays",
+    "Friday",
+    "Fridays",
+    "Saturday",
+    "Saturdays",
+    "Sunday",
+    "Sundays",
+    "January",
+    "February",
+    # March omitted because it's a regular word too
+    "April",
+    # May omitted because it's a regular word too
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
 ]
 
-mapping_vocabulary = {
-    "i": "I",
-    "i'm": "I'm",
-    "i've": "I've",
-    "i'll": "I'll",
-    "i'd": "I'd",
+# Add single words here if Talon recognizes, but they need to have their
+# spelling adjusted.
+word_map = {
+    # For example:
+    # "color": "colour",
 }
+word_map.update({x.lower(): x for x in capitalize})
 
+# Add words (or phrases you want treated as words) here if Talon doesn't
+# recognize them at all.
+simple_vocabulary = ["nmap", "admin", "Cisco", "Citrix", "VPN", "DNS", "minecraft"]
+
+# Add vocabulary words (or phrases you want treated as words) here that aren't
+# recognized by Talon and are written differently than they're pronounced.
+mapping_vocabulary = {
+    # For example:
+    # "enn map": "nmap",
+    # "under documented": "under-documented",
+}
 mapping_vocabulary.update(dict(zip(simple_vocabulary, simple_vocabulary)))
+
 
 mod = Module()
 
 
-@mod.capture(rule="({user.vocabulary})")
+@mod.capture(rule="{user.vocabulary}")
 def vocabulary(m) -> str:
     return m.vocabulary
 
@@ -34,7 +71,13 @@ def word(m) -> str:
     try:
         return m.vocabulary
     except AttributeError:
-        return actions.dictate.parse_words(m.word)[-1]
+        # TODO: if the word is both a regular word AND user.vocabulary, then in
+        # principle it may parse as <word> instead; we ought to pass it through
+        # mapping_vocabulary to be sure. But we should be doing that in
+        # user.text, below, too.
+        words = actions.dictate.replace_words(actions.dictate.parse_words(m.word))
+        assert len(words) == 1
+        return words[0]
 
 
 punctuation = set(".,-!?;:")
@@ -43,20 +86,18 @@ punctuation = set(".,-!?;:")
 @mod.capture(rule="(<user.vocabulary> | <phrase>)+")
 def text(m) -> str:
     words = []
-    result = ""
     for item in m:
-        # print(m)
         if isinstance(item, grammar.vm.Phrase):
-            words = words + actions.dictate.replace_words(
-                actions.dictate.parse_words(item)
+            words.extend(
+                actions.dictate.replace_words(actions.dictate.parse_words(item))
             )
         else:
-            words = words + item.split(" ")
+            words.extend(item.split(" "))
 
+    result = ""
     for i, word in enumerate(words):
         if i > 0 and word not in punctuation and words[i - 1][-1] not in ("/-("):
             result += " "
-
         result += word
     return result
 
@@ -65,6 +106,12 @@ mod.list("vocabulary", desc="user vocabulary")
 
 ctx = Context()
 
-# setup the word map too
-ctx.settings["dictate.word_map"] = mapping_vocabulary
+# dictate.word_map is used by actions.dictate.replace_words to rewrite words
+# Talon recognized. Entries in word_map don't change the priority with which
+# Talon recognizes some words over others.
+ctx.settings["dictate.word_map"] = word_map
+
+# user.vocabulary is used to explicitly add words/phrases that Talon doesn't
+# recognize. Words in user.vocabulary (or other lists and captures) are
+# "command-like" and their recognition is prioritized over ordinary words.
 ctx.lists["user.vocabulary"] = mapping_vocabulary

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -36,7 +36,7 @@ capitalize = [
     "December",
 ]
 
-# Add single words here if Talon recognizes, but they need to have their
+# Add single words here if Talon recognizes them, but they need to have their
 # spelling adjusted.
 word_map = {
     # For example:


### PR DESCRIPTION
Per some discussion in the slack (https://talonvoice.slack.com/archives/G9YTMSZ2T/p1599345924139300), it would be nice if rewriting words Talon already recognizes ("i'm" -> "I'm") didn't change recognition behavior - apparently, adding new words to user.vocabulary makes Talon prefer recognizing them over ordinary words. This PR adjusts vocabulary.py to separate "changing spellings of things Talon recognizes" from "adding new words Talon doesn't recognize".

However, I've only tested this on w2l. Since this affects a pretty core part of knausj_talon, probably it should get tested by someone using Dragon!

I also added capitalization for days of the week & months to the word map.