### PR TITLE
add "sentence" as a command for formatting prose, remove as formatter

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -181,7 +181,7 @@ all_formatters.update(formatters_words)
 
 mod = Module()
 mod.list("formatters", desc="list of formatters")
-mod.list("prose_formatter", desc="list of formatters to apply to prose")
+mod.list("prose_formatter", desc="words to start dictating prose, and the formatter they apply")
 
 
 @mod.capture(rule="{self.formatters}+")

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -162,7 +162,7 @@ formatters_words = {
     "packed": formatters_dict["DOUBLE_COLON_SEPARATED"],
     "padded": formatters_dict["SPACE_SURROUNDED_STRING"],
     # "say": formatters_dict["NOOP"],
-    "sentence": formatters_dict["CAPITALIZE_FIRST_WORD"],
+    # "sentence": formatters_dict["CAPITALIZE_FIRST_WORD"],
     "slasher": formatters_dict["SLASH_SEPARATED"],
     "smash": formatters_dict["NO_SPACES"],
     "snake": formatters_dict["SNAKE_CASE"],
@@ -181,13 +181,13 @@ all_formatters.update(formatters_words)
 
 mod = Module()
 mod.list("formatters", desc="list of formatters")
+mod.list("prose_formatter", desc="list of formatters to apply to prose")
 
 
 @mod.capture(rule="{self.formatters}+")
 def formatters(m) -> str:
     "Returns a comma-separated string of formatters e.g. 'SNAKE,DUBSTRING'"
     return ",".join(m.formatters_list)
-
 
 @mod.capture(
     # Note that if the user speaks something like "snake dot", it will
@@ -293,6 +293,10 @@ class Actions:
 
 
 ctx.lists["self.formatters"] = formatters_words.keys()
+ctx.lists["self.prose_formatter"] = {
+    "say": "NOOP", "speak": "NOOP",
+    "sentence": "CAPITALIZE_FIRST_WORD",
+}
 
 
 @imgui.open(software=app.platform == "linux")

--- a/misc/formatters.talon
+++ b/misc/formatters.talon
@@ -1,8 +1,8 @@
 #provide both anchored and unachored commands via 'over'
 phrase <user.text>$: user.insert_formatted(text, "NOOP")
 phrase <user.text> over: user.insert_formatted(text, "NOOP")
-(say | speak) <user.prose>$: user.insert_formatted(prose, "NOOP")
-(say | speak) <user.prose> over: user.insert_formatted(prose, "NOOP")
+{user.prose_formatter} <user.prose>$: user.insert_formatted(prose, prose_formatter)
+{user.prose_formatter} <user.prose> over: user.insert_formatted(prose, prose_formatter)
 <user.format_text>+$: user.insert_many(format_text_list)
 <user.format_text>+ over: user.insert_many(format_text_list)
 <user.formatters> that: user.formatters_reformat_selection(user.formatters)


### PR DESCRIPTION
To address #299, this removes sentence as a generic formatter, and adds it as a way to emit capitalized <user.prose>.