### PR TITLE
fix edit.selected_text to return empty string if there is no selection

### DIFF
--- a/code/edit.py
+++ b/code/edit.py
@@ -8,19 +8,12 @@ mod = Module()
 @ctx.action_class("edit")
 class edit_actions:
     def selected_text() -> str:
-        # try:
-        #     text = ui.focused_element().AXSelectedText
-        #     if text:
-        #         return text
-        # except Exception:
-        #     pass
-
+        with clip.capture() as s:
+            actions.edit.copy()
         try:
-            with clip.capture() as s:
-                actions.edit.copy()
             return s.get()
         except clip.NoChange:
-            return clip.get()
+            return ""
 
 
 @mod.action_class


### PR DESCRIPTION
edit.selected_text has a bug where if there is no selection it returns the current clipboard value. this fixes that bug, per discussion with aegis in slack (https://talonvoice.slack.com/archives/G9YTMSZ2T/p1603817479056200?thread_ts=1603815852.050700&cid=G9YTMSZ2T). I'm a bit worried that we might have some code that depends on this behavior though, so I'd appreciate people testing this out before merging.