### PR TITLE
CSV-based Talon lists

### DIFF
--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -22,7 +22,6 @@ def _load_csv_dict(
     file_name: str, headers=Tuple[str, str], default: Dict[str, str] = {}
 ) -> Dict[str, str]:
     """Load a word mapping from a CSV file. If it doesn't exist, create it."""
-    # TODO: utf-8
     assert file_name.endswith(".csv")
     path = SETTINGS_DIR / file_name
 

--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -1,0 +1,149 @@
+from talon import Module, fs, Context
+import os
+import csv
+from pathlib import Path
+from typing import Dict, List, Tuple
+import threading
+
+
+# NOTE: This method requires this module to be one folder below the top-level
+#   knausj folder.
+SETTINGS_DIR = Path(__file__).parents[1] / "settings"
+
+if not SETTINGS_DIR.is_dir():
+    os.mkdir(SETTINGS_DIR)
+
+
+mod = Module()
+ctx = Context()
+
+
+def _load_csv_dict(
+    file_name: str, headers=Tuple[str, str], default: Dict[str, str] = {}
+) -> Dict[str, str]:
+    """Load a word mapping from a CSV file. If it doesn't exist, create it."""
+    # TODO: utf-8
+    assert file_name.endswith(".csv")
+    path = SETTINGS_DIR / file_name
+
+    # Create the file if it doesn't exist
+    if not SETTINGS_DIR.is_dir():
+        os.mkdir(SETTINGS_DIR)
+    if not path.is_file():
+        with open(path, "w", encoding="utf-8") as file:
+            writer = csv.writer(file)
+            writer.writerow(headers)
+            for key, value in default.items():
+                writer.writerow([key] if key == value else [value, key])
+
+    # Now read from disk
+    with open(path, "r", encoding="utf-8") as file:
+        rows = list(csv.reader(file))
+
+    mapping = {}
+    if len(rows) >= 2:
+        actual_headers = rows[0]
+        if not actual_headers == list(headers):
+            print(
+                f'"{file_name}": Malformed headers - {actual_headers}.'
+                + f" Should be {list(headers)}. Ignoring row."
+            )
+        for row in rows[1:]:
+            if len(row) == 0:
+                # Windows newlines are sometimes read as empty rows. :champagne:
+                continue
+            if len(row) == 1:
+                mapping[row[0]] = row[0]
+            else:
+                mapping[row[1]] = row[0]
+                if len(row) > 2:
+                    print(
+                        f'"{file_name}": More than two values in row: {row}.'
+                        + " Ignoring the extras."
+                    )
+    return mapping
+
+
+_mapped_lists = {}
+_settings_lock = threading.Lock()
+_word_map_params = None
+
+
+def _update_list(list_name: str, *csv_params):
+    """Update list with `list_name` from a csv on disk.
+
+    `csv_params` will be passed to `_load_csv_dict`.
+
+    """
+    global ctx
+    ctx.lists[list_name] = _load_csv_dict(*csv_params)
+
+
+def _update_word_map(*csv_params):
+    """Update `dictate.word_map` from disk.
+
+    `csv_params` will be passed to `_load_csv_dict`.
+
+    """
+    global ctx
+    ctx.settings["dictate.word_map"] = _load_csv_dict(*csv_params)
+
+
+def _update_lists(*_):
+    """Update all CSV lists from disk."""
+    print("Updating CSV lists...")
+    with _settings_lock:
+        for list_name, csv_params in _mapped_lists.items():
+            try:
+                _update_list(list_name, *csv_params)
+            except Exception as e:
+                print(f'Error loading list "{list_name}": {e}')
+        # Special case - `dictate.word_map` isn't a list.
+        if _word_map_params:
+            try:
+                _update_word_map(*_word_map_params)
+            except Exception as e:
+                print(f'Error updating "dictate.word_map": {e}')
+
+
+def bind_list_to_csv(
+    list_name: str,
+    csv_name: str,
+    csv_headers: Tuple[str, str],
+    default_values: Dict[str, str] = {},
+) -> None:
+    """Register a Talon list that should be updated from a CSV on disk.
+
+    The CSV file will be created automatically in the "settings" dir if it
+    doesn't exist. This directory can be tracked independently to
+    `knausj_talon`, allowing the user to specify things like private vocab
+    separately.
+
+    Note the list must be declared separately.
+
+    """
+    global _mapped_lists
+    with _settings_lock:
+        _update_list(list_name, csv_name, csv_headers, default_values)
+        # If there were no errors, we can register it permanently.
+        _mapped_lists[list_name] = (csv_name, csv_headers, default_values)
+
+
+def bind_word_map_to_csv(
+    csv_name: str, csv_headers: Tuple[str, str], default_values: Dict[str, str] = {}
+) -> None:
+    """Like `bind_list_to_csv`, but for the `dictate.word_map` setting.
+
+    Since it is a setting, not a list, it has to be handled separately.
+
+    """
+    global _word_map_params
+    # TODO: Maybe a generic system for binding the dicts to settings? Only
+    #   implement if it's needed.
+    with _settings_lock:
+        _update_word_map(csv_name, csv_headers, default_values)
+        # If there were no errors, we can register it permanently.
+        _word_map_params = (csv_name, csv_headers, default_values)
+
+
+fs.watch(str(SETTINGS_DIR), _update_lists)

--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -10,9 +10,6 @@ import threading
 #   knausj folder.
 SETTINGS_DIR = Path(__file__).parents[1] / "settings"
 
-if not SETTINGS_DIR.is_dir():
-    os.mkdir(SETTINGS_DIR)
-
 
 mod = Module()
 ctx = Context()

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -1,8 +1,9 @@
 from talon import Context, Module, actions, grammar
+from .user_settings import bind_list_to_csv, bind_word_map_to_csv
 
-# Add single words here if Talon recognizes them, but they need to have their
-# capitalization adjusted.
-capitalize = [
+
+# Default words that will need to be capitalized (particularly under w2l).
+_capitalize_defaults = [
     "I",
     "I'm",
     "I've",
@@ -36,26 +37,21 @@ capitalize = [
     "December",
 ]
 
-# Add single words here if Talon recognizes them, but they need to have their
-# spelling adjusted.
-word_map = {
-    # For example:
-    # "color": "colour",
+# Default words that need to be remapped.
+_word_map_defaults = {
+    # E.g:
+    # "cash": "cache",
 }
-word_map.update({x.lower(): x for x in capitalize})
 
-# Add words (or phrases you want treated as words) here if Talon doesn't
-# recognize them at all.
-simple_vocabulary = ["nmap", "admin", "Cisco", "Citrix", "VPN", "DNS", "minecraft"]
+# Default words that should be added to Talon's vocabulary.
+_simple_vocab_default = ["nmap", "admin", "Cisco", "Citrix", "VPN", "DNS", "Minecraft"]
 
-# Add vocabulary words (or phrases you want treated as words) here that aren't
-# recognized by Talon and are written differently than they're pronounced.
-mapping_vocabulary = {
-    # For example:
-    # "enn map": "nmap",
-    # "under documented": "under-documented",
+# Defaults for different pronounciations of words that need to be added to
+# Talon's vocabulary.
+_mapping_vocab_default = {
+    "N map": "nmap",
+    "under documented": "under-documented",
 }
-mapping_vocabulary.update(dict(zip(simple_vocabulary, simple_vocabulary)))
 
 
 mod = Module()
@@ -106,12 +102,28 @@ mod.list("vocabulary", desc="user vocabulary")
 
 ctx = Context()
 
-# dictate.word_map is used by actions.dictate.replace_words to rewrite words
+
+_default_word_map = {}
+_default_word_map.update(_word_map_defaults)
+_default_word_map.update({word.lower(): word for word in _capitalize_defaults})
+# "dictate.word_map" is used by `actions.dictate.replace_words` to rewrite words
 # Talon recognized. Entries in word_map don't change the priority with which
 # Talon recognizes some words over others.
-ctx.settings["dictate.word_map"] = word_map
+bind_word_map_to_csv(
+    "words_to_replace.csv",
+    csv_headers=("Replacement", "Original"),
+    default_values=_default_word_map,
+)
 
-# user.vocabulary is used to explicitly add words/phrases that Talon doesn't
+_default_vocabulary = {}
+_default_vocabulary.update({word: word for word in _simple_vocab_default})
+_default_vocabulary.update(_mapping_vocab_default)
+# "user.vocabulary" is used to explicitly add words/phrases that Talon doesn't
 # recognize. Words in user.vocabulary (or other lists and captures) are
 # "command-like" and their recognition is prioritized over ordinary words.
-ctx.lists["user.vocabulary"] = mapping_vocabulary
+bind_list_to_csv(
+    "user.vocabulary",
+    "additional_words.csv",
+    csv_headers=("Word(s)", "Spoken Form (If Different)"),
+    default_values=_default_vocabulary,
+)


### PR DESCRIPTION
First attempt at pulling Talon lists out into user-defined CSV files.

The system I ended up implementing is a 1:1 mapping between CSV files and Talon dicts. You call a function to tie a Talon list to a CSV file, and it's mirrored from then on. When the CSV is changed, it's reloaded into a list in the `user.user_settings` context (which is active globally). All CSVs are stored in a separate `"settings"` folder, so the user can be track them independently. The API is designed to be simple, calls look like this:

```
bind_list_to_csv(
    "user.vocabulary",
    "additional_words.csv",
    csv_headers=("Word(s)", "Spoken Form (If Different)"),
    default_values={"the csv": "will be created", "with these": "values", "if it does not": "exist"},
)
```

The default values are only used when initially creating the CSV.

In the CSV files, values are stored on the left. Keys are optional, and stored on the right (if left blank, the key will be the same as the value). Each CSV takes a pair of headers to explain the columns:

```
| Word(s) | Spoken Form (If Different) |
| ------- | -------------------------- |
| def     |                            |
| nmap    |                            |
| nmap    | enn map                    |
| nmap    | N map                      |
```

This is a generic system - you can register any talon list and bind it to a CSV file, all from Python (the CSVs are created on-demand).

I initially implemented the approach discussed in #239 (four separate files) but the wiring was a lot more complicated than this system (and was pretty vocab-specific). We could go back to that for vocab settings, but this is a lot simpler on the backend it would muddy the 1:1 mapping I have set up here. Let me know what you think.

Closes #239 