### PR TITLE
fix bug in homophones.py that was forgetting all the homophones

### DIFF
--- a/code/homophones.py
+++ b/code/homophones.py
@@ -30,10 +30,8 @@ def update_homophones(name, flags):
     if name is not None and name != homophones_file:
         return
 
-    global all_homophones
     phones = {}
     canonical_list = []
-
     with open(homophones_file, "r") as f:
         for h in f:
             h = h.rstrip()
@@ -51,8 +49,8 @@ def update_homophones(name, flags):
                     others = sorted(others)
                     phones[w] = others
 
+    global all_homophones
     all_homophones = phones
-    # print(str(canonical_list))
     ctx.lists["self.homophones_canonicals"] = canonical_list
 
 

--- a/code/homophones.py
+++ b/code/homophones.py
@@ -33,21 +33,13 @@ def update_homophones(name, flags):
     phones = {}
     canonical_list = []
     with open(homophones_file, "r") as f:
-        for h in f:
-            h = h.rstrip()
-            h = h.split(",")
-            canonical_list.append(max(h, key=len))
-            for w in h:
-                w = w.lower()
-                others = phones.get(w, None)
-                if others is None:
-                    phones[w] = sorted(h)
-                else:
-                    # if there are multiple hits, collapse them into one list
-                    others += h
-                    others = set(others)
-                    others = sorted(others)
-                    phones[w] = others
+        for line in f:
+            words = line.rstrip().split(",")
+            canonical_list.append(max(words, key=len))
+            for word in words:
+                word = word.lower()
+                old_words = phones.get(word, [])
+                phones[word] = sorted(set(old_words + words))
 
     global all_homophones
     all_homophones = phones

--- a/code/homophones.py
+++ b/code/homophones.py
@@ -27,26 +27,29 @@ main_screen = ui.main_screen()
 
 
 def update_homophones(name, flags):
-    global phones, canonical_list, all_homophones
+    if name is not None and name != homophones_file:
+        return
+
+    global all_homophones
     phones = {}
     canonical_list = []
-    if name is None or name == homophones_file:
-        with open(homophones_file, "r") as f:
-            for h in f:
-                h = h.rstrip()
-                h = h.split(",")
-                canonical_list.append(max(h, key=len))
-                for w in h:
-                    w = w.lower()
-                    others = phones.get(w, None)
-                    if others is None:
-                        phones[w] = sorted(h)
-                    else:
-                        # if there are multiple hits, collapse them into one list
-                        others += h
-                        others = set(others)
-                        others = sorted(others)
-                        phones[w] = others
+
+    with open(homophones_file, "r") as f:
+        for h in f:
+            h = h.rstrip()
+            h = h.split(",")
+            canonical_list.append(max(h, key=len))
+            for w in h:
+                w = w.lower()
+                others = phones.get(w, None)
+                if others is None:
+                    phones[w] = sorted(h)
+                else:
+                    # if there are multiple hits, collapse them into one list
+                    others += h
+                    others = set(others)
+                    others = sorted(others)
+                    phones[w] = others
 
     all_homophones = phones
     # print(str(canonical_list))


### PR DESCRIPTION
Previously homophones.py was conditionally reading homophones.csv, but unconditionally updating all_homophones and ctx.lists["self.homophones_canonical"], which meant that updates that didn't change homophones.csv would wipe the homophones list.