### PR TITLE
make a user.prose capture that supports punctuation

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -22,6 +22,7 @@ mod.list("number_key", desc="All number keys")
 mod.list("modifier_key", desc="All modifier keys")
 mod.list("function_key", desc="All function keys")
 mod.list("special_key", desc="All special keys")
+mod.list("punctuation", desc="words for inserting punctuation into text")
 
 
 @mod.capture(rule="{self.modifier_key}+")
@@ -115,37 +116,50 @@ ctx.lists["self.modifier_key"] = {
 }
 alphabet = dict(zip(default_alphabet, letters_string))
 ctx.lists["self.letter"] = alphabet
-ctx.lists["self.symbol_key"] = {
+
+# `punctuation_words` is for words you want available BOTH in dictation and as
+# key names in command mode. `symbol_key_words` is for key names that should be
+# available in command mode, but NOT during dictation.
+punctuation_words = {
+    # TODO: I'm not sure why we need these, I think it has something to do with
+    # Dragon. Possibly it has been fixed by later improvements to talon? -rntz
+    "`": "`", ",": ",", # <== these things
     "back tick": "`",
-    "`": "`",
     "comma": ",",
-    ",": ",",
-    "dot": ".",
     "period": ".",
-    "semi": ";",
     "semicolon": ";",
+    "colon": ":",
+    "forward slash": "/",
+    "question mark": "?",
+    "exclamation point": "!",
+    "dollar sign": "$",
+    "asterisk": "*",
+    "hash sign": "#",
+    "number sign": "#",
+    "percent sign": "%",
+    "at sign": "@",
+    "and sign": "&",
+    "ampersand": "&",
+}
+symbol_key_words = {
+    "dot": ".",
     "quote": "'",
     "L square": "[",
     "left square": "[",
     "square": "[",
     "R square": "]",
     "right square": "]",
-    "forward slash": "/",
     "slash": "/",
     "backslash": "\\",
     "minus": "-",
     "dash": "-",
     "equals": "=",
     "plus": "+",
-    "question mark": "?",
     "tilde": "~",
     "bang": "!",
-    "exclamation point": "!",
     "dollar": "$",
-    "dollar sign": "$",
     "down score": "_",
     "under score": "_",
-    "colon": ":",
     "paren": "(",
     "L paren": "(",
     "left paren": "(",
@@ -163,24 +177,20 @@ ctx.lists["self.symbol_key"] = {
     "right angle": ">",
     "greater than": ">",
     "star": "*",
-    "asterisk": "*",
     "pound": "#",
     "hash": "#",
-    "hash sign": "#",
-    "number sign": "#",
     "percent": "%",
-    "percent sign": "%",
     "caret": "^",
-    "at sign": "@",
-    "and sign": "&",
-    "ampersand": "&",
     "amper": "&",
     "pipe": "|",
     "dubquote": '"',
     "double quote": '"',
 }
 
-
+# make punctuation words also included in {user.symbol_keys}
+symbol_key_words.update(punctuation_words)
+ctx.lists["self.punctuation"] = punctuation_words
+ctx.lists["self.symbol_key"] = symbol_key_words
 ctx.lists["self.number_key"] = dict(zip(default_digits, numbers))
 ctx.lists["self.arrow_key"] = {
     "down": "down",

--- a/code/keys.py
+++ b/code/keys.py
@@ -131,6 +131,7 @@ punctuation_words = {
     "colon": ":",
     "forward slash": "/",
     "question mark": "?",
+    "exclamation mark": "!",
     "exclamation point": "!",
     "dollar sign": "$",
     "asterisk": "*",

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -1,9 +1,75 @@
 from talon import Context, Module, actions, grammar
 from .user_settings import bind_list_to_csv, bind_word_map_to_csv
 
+mod = Module()
+ctx = Context()
+
+mod.list("vocabulary", desc="additional vocabulary words")
+mod.list("punctuation", desc="words for inserting punctuation into text")
+
+
+@mod.capture(rule="{user.vocabulary}")
+def vocabulary(m) -> str:
+    return m.vocabulary
+
+
+@mod.capture(rule="({user.vocabulary} | <word>)")
+def word(m) -> str:
+    try:
+        return m.vocabulary
+    except AttributeError:
+        # TODO: if the word is both a regular word AND user.vocabulary, then in
+        # principle it may parse as <word> instead; we ought to pass it through
+        # mapping_vocabulary to be sure. But we should be doing that in
+        # user.text, below, too.
+        words = actions.dictate.replace_words(actions.dictate.parse_words(m.word))
+        assert len(words) == 1
+        return words[0]
+
+
+punctuation = set(".,-!?;:")
+
+
+@mod.capture(rule="({user.vocabulary} | {user.punctuation} | <phrase>)+")
+def text(m) -> str:
+    words = []
+    for item in m:
+        if isinstance(item, grammar.vm.Phrase):
+            words.extend(
+                actions.dictate.replace_words(actions.dictate.parse_words(item))
+            )
+        else:
+            words.extend(item.split(" "))
+
+    result = ""
+    for i, word in enumerate(words):
+        if i > 0 and word not in punctuation and words[i - 1][-1] not in ("/-("):
+            result += " "
+        result += word
+    return result
+
+
+
+# ---------- LISTS ----------
+# Default punctuation words.
+default_punctuation = {
+    "period": ".",
+    "comma": ",",
+    "colon": ":",
+    "semicolon": ";", "semi colon": ";",
+    "question mark": "?",
+    "exclamation mark": "!",
+}
+
+bind_list_to_csv(
+    "user.punctuation",
+    "punctuation.csv",
+    csv_headers=("Punctuation Mark", "Word or Phrase"),
+    default_values=default_punctuation,
+)
 
 # Default words that will need to be capitalized (particularly under w2l).
-_capitalize_defaults = [
+capitalize = [
     "I",
     "I'm",
     "I've",
@@ -38,86 +104,34 @@ _capitalize_defaults = [
 ]
 
 # Default words that need to be remapped.
-_word_map_defaults = {
+default_word_map = {
     # E.g:
     # "cash": "cache",
+    # "centre": "center",
 }
+default_word_map.update({word.lower(): word for word in capitalize})
 
-# Default words that should be added to Talon's vocabulary.
-_simple_vocab_default = ["nmap", "admin", "Cisco", "Citrix", "VPN", "DNS", "Minecraft"]
-
-# Defaults for different pronounciations of words that need to be added to
-# Talon's vocabulary.
-_mapping_vocab_default = {
-    "N map": "nmap",
-    "under documented": "under-documented",
-}
-
-
-mod = Module()
-
-
-@mod.capture(rule="{user.vocabulary}")
-def vocabulary(m) -> str:
-    return m.vocabulary
-
-
-@mod.capture(rule="(<user.vocabulary> | <word>)")
-def word(m) -> str:
-    try:
-        return m.vocabulary
-    except AttributeError:
-        # TODO: if the word is both a regular word AND user.vocabulary, then in
-        # principle it may parse as <word> instead; we ought to pass it through
-        # mapping_vocabulary to be sure. But we should be doing that in
-        # user.text, below, too.
-        words = actions.dictate.replace_words(actions.dictate.parse_words(m.word))
-        assert len(words) == 1
-        return words[0]
-
-
-punctuation = set(".,-!?;:")
-
-
-@mod.capture(rule="(<user.vocabulary> | <phrase>)+")
-def text(m) -> str:
-    words = []
-    for item in m:
-        if isinstance(item, grammar.vm.Phrase):
-            words.extend(
-                actions.dictate.replace_words(actions.dictate.parse_words(item))
-            )
-        else:
-            words.extend(item.split(" "))
-
-    result = ""
-    for i, word in enumerate(words):
-        if i > 0 and word not in punctuation and words[i - 1][-1] not in ("/-("):
-            result += " "
-        result += word
-    return result
-
-
-mod.list("vocabulary", desc="user vocabulary")
-
-ctx = Context()
-
-
-_default_word_map = {}
-_default_word_map.update(_word_map_defaults)
-_default_word_map.update({word.lower(): word for word in _capitalize_defaults})
 # "dictate.word_map" is used by `actions.dictate.replace_words` to rewrite words
 # Talon recognized. Entries in word_map don't change the priority with which
 # Talon recognizes some words over others.
 bind_word_map_to_csv(
     "words_to_replace.csv",
     csv_headers=("Replacement", "Original"),
-    default_values=_default_word_map,
+    default_values=default_word_map,
 )
 
-_default_vocabulary = {}
-_default_vocabulary.update({word: word for word in _simple_vocab_default})
-_default_vocabulary.update(_mapping_vocab_default)
+
+# Default words that should be added to Talon's vocabulary.
+simple_vocabulary = ["admin", "VPN", "DNS", "USB", "FAQ", "PhD", "Minecraft"]
+
+# Defaults for different pronounciations of words that need to be added to
+# Talon's vocabulary.
+default_vocabulary = {
+    "N map": "nmap",
+    "under documented": "under-documented",
+}
+default_vocabulary.update({word: word for word in simple_vocabulary})
+
 # "user.vocabulary" is used to explicitly add words/phrases that Talon doesn't
 # recognize. Words in user.vocabulary (or other lists and captures) are
 # "command-like" and their recognition is prioritized over ordinary words.
@@ -125,5 +139,5 @@ bind_list_to_csv(
     "user.vocabulary",
     "additional_words.csv",
     csv_headers=("Word(s)", "Spoken Form (If Different)"),
-    default_values=_default_vocabulary,
+    default_values=default_vocabulary,
 )

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -21,13 +21,13 @@ def prose(m) -> str: return format_phrase(m)
 
 # TODO: unify this formatting code with the dictation formatting code, so that
 # user.prose behaves the same way as dictation mode.
-punctuation = set(".,-!?;:")
-no_space_after = set("/-(")
+no_space_before = set(".,-!?;:#$)]}")
+no_space_after = set("/-([{")
 def format_phrase(m):
     words = capture_to_word_list(m)
     result = ""
     for i, word in enumerate(words):
-        if i > 0 and word not in punctuation and words[i - 1][-1] not in no_space_after:
+        if i > 0 and word not in no_space_before and words[i - 1][-1] not in no_space_after:
             result += " "
         result += word
     return result

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -5,7 +5,6 @@ mod = Module()
 ctx = Context()
 
 mod.list("vocabulary", desc="additional vocabulary words")
-mod.list("punctuation", desc="words for inserting punctuation into text")
 
 @mod.capture(rule="({user.vocabulary} | <word>)")
 def word(m) -> str:
@@ -44,21 +43,6 @@ def capture_to_word_list(m):
 
 
 # ---------- LISTS (punctuation, additional/replacement words) ----------
-bind_list_to_csv(
-    "user.punctuation",
-    "punctuation.csv",
-    csv_headers=("Punctuation Mark", "Word or Phrase"),
-    default_values={
-        "period": ".",
-        "comma": ",",
-        "colon": ":",
-        "semicolon": ";", "semi colon": ";",
-        "question mark": "?",
-        "exclamation mark": "!",
-    }
-)
-
-
 # Default words that will need to be capitalized (particularly under w2l).
 _capitalize_defaults = [
     "I",

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -60,7 +60,7 @@ bind_list_to_csv(
 
 
 # Default words that will need to be capitalized (particularly under w2l).
-capitalize = [
+_capitalize_defaults = [
     "I",
     "I'm",
     "I've",
@@ -95,12 +95,11 @@ capitalize = [
 ]
 
 # Default words that need to be remapped.
-default_word_map = {
+_word_map_defaults = {
     # E.g:
     # "cash": "cache",
-    # "centre": "center",
 }
-default_word_map.update({word.lower(): word for word in capitalize})
+_word_map_defaults.update({word.lower(): word for word in _capitalize_defaults})
 
 # "dictate.word_map" is used by `actions.dictate.replace_words` to rewrite words
 # Talon recognized. Entries in word_map don't change the priority with which
@@ -108,20 +107,20 @@ default_word_map.update({word.lower(): word for word in capitalize})
 bind_word_map_to_csv(
     "words_to_replace.csv",
     csv_headers=("Replacement", "Original"),
-    default_values=default_word_map,
+    default_values=_word_map_defaults,
 )
 
 
 # Default words that should be added to Talon's vocabulary.
-simple_vocabulary = ["admin", "LCD", "VPN", "DNS", "USB", "FAQ", "PhD", "Minecraft"]
+_simple_vocab_default = ["nmap", "admin", "Cisco", "Citrix", "VPN", "DNS", "Minecraft"]
 
 # Defaults for different pronounciations of words that need to be added to
 # Talon's vocabulary.
-default_vocabulary = {
+_default_vocabulary = {
     "N map": "nmap",
     "under documented": "under-documented",
 }
-default_vocabulary.update({word: word for word in simple_vocabulary})
+_default_vocabulary.update({word: word for word in _simple_vocab_default})
 
 # "user.vocabulary" is used to explicitly add words/phrases that Talon doesn't
 # recognize. Words in user.vocabulary (or other lists and captures) are
@@ -130,5 +129,5 @@ bind_list_to_csv(
     "user.vocabulary",
     "additional_words.csv",
     csv_headers=("Word(s)", "Spoken Form (If Different)"),
-    default_values=default_vocabulary,
+    default_values=_default_vocabulary,
 )

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, grammar, registry
+from talon import Context, Module, actions, grammar
 from .user_settings import bind_list_to_csv, bind_word_map_to_csv
 
 mod = Module()
@@ -17,21 +17,14 @@ def word(m) -> str:
 def text(m) -> str: return format_phrase(m)
 
 @mod.capture(rule="({user.vocabulary} | {user.punctuation} | <phrase>)+")
-def prose(m) -> str:
-    # registry.lists["user.punctuation"] returns a priority-ordered list of all
-    # definitions of user.punctuation in active contexts; we want the currently
-    # active value, so we take the last (highest priority).
-    return format_phrase(m, registry.lists.get("user.punctuation", [{}])[-1])
+def prose(m) -> str: return format_phrase(m)
 
 # TODO: unify this formatting code with the dictation formatting code, so that
 # user.prose behaves the same way as dictation mode.
-no_space_before = set(".,/-!?;:)]}")
-no_space_after = set("/-#$([{")
-def format_phrase(m, replacements=None):
+no_space_before = set(".,-!?;:#$)]}")
+no_space_after = set("/-([{")
+def format_phrase(m):
     words = capture_to_word_list(m)
-    if replacements:
-        assert isinstance(replacements, dict)
-        words = replace_word_sequences(replacements, words)
     result = ""
     for i, word in enumerate(words):
         if i > 0 and word not in no_space_before and words[i - 1][-1] not in no_space_after:
@@ -47,27 +40,6 @@ def capture_to_word_list(m):
             if isinstance(item, grammar.vm.Phrase) else
             item.split(" "))
     return words
-
-def replace_word_sequences(replacements, words):
-    # bucket replacements by how many words they contain
-    buckets = {}
-    for pattern, replacement in replacements.items():
-        pattern = tuple(pattern.split())
-        buckets.setdefault(len(pattern), {})[pattern] = replacement
-    # go through `words` position by position, replacing matching sequences
-    result = []
-    i = 0
-    while i < len(words):
-        consumed, emitted = 1, [words[i]]
-        for (n, bucket) in buckets.items():
-            if i + n > len(words): continue
-            fragment = tuple(words[i:i+n])
-            if fragment in bucket:
-                consumed, emitted = n, bucket[fragment].split(" ")
-                break
-        i += consumed
-        result.extend(emitted)
-    return result
 
 
 # ---------- LISTS (punctuation, additional/replacement words) ----------

--- a/misc/formatters.talon
+++ b/misc/formatters.talon
@@ -1,10 +1,8 @@
 #provide both anchored and unachored commands via 'over'
-(say | speak | phrase) <user.text>$: 
-  result = user.formatted_text(text, "NOOP")
-  insert(result)
-(say | speak | phrase) <user.text> over: 
-  result = user.formatted_text(text, "NOOP")
-  insert(result)
+phrase <user.text>$: user.insert_formatted(text, "NOOP")
+phrase <user.text> over: user.insert_formatted(text, "NOOP")
+(say | speak) <user.prose>$: user.insert_formatted(prose, "NOOP")
+(say | speak) <user.prose> over: user.insert_formatted(prose, "NOOP")
 <user.format_text>+$: user.insert_many(format_text_list)
 <user.format_text>+ over: user.insert_many(format_text_list)
 <user.formatters> that: user.formatters_reformat_selection(user.formatters)

--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -3,17 +3,8 @@ mode: dictation
 #everything here should call auto_insert to preserve the state to correctly auto-capitalize/auto-space.
 <user.text>: auto_insert(text)
 enter: auto_insert("new-line")
-period: auto_insert(".")
-(comma | kama): 
-    auto_insert(",")
-question mark: auto_insert("?")
-(bang | exclamation [mark]): auto_insert("!")
-dash: auto_insert("-")
-colon: auto_insert(":")
-# user.dictate no longer exists, so I'm not sure what this was supposed to do.
-#space: user.dictate(" ")
-(semi colon | semicolon): auto_insert(";")
-cap <user.text>: 
+{user.punctuation}: auto_insert(punctuation)
+cap <user.text>:
     result = user.formatted_text(user.text, "CAPITALIZE_FIRST_WORD")
     auto_insert(result)
 #navigation


### PR DESCRIPTION
This patch adds a <user.prose> capture that supports punctuation words like "comma" and "period" and uses it for the `say|speak` command. Things worth noting:

1. My eventual goal is for `<user.prose>` to act like dictation mode, handling auto-capitalization as well. However, for now it only handles punctuation.

2. I previously tried adding punctuation to `user.text`, but decided against it; `<user.text>` is unchanged by this PR. This is for a few reasons. First, sometimes it's handy to be able to speak text without punctuation. Second, adding punctuation to `<user.text>` without also adding auto-capitalization was breaking auto-capitalization in dictation mode (because it was getting parsed as part of the `user.text` capture instead of the dictation mode commands).

3. `phrase` and `say|speak` now **behave differently**. We have `phrase <user.text>` and `(say|speak) <user.prose>`. This is so that we have commands for both inserting with & without punctuation/auto-capitalization. However, this is just my personal preference; perfectly happy to change this if folks prefer otherwise, e.g. having all three act the same.

Things I'd like your feedback on:

1. Are you happy with `phrase` behaving differently than `say|speak`?

2. What punctuation words should we have? The PR makes a settings CSV file for them, like for additional vocabulary. The default list that I came up with is pretty bare-bones, happy to have more.