### PR TITLE
dunst: use system cmds via dunstctl

### DIFF
--- a/apps/linux/dunst.talon
+++ b/apps/linux/dunst.talon
@@ -2,8 +2,8 @@ os: linux
 -
 
 show notifications: key(ctrl-`)
-dismiss [notifications]: key(ctrl-space)
-dismiss all [notifications]: key(ctrl-shift-space)
+dismiss [notifications]: user.system_command('dunstctl close')
+dismiss all [notifications]: user.system_command('dunstctl close-all')
 #dunce pause: user.system_command('notify-send "DUNST_COMMAND_PAUSE"')
 #dunce resume: user.system_command('notify-send "DUNST_COMMAND_RESUME"')
 #test notification: user.system_command('notify-send "Hello from Talon"')


### PR DESCRIPTION
The keybindings ctrl-space and ctrl-shift-space for notifications are not setup
by default on all window managers / desktop environments, so we should use
`dunstctl` for portability.