### PR TITLE
Mouse fixes for 0.1.0

### DIFF
--- a/code/mouse.py
+++ b/code/mouse.py
@@ -1,7 +1,6 @@
 from talon import cron, ctrl, ui, Module, Context, actions, noise, settings, imgui, app
-from talon.engine import engine
 from talon_plugins import speech, eye_mouse, eye_zoom_mouse
-from talon_plugins.eye_mouse import toggle_control, config
+from talon_plugins.eye_mouse import toggle_control, toggle_camera_overlay, config
 import subprocess
 import os
 import pathlib
@@ -28,7 +27,7 @@ default_cursor = {
     "SizeNS": "%SystemRoot%\\Cursors\\aero_ns.cur",
     "SizeNWSE": "%SystemRoot%\\Cursors\\aero_nwse.cur",
     "SizeWE": "%SystemRoot%\\Cursors\\aero_ew.cur",
-    "UpArrow": "%SystemRoot%\Cursors\\aero_up.cur",
+    "UpArrow": "%SystemRoot%\\Cursors\\aero_up.cur",
     "Wait": "%SystemRoot%\\Cursors\\aero_busy.ani",
     "Crosshair": "",
     "IBeam": "",
@@ -115,6 +114,10 @@ class Actions:
     def mouse_toggle_control_mouse():
         """Toggles control mouse"""
         toggle_control(not config.control_mouse)
+
+    def mouse_toggle_camera_overlay():
+        """Toggles camera overlay"""
+        toggle_camera_overlay(not config.show_camera)        
 
     def mouse_toggle_zoom_mouse():
         """Toggles zoom mouse"""

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -1,6 +1,6 @@
 control mouse: user.mouse_toggle_control_mouse()
 zoom mouse: user.mouse_toggle_zoom_mouse()
-camera overlay: eye_mouse.camera_overlay.toggle()
+camera overlay: user.mouse_toggle_camera_overlay()
 run calibration: user.mouse_calibrate()	
 touch: 
 	mouse_click(0)


### PR DESCRIPTION
During testing with talon public v0.1.0, macOS 10.15:

Removed import of `talon.engine`.
mouse.py tries (and fails) to import it, and appears to work fine once removed, no apparent references to `engine`.

Tested functionality of mouse.talon and found "camera overlay" fails:
`KeyError: "Action 'eye_mouse.camera_overlay.toggle' is not declared."` 

I added a corresponding function in mouse.py modeled on the existing control_mouse toggle.

Escaped UpArrow path to match the other Windows cursors listed. I have not been able to test this on Windows.