### PR TITLE
rewrite code/ordinals.py, fixing off by one error

### DIFF
--- a/code/ordinals.py
+++ b/code/ordinals.py
@@ -1,54 +1,4 @@
-import os
-import re
-import time
-from math import floor
-
 from talon import Context, Module, actions, app, ui
-
-ordinal_words = {}
-ordinal_ones = [
-    "first",
-    "second",
-    "third",
-    "fourth",
-    "fifth",
-    "sixth",
-    "seventh",
-    "eighth",
-    "ninth",
-]
-ordinal_teens = [
-    "tenth",
-    "eleventh",
-    "twelfth",
-    "thirteenth",
-    "fourteenth",
-    "fifteenth",
-    "sixteenth",
-    "seventeenth",
-    "eighteenth",
-    "nineteenth",
-]
-ordinal_tens = [
-    "twentieth",
-    "thirtieth",
-    "fortieth",
-    "fiftieth",
-    "sixtieth",
-    "seventieth",
-    "eightieth",
-    "ninetieth",
-]
-ordinal_tenty = [
-    "twenty",
-    "thirty",
-    "forty",
-    "fifty",
-    "sixty",
-    "seventy",
-    "eighty",
-    "ninety",
-]
 
 
 def ordinal(n):
@@ -66,47 +16,59 @@ def ordinal(n):
     return str(n) + suffix
 
 
-def ordinal_word(n):
-    n = int(n)
-    ordinal_list = []
-    if n > 19:
-        if n % 10 == 0:
-            ordinal_list.append(ordinal_tens[floor((n / 10)) - 2])
-        else:
-            ordinal_list.append(ordinal_tenty[floor(n / 10) - 2])
-            ordinal_list.append(ordinal_ones[(n % 10) - 1])
-    elif n > 9:
-        ordinal_list.append(ordinal_teens[n - 11])
-    else:
-        ordinal_list.append(ordinal_ones[n - 1])
+# The primitive ordinal words in English below a hundred.
+ordinal_words = {
+    0: "zeroth",
+    1: "first",
+    2: "second",
+    3: "third",
+    4: "fourth",
+    5: "fifth",
+    6: "sixth",
+    7: "seventh",
+    8: "eighth",
+    9: "ninth",
+    10: "tenth",
+    11: "eleventh",
+    12: "twelfth",
+    13: "thirteenth",
+    14: "fourteenth",
+    15: "fifteenth",
+    16: "sixteenth",
+    17: "seventeenth",
+    18: "eighteenth",
+    19: "nineteenth",
+    20: "twentieth",
+    30: "thirtieth",
+    40: "fortieth",
+    50: "fiftieth",
+    60: "sixtieth",
+    70: "seventieth",
+    80: "eightieth",
+    90: "ninetieth",
+}
+tens_words = "zero ten twenty thirty forty fifty sixty seventy eighty ninety".split()
 
-    result = " ".join(ordinal_list)
-    return result
-
-
+# ordinal_numbers maps ordinal words into their corresponding numbers.
+ordinal_numbers = {}
 for n in range(1, 100):
-    # This was initially minus one to compensate for its only use as a command
-    # repeater, however ordinals themselves have other uses, so accommodating
-    # the negative one in the command repeaters done in the actual talon file
-    # now
-    # ordinal_words[ordinal_word(n)] = n - 1
-    ordinal_words[ordinal_word(n)] = n
+    if n in ordinal_words:
+        word = ordinal_words[n]
+    else:
+        (tens, units) = divmod(n, 10)
+        assert 1 < tens < 10, "we have already handled all ordinals < 20"
+        assert 0 < units, "we have already handled all ordinals divisible by ten"
+        word = f"{tens_words[tens]} {ordinal_words[units]}"
+    ordinal_numbers[word] = n
+
 
 mod = Module()
-mod.list("ordinal_words", desc="list of ordinals")
-
 ctx = Context()
+mod.list("ordinals", desc="list of ordinals")
+ctx.lists["self.ordinals"] = ordinal_numbers.keys()
 
 
-@mod.capture
+@mod.capture(rule="{self.ordinals}")
 def ordinals(m) -> int:
-    "Returns a single ordinial as a digit"
-
-
-@ctx.capture(rule="{self.ordinal_words}")
-def ordinals(m):
-    o = m[0]
-    return int(ordinal_words[o])
-
-
-ctx.lists["self.ordinal_words"] = ordinal_words.keys()
+    """Returns a single ordinal as a digit"""
+    return int(ordinal_numbers[m[0]])


### PR DESCRIPTION
ordinals.py had a bug where it was generating numbers that were off by one for ordinals more than “tenth”. This fixes that bug and simplifies the implementation.