### PR TITLE
Add command to reformat selected text

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -1,9 +1,11 @@
 from talon import Module, Context, actions, ui, imgui
 from talon.grammar import Phrase
 from typing import List, Union
+import re
 
 ctx = Context()
 key = actions.key
+edit = actions.edit
 
 words_to_keep_lowercase = "a,an,the,at,by,for,in,is,of,on,to,up,and,as,but,or,nor".split(
     ","
@@ -227,6 +229,19 @@ class Actions:
         """Reformats last formatted phrase"""
         global last_phrase
         return format_phrase(last_phrase, formatters)
+
+    def formatters_reformat_selection(formatters: str) -> str:
+        """Reformats the current selection."""
+        selected = edit.selected_text()
+        unformatted = re.sub(r"[^a-zA-Z0-9]+", " ", selected).lower()
+        # TODO: Separate out camelcase & studleycase vars
+
+        # Delete separately for compatibility with programs that don't overwrite
+        # selected text (e.g. Emacs)
+        edit.delete()
+        text = actions.self.formatted_text(unformatted, formatters)
+        actions.insert(text)
+        return text
 
 
 @ctx.capture(rule="{self.formatters}+")

--- a/misc/formatters.talon
+++ b/misc/formatters.talon
@@ -7,6 +7,7 @@
   insert(result)
 <user.format_text>$: insert(format_text)
 <user.format_text> over: insert(format_text)
+<user.formatters> that: user.formatters_reformat_selection(user.formatters)
 word <user.word>: insert(user.word)
 format help: user.formatters_help_toggle()
 format recent: user.formatters_recent_toggle()

--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -65,13 +65,7 @@ formatted <user.format_text>:
     auto_insert(format_text)
     user.auto_format_resume()
 ^format selection <user.formatters>$:
-    edit.copy()
-    sleep(100ms)
-    text = clip.text()
-    result = user.formatted_text(text, formatters)
-    user.auto_format_pause()
-    auto_insert(result)
-    user.auto_format_resume()
+    user.formatters_reformat_selection(formatters)
 #corrections
 scratch that: user.clear_last_utterance()
 scratch selection: edit.delete()


### PR DESCRIPTION
Small command that reformats the currently selected text.

This implementation strips punctuation before formatting, but it doesn't separate out camel & studley case variables. I can add a heuristic for that if you'd like though.

I also replaced the dictation mode implementation - let me know if I've misinterpreted what that code was doing.

Closes #224 