### PR TITLE
bunch of small language fixes

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -263,7 +263,5 @@ class user_actions:
         actions.user.code_insert_function(result, None)
 
     def code_insert_library(text: str, selection: str):
-        actions.insert("#include <>")
-        actions.edit.left()
-        actions.clip.set_text(text + "{}".format(selection))
-        actions.edit.paste()
+        actions.user.paste("include <{}>".format(selection))
+

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -1,14 +1,19 @@
-# XXX - reorder some dicts for human readability so we see functions and libraries
-# first
-
 from talon import Context, Module, actions, settings
 
 mod = Module()
 mod.setting(
-    "use_stdint_datatypes ", type=int, default=1, desc="beep",
+    "use_stdint_datatypes ",
+    type=int,
+    default=1,
+    desc="Use the stdint datatype naming in commands by default",
 )
 
 ctx = Context()
+ctx.matches = r"""
+mode: user.c
+mode: command
+and code.language: c
+"""
 
 ctx.lists["self.c_pointers"] = {
     "pointer": "*",
@@ -64,7 +69,7 @@ ctx.lists["self.c_types"] = {
     "float": "float",
 }
 
-ctx.lists["self.c_libraries"] = {
+ctx.lists["user.code_libraries"] = {
     "assert": "assert.h",
     "type": "ctype.h",
     "error": "errno.h",
@@ -84,7 +89,7 @@ ctx.lists["self.c_libraries"] = {
     "standard int": "stdint.h",
 }
 
-ctx.lists["self.c_functions"] = {
+ctx.lists["user.code_functions"] = {
     "mem copy": "memcpy",
     "mem set": "memset",
     "string cat": "strcat",
@@ -131,19 +136,17 @@ ctx.lists["self.c_functions"] = {
 mod.list("c_pointers", desc="Common C pointers")
 mod.list("c_signed", desc="Common C datatype signed modifiers")
 mod.list("c_types", desc="Common C types")
-mod.list("c_libraries", desc="Standard C library")
-mod.list("c_functions", desc="Standard C functions")
 mod.list("stdint_types", desc="Common stdint C types")
 mod.list("stdint_signed", desc="Common stdint C datatype signed modifiers")
 
 
 @mod.capture
-def cast(m) -> str:
+def c_cast(m) -> str:
     "Returns a string"
 
 
 @mod.capture
-def stdint_cast(m) -> str:
+def c_stdint_cast(m) -> str:
     "Returns a string"
 
 
@@ -163,11 +166,6 @@ def c_types(m) -> str:
 
 
 @mod.capture
-def c_functions(m) -> str:
-    "Returns a string"
-
-
-@mod.capture
 def stdint_types(m) -> str:
     "Returns a string"
 
@@ -178,17 +176,7 @@ def stdint_signed(m) -> str:
 
 
 @mod.capture
-def variable(m) -> str:
-    "Returns a string"
-
-
-@mod.capture
-def function(m) -> str:
-    "Returns a string"
-
-
-@mod.capture
-def library(m) -> str:
+def c_variable(m) -> str:
     "Returns a string"
 
 
@@ -212,11 +200,6 @@ def c_types(m) -> str:
     return m.c_types
 
 
-@ctx.capture(rule="{self.c_functions}")
-def c_functions(m) -> str:
-    return m.c_functions
-
-
 @ctx.capture(rule="{self.stdint_types}")
 def stdint_types(m) -> str:
     return m.stdint_types
@@ -227,25 +210,60 @@ def stdint_signed(m) -> str:
     return m.stdint_signed
 
 
-@ctx.capture(rule="{self.c_libraries}")
-def library(m) -> str:
-    return m.c_libraries
-
-
 # NOTE: we purposely we don't have a space after signed, to faciltate stdint
 # style uint8_t constructions
 @ctx.capture(rule="[<self.c_signed>]<self.c_types> [<self.c_pointers>+]")
-def cast(m) -> str:
+def c_cast(m) -> str:
     return "(" + " ".join(list(m)) + ")"
 
 
 # NOTE: we purposely we don't have a space after signed, to faciltate stdint
 # style uint8_t constructions
 @ctx.capture(rule="[<self.stdint_signed>]<self.stdint_types> [<self.c_pointers>+]")
-def stdint_cast(m) -> str:
+def c_stdint_cast(m) -> str:
     return "(" + "".join(list(m)) + ")"
 
 
 @ctx.capture(rule="[<self.c_signed>]<self.c_types>[<self.c_pointers>]")
-def variable(m) -> str:
+def c_variable(m) -> str:
     return " ".join(list(m))
+
+
+@ctx.action_class("user")
+class user_actions:
+    def code_insert_function(text: str, selection: str):
+        if selection:
+            text = text + "({})".format(selection)
+        else:
+            text = text + "()"
+
+        actions.user.paste(text)
+        actions.edit.left()
+
+    # TODO - it would be nice that you integrate that types from c_cast
+    # instead of defaulting to void
+    def code_private_function(text: str):
+        """Inserts private function declaration"""
+        result = "void {}".format(
+            actions.user.formatted_text(
+                text, settings.get("user.code_private_function_formatter")
+            )
+        )
+
+        actions.user.code_insert_function(result, None)
+
+    def code_private_static_function(text: str):
+        """Inserts private static function"""
+        result = "static void {}".format(
+            actions.user.formatted_text(
+                text, settings.get("user.code_private_function_formatter")
+            )
+        )
+
+        actions.user.code_insert_function(result, None)
+
+    def code_insert_library(text: str, selection: str):
+        actions.insert("#include <>")
+        actions.edit.left()
+        actions.clip.set_text(text + "{}".format(selection))
+        actions.edit.paste()

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -155,3 +155,8 @@ standard <user.stdint_types>: "{stdint_types}"
 int main:
     insert("int main()")
     edit.left()
+
+toggle includes: user.code_toggle_libraries()
+include <user.code_libraries>:
+    user.code_insert_library(code_libraries, "")
+    key(end enter)

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -105,6 +105,10 @@ action(user.code_block_comment):
 action(user.code_block_comment_prefix): "/*"
 action(user.code_block_comment_suffix): "*/"
 
+^funky <user.text>$: user.code_private_function(text)
+^static funky <user.text>$: user.code_private_static_function(text)
+
+
 # XXX - make these generic in programming, as they will match cpp, etc
 state define: "#define "
 state undefine: "#undef "
@@ -116,10 +120,7 @@ state error: "#error "
 state pre else if: "#elif "
 state pre end: "#endif "
 state pragma: "#pragma "
-
-
 state default: "default:\nbreak;"
-state break: "break;"
 
 #control flow
 #best used with a push like command
@@ -137,38 +138,20 @@ push brackets:
 
 # Declare variables or structs etc.
 # Ex. * int myList
-<user.variable> <phrase>:
-    insert("{variable} ")
+<user.c_variable> <phrase>:
+    insert("{c_variable} ")
     insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE,NO_SPACES"))
 
-<user.variable> <user.letter>:
-    insert("{variable} {letter} ")
-
-# Ex. int * testFunction
-# TODO: these clearly don't want to use function_key, so what do they want to use?
-# fun <user.function> <phrase>:
-#     insert("{function} ")
-#     insert(user.formatted_text(phrase, "PRIVATE_CAMEL_CASE,NO_SPACES"))
-#     insert("()")
-#     edit.left()
-
-# <user.function>:
-#     insert("{function} ")
+<user.c_variable> <user.letter>:
+    insert("{c_variable} {letter} ")
 
 # Ex. (int *)
-cast to <user.cast>: "{cast}"
+cast to <user.c_cast>: "{c_cast}"
 standard cast to <user.stdint_cast>: "{stdint_cast}"
 <user.c_types>: "{c_types}"
 <user.c_pointers>: "{c_pointers}"
 <user.c_signed>: "{c_signed}"
 standard <user.stdint_types>: "{stdint_types}"
-call <user.c_functions>:
-    insert("{c_functions}()")
-    edit.left()
-#import standard libraries
-include <user.library>:
-    insert("#include <{library}>")
-    key(enter)
 int main:
     insert("int main()")
     edit.left()

--- a/lang/comment.talon
+++ b/lang/comment.talon
@@ -1,25 +1,25 @@
 tag: user.code_comment
 -
 comment: user.code_comment()
-comment line: 
+comment line:
     #todo: this should probably be a single function once
     #.talon supports implementing actions with parameters?
 	edit.line_start()
     user.code_comment()
 #adds comment to the start of the line
-comment line <user.text> over: 
+comment line <user.text> over:
     #todo: this should probably be a single function once
     #.talon supports implementing actions with parameters?
     edit.line_start()
     user.code_comment()
 	insert(user.text)
     insert(" ")
-comment <user.text> over: 
+comment <user.text> over:
     #todo: this should probably be a single function once
     #.talon supports implementing actions with parameters?
 	user.code_comment()
     insert(user.text)
-comment <user.text>$: 
+comment <user.text>$:
     #todo: this should probably be a single function once
     #.talon supports implementing actions with parameters?
     user.code_comment()

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -1,9 +1,9 @@
-from talon import Module, Context, actions, ui, imgui, settings
+from talon import Context, Module, actions, imgui, settings, ui
 
 ctx = Context()
 ctx.matches = r"""
 mode: user.csharp
-mode: command 
+mode: command
 and code.language: csharp
 """
 ctx.lists["user.code_functions"] = {
@@ -45,7 +45,7 @@ class user_actions:
         actions.user.code_insert_function(result, None)
 
     def code_protected_function(text: str):
-        result = "private static void {}".format(
+        result = "private void {}".format(
             actions.user.formatted_text(
                 text, settings.get("user.code_protected_function_formatter")
             )

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -1,5 +1,5 @@
 mode: user.csharp
-mode: command 
+mode: command
 and code.language: csharp
 -
 tag(): user.code_operators
@@ -50,8 +50,8 @@ action(user.code_operator_bitwise_left_shift): " << "
 action(user.code_operator_bitwise_left_shift_assignment): " <<= "
 action(user.code_operator_bitwise_right_shift): " >> "
 action(user.code_operator_bitwise_right_shift_assignment): " >>= "
-action(user.code_block): 
-    insert("{}") 
+action(user.code_block):
+    insert("{}")
 	key(left enter enter up tab)
 action(user.code_self): "this"
 action(user.code_null): "null"

--- a/lang/go.talon
+++ b/lang/go.talon
@@ -1,5 +1,5 @@
 mode: user.go
-mode: command 
+mode: command
 and code.language: go
 -
 variadic: "..."

--- a/lang/programming.talon
+++ b/lang/programming.talon
@@ -44,9 +44,7 @@ toggle funk: user.code_toggle_functions()
 toggle library: user.code_toggle_libraries()
 funk <user.code_functions>:
     user.code_insert_function(code_functions, "")
-library <user.code_libraries>:
-    insert("library()")
-    key(left)
+(include|import|library) <user.code_libraries>:
     user.code_insert_library(code_libraries, "")
     key(end enter)
 funk cell <number>:

--- a/lang/programming.talon
+++ b/lang/programming.talon
@@ -41,12 +41,8 @@ state false: user.code_false()
 
 # show and print functions and libraries
 toggle funk: user.code_toggle_functions()
-toggle library: user.code_toggle_libraries()
 funk <user.code_functions>:
     user.code_insert_function(code_functions, "")
-(include|import|library) <user.code_libraries>:
-    user.code_insert_library(code_libraries, "")
-    key(end enter)
 funk cell <number>:
     user.code_select_function(number - 1, "")
 funk wrap <user.code_functions>:

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -22,7 +22,7 @@ ctx.lists["user.code_functions"] = {
     "update": "update",
 }
 
-"""a set of fields used in python dog strings that will follow the
+"""a set of fields used in python docstrings that will follow the
 reStructuredText format"""
 docstring_fields = {
     "class": ":class:",

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -1,13 +1,12 @@
-from talon import Module, Context, actions, ui, imgui, clip, settings
 import re
 
-from talon import actions, Context, Module
+from talon import Context, Module, actions, settings
 
 mod = Module()
 ctx = Context()
 ctx.matches = r"""
 mode: user.python
-mode: command 
+mode: command
 and code.language: python
 """
 ctx.lists["user.code_functions"] = {
@@ -22,6 +21,48 @@ ctx.lists["user.code_functions"] = {
     "string": "str",
     "update": "update",
 }
+
+"""a set of fields used in python dog strings that will follow the
+reStructuredText format"""
+docstring_fields = {
+    "class": ":class:",
+    "function": ":func:",
+    "parameter": ":param:",
+    "raise": ":raise:",
+    "returns": ":return:",
+    "type": ":type:",
+    "return type": ":rtype:",
+    # these are sphinx-specific
+    "see also": ".. seealso:: ",
+    "notes": ".. notes:: ",
+    "warning": ".. warning:: ",
+    "todo": ".. todo:: ",
+}
+
+mod.list("python_docstring_fields", desc="python docstring fields")
+ctx.lists["user.python_docstring_fields"] = docstring_fields
+
+type_list = {
+    "boolean": "bool",
+    "integer": "int",
+    "string": "str",
+    "none": "None",
+    "dick": "Dict",
+    "float": "float",
+    "any": "Any",
+    "tuple": "Tuple",
+    "union": "UnionAny",
+    "iterable": "Iterable",
+    "vector": "Vector",
+    "bytes": "bytes",
+    "sequence": "Sequence",
+    "callable": "Callable",
+    "list": "List",
+    "no return": "NoReturn",
+}
+
+mod.list("python_type_list", desc="python types")
+ctx.lists["user.python_type_list"] = type_list
 
 exception_list = [
     "BaseException",
@@ -141,4 +182,3 @@ class module_actions:
             actions.key(f"left:{len(s) - end_pos}")
         else:
             actions.insert(text)
-

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -99,7 +99,6 @@ action(user.code_document_string): user.insert_cursor("\"\"\"[|]\"\"\"")
 #^static funky <user.text>$: user.code_private_static_function(text)
 #^pro static funky <user.text>$: user.code_protected_static_function(text)
 #^pub static funky <user.text>$: user.code_public_static_function(text)
-
 raise {user.python_exception}: user.insert_cursor("raise {python_exception}([|])")
 
 # for annotating function parameters
@@ -121,4 +120,11 @@ dock returns type {user.python_type_list}:
 dunder in it: "__init__"
 self taught: "self."
 pie test: "pytest"
-state pass: "pass"
+state past: "pass"
+
+import <user.code_libraries>: import {code_libraries}
+
+toggle imports: user.code_toggle_libraries()
+import <user.code_libraries>:
+    user.code_insert_library(code_libraries, "")
+    key(end enter)

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -93,6 +93,12 @@ action(user.code_true): "True"
 action(user.code_false): "False"
 action(user.code_document_string): user.insert_cursor("\"\"\"[|]\"\"\"")
 
+#python-specific grammars
+dunder in it: "__init__"
+self taught: "self."
+pie test: "pytest"
+state past: "pass"
+
 ^funky <user.text>$: user.code_private_function(text)
 #^pro funky <user.text>$: user.code_protected_function(text)
 ^pub funky <user.text>$: user.code_public_function(text)
@@ -116,11 +122,6 @@ dock type {user.python_type_list}:
     user.insert_cursor(":type [|]: {python_type_list}")
 dock returns type {user.python_type_list}:
     user.insert_cursor(":rtype [|]: {python_type_list}")
-
-dunder in it: "__init__"
-self taught: "self."
-pie test: "pytest"
-state past: "pass"
 
 import <user.code_libraries>: import {code_libraries}
 

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -95,6 +95,7 @@ action(user.code_document_string): user.insert_cursor("\"\"\"[|]\"\"\"")
 
 #python-specific grammars
 dunder in it: "__init__"
+state (def | deaf | deft): "def "
 self taught: "self."
 pie test: "pytest"
 state past: "pass"

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -93,16 +93,32 @@ action(user.code_true): "True"
 action(user.code_false): "False"
 action(user.code_document_string): user.insert_cursor("\"\"\"[|]\"\"\"")
 
-#python-specicic grammars
-dunder in it: insert("__init__")
-state (def | deaf | deft): "def "
-pie test: "pytest"
-state past: "pass"
-
 ^funky <user.text>$: user.code_private_function(text)
 #^pro funky <user.text>$: user.code_protected_function(text)
 ^pub funky <user.text>$: user.code_public_function(text)
 #^static funky <user.text>$: user.code_private_static_function(text)
 #^pro static funky <user.text>$: user.code_protected_static_function(text)
 #^pub static funky <user.text>$: user.code_public_static_function(text)
+
 raise {user.python_exception}: user.insert_cursor("raise {python_exception}([|])")
+
+# for annotating function parameters
+is type {user.python_type_list}:
+    insert(": {python_type_list}")
+returns [type] {user.python_type_list}:
+    insert(" -> {python_type_list}")
+# for generic reference of types
+type {user.python_type_list}:
+    insert("{python_type_list}")
+dock {user.python_docstring_fields}:
+    insert("{python_docstring_fields}")
+    edit.left()
+dock type {user.python_type_list}:
+    user.insert_cursor(":type [|]: {python_type_list}")
+dock returns type {user.python_type_list}:
+    user.insert_cursor(":rtype [|]: {python_type_list}")
+
+dunder in it: "__init__"
+self taught: "self."
+pie test: "pytest"
+state pass: "pass"

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -1,4 +1,4 @@
-from talon import Module, Context, actions, ui, imgui, clip, settings
+from talon import Context, Module, actions, clip, imgui, settings, ui
 
 ctx = Context()
 
@@ -207,6 +207,7 @@ ctx.lists["user.code_libraries"] = {
     "shiny alert": "shinyalert",
 }
 
+
 @ctx.action_class("user")
 class user_actions:
     def code_insert_function(text: str, selection: str):
@@ -233,5 +234,7 @@ class user_actions:
         actions.edit.left()
 
     def code_insert_library(text: str, selection: str):
+        actions.insert("library()")
+        actions.edit.left()
         actions.clip.set_text(text + "{}".format(selection))
         actions.edit.paste()

--- a/lang/r/r.talon
+++ b/lang/r/r.talon
@@ -47,6 +47,10 @@ action(user.code_state_for):
 action(user.code_state_while):
     insert("while () {}")
     key(left enter up end left:3)
+toggle library: user.code_toggle_libraries()
+library <user.code_libraries>:
+    user.code_insert_library(code_libraries, "")
+    key(end enter)
 action(user.code_import):
     insert("library()")
     key(left)

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -1,5 +1,5 @@
 mode: user.talon
-mode: command 
+mode: command
 and code.language: talon
 -
 tag(): user.code_operators
@@ -41,12 +41,11 @@ key <user.keys> over: "{keys}"
 key <user.modifiers> over: "{modifiers}"
 #funk commands, consistent with other languages
 toggle funk: user.code_toggle_functions()
-funk <user.code_functions>: 
+funk <user.code_functions>:
     user.code_insert_function(code_functions, "")
-funk cell <number>: 
+funk cell <number>:
     user.code_select_function(number - 1, "")
-funk wrap <user.code_functions>: 
+funk wrap <user.code_functions>:
     user.code_insert_function(code_functions, edit.selected_text())
-funk wrap <number>: 
+funk wrap <number>:
     user.code_select_function(number - 1, edit.selected_text())
-	

--- a/lang/typescript/typescript.talon
+++ b/lang/typescript/typescript.talon
@@ -34,8 +34,8 @@ action(user.code_state_else):
   insert(" else {}")
   key(left enter)
 
-action(user.code_block): 
-  insert("{}") 
+action(user.code_block):
+  insert("{}")
   key(left enter)
 
 action(user.code_self): "this"


### PR DESCRIPTION
this includes a fix #248, a couple automatic white space changes, a typo in csharp, some additional python stuff for adding docstring documentation as well as type hinting. 

also changed the way the generic library command worked in programmin.talon is because it seems specific to r? now I make it possible in programming.talon to just to add from a list of available includes or libraries or whatever, which makes it a little bit harder to generically do because the terminology differs for different programing languages, so it may be something we don't want generic?