### PR TITLE
check mouse hide setting in scroll down

### DIFF
--- a/code/mouse.py
+++ b/code/mouse.py
@@ -171,7 +171,8 @@ class Actions:
         if scroll_job is None:
             start_scroll()
 
-        gui_wheel.show()
+        if setting_mouse_hide_mouse_gui.get() == 0:
+            gui_wheel.show()
 
     def mouse_scroll_up():
         """Scrolls up"""


### PR DESCRIPTION
i believe this is what's intended based on `mouse_scroll_up_continuous`
when scrolling up the setting works but when continuous scroll down the gui is always shown regardless of the setting. this fixes that
