### PR TITLE
Allow history window to move after history update

### DIFF
--- a/code/history.py
+++ b/code/history.py
@@ -24,10 +24,6 @@ def on_phrase(j):
         history.append(val)
         history = history[-hist_len:]
 
-        if gui.showing:
-            gui.freeze()
-
-
 # todo: dynamic rect?
 @imgui.open(y=0, software=False)
 def gui(gui: imgui.GUI):
@@ -55,7 +51,7 @@ class Actions:
 
     def history_enable():
         """Enables the history"""
-        gui.freeze()
+        gui.show()
 
     def history_disable():
         """Disables the history"""


### PR DESCRIPTION
When a new command is added to the command history window, the `gui.freeze()` calls were making it so the window was not able to be moved