### PR TITLE
Change phones so that first word is used instead of longest word

### DIFF
--- a/code/homophones.py
+++ b/code/homophones.py
@@ -35,7 +35,7 @@ def update_homophones(name, flags):
     with open(homophones_file, "r") as f:
         for line in f:
             words = line.rstrip().split(",")
-            canonical_list.append(max(words, key=len))
+            canonical_list.append(words[0])
             for word in words:
                 word = word.lower()
                 old_words = phones.get(word, [])


### PR DESCRIPTION
Currently phones appears to be using the longest word from the row. This seems sub-optimal since it's possible to order homophones.csv so that the most popular/common word is first

Separate PR coming in a few minutes with homophones.csv re-ordered with most popular word first.