### PR TITLE
make <user.letters> produce a string instead of a list

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -215,6 +215,10 @@ class Actions:
         """Formats a phrase according to formatters. formatters is a comma-separated string of formatters (e.g. 'CAPITALIZE_ALL_WORDS,DOUBLE_QUOTED_STRING')"""
         return format_phrase(phrase, formatters)
 
+    def insert_formatted(phrase: Union[str, Phrase], formatters: str):
+        """Inserts a phrase formatted according to formatters. Formatters is a comma separated list of formatters (e.g. 'CAPITALIZE_ALL_WORDS,DOUBLE_QUOTED_STRING')"""
+        actions.insert(format_phrase(phrase, formatters))
+
     def formatters_help_toggle():
         """Lists all formatters"""
         if gui.showing:

--- a/code/keys.py
+++ b/code/keys.py
@@ -50,7 +50,7 @@ def letter(m) -> str:
 
 
 @mod.capture
-def letters(m) -> list:
+def letters(m) -> str:
     "Multiple letter keys"
 
 
@@ -258,15 +258,11 @@ def keys(m) -> str:
 
 @ctx.capture(rule="{self.letter}+")
 def letters(m):
-    return m.letter_list
+    return ''.join(m.letter_list)
 
 
 @mod.action_class
 class Actions:
-    def keys_uppercase_letters(m: list):
-        """Inserts uppercase letters from list"""
-        actions.insert("".join(m).upper())
-
     def get_alphabet() -> dict:
         """Provides the alphabet dictionary"""
         return alphabet

--- a/misc/keys.talon
+++ b/misc/keys.talon
@@ -3,7 +3,7 @@ go <user.arrow_keys>: key(arrow_keys)
 #<user.number_key>: key(number_key)
 <user.letter>: key(letter)
 (ship | uppercase) <user.letters> [(lowercase | sunk)]: 
-    user.keys_uppercase_letters(letters)
+    user.insert_formatted(letters, "ALL_CAPS")
 <user.symbol_key>: key(symbol_key)
 <user.function_key>: key(function_key)
 <user.special_key>: key(special_key)

--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -71,15 +71,12 @@ formatted <user.format_text>:
 scratch that: user.clear_last_utterance()
 scratch selection: edit.delete()
 select that: user.select_last_utterance()
+spell that <user.letters>: auto_insert(letters)
 spell that <user.formatters> <user.letters>:
-    result = dictate.join_words(user.letters, "")
-    result = user.formatted_text(result, formatters)
+    result = user.formatted_text(letters, formatters)
     user.auto_format_pause()
     auto_insert(result)
     user.auto_format_resume()
-spell that <user.letters>:
-    result = dictate.join_words(user.letters, "")
-    auto_insert(result)
 #escape, type things that would otherwise be commands
 ^escape <user.text>$:
     auto_insert(user.text)


### PR DESCRIPTION
I don't think we gain anything from having <user.letters> produce a list instead of a string,  since a string is essentially a list of characters, and each letter should map to a single character. It doesn't look like <user.letters> has been used in very many places in the repo, and I've updated all of them, but people might need to rewrite some of their own custom commands.

I have also added an action `user.insert_formatted`, to insert formatted text, since that seems to be a fairly common thing to need to do.