### PR TITLE
exec.py: pass shell=True to Popen in system_command_nb

### DIFF
--- a/code/exec.py
+++ b/code/exec.py
@@ -14,4 +14,4 @@ class Actions:
 
     def system_command_nb(cmd: str):
         """execute a command on the system without blocking"""
-        subprocess.Popen(cmd)
+        subprocess.Popen(cmd, shell=True)


### PR DESCRIPTION
Without this, the call to `Popen` cannot accept arguments (at least on linux), which makes system_command_nb behave differently and less usefully than system_command.