### PR TITLE
Add user.symbol_keys to user.text capture

### DIFF
--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -79,7 +79,7 @@ def word(m) -> str:
 punctuation = set(".,-!?;:")
 
 
-@mod.capture(rule="(<user.vocabulary> | <phrase>)+")
+@mod.capture(rule="(<user.vocabulary> | <phrase> | <user.symbol_key>)+")
 def text(m) -> str:
     words = []
     for item in m:


### PR DESCRIPTION
With Dragon and recent changes to the beta, commands such as

`say this is a test period` ->`this is a test period` 

whereas it used to be `this is a test.`

This change would allow similar behavior on both wav2letter or Dragon for special symbols, if we want it. 

Thoughts?