### PR TITLE
Create the settings folder immediately

### DIFF
--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -10,6 +10,8 @@ import threading
 #   knausj folder.
 SETTINGS_DIR = Path(__file__).parents[1] / "settings"
 
+if not SETTINGS_DIR.is_dir():
+    os.mkdir(SETTINGS_DIR)
 
 mod = Module()
 ctx = Context()


### PR DESCRIPTION
The settings folder does actually need to be created up-front. Needs to exist when we start watching the path. This is a quick reversion so it's created ASAP. 