### PR TITLE
Use run-command-by-id in vscode

### DIFF
--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -1,0 +1,5 @@
+# VSCode support
+
+Assumes that you have the [Run Command by
+Id](https://marketplace.visualstudio.com/items?itemName=pokey.run-command-by-id)
+extension installed.

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -85,6 +85,20 @@ class Actions:
         actions.edit.paste()
         actions.key("enter")
 
+    def vscode_terminal(number: int):
+        """Activate a terminal by number"""
+        actions.user.vscode_by_id(f"workbench.action.terminal.focusAtIndex{number}")
+
+    def vscode_by_id(command: str):
+        """Execute command via run-command-by-id. Preserves the clipboard."""
+        if not is_mac:
+            actions.key("ctrl-shift-alt-p")
+        else:
+            actions.key("cmd-shift-alt-p")
+
+        actions.user.paste(f"{command}")
+        actions.key("enter")
+
 
 @ctx.action_class("user")
 class user_actions:
@@ -223,4 +237,3 @@ class user_actions:
         actions.key("esc")
 
     # find_and_replace.py support end
-

--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -14,6 +14,8 @@ action(app.tab_previous): user.vscode("workbench.action.previousEditorInGroup")
 action(app.tab_reopen): user.vscode("workbench.action.reopenClosedEditor")
 action(app.window_close): user.vscode("workbench.action.closeWindow")
 action(app.window_open): user.vscode("workbench.action.newWindow")
+go last: user.vscode_by_id("workbench.action.openPreviousRecentlyUsedEditorInGroup")
+go next: user.vscode_by_id("workbench.action.openNextRecentlyUsedEditorInGroup")
 
 #talon code actions
 action(code.toggle_comment): user.vscode("editor.action.commentLine")
@@ -185,8 +187,10 @@ terminal next: user.vscode("workbench.action.terminal.focusNextPane")
 terminal last:user.vscode("workbench.action.terminal.focusPreviousPane")
 terminal split: user.vscode("workbench.action.terminal.split")
 terminal trash: user.vscode("Terminal:Kill")
+terminal toggle: user.vscode_by_id("workbench.action.terminal.toggleTerminal")
 terminal scroll up: user.vscode("Terminal:ScrollUp")
 terminal scroll down: user.vscode("Terminal:ScrollDown")
+terminal <number>: user.vscode_terminal(number)
 
 #TODO: should this be added to linecommands?
 copy line down: user.vscode("editor.action.copyLinesDownAction")


### PR DESCRIPTION
I noticed that some commands in vscode can't be accessed via `cmd+p`.  I created an [extension](https://marketplace.visualstudio.com/items?itemName=pokey.run-command-by-id) that allows the user to type in the id of any command to run, and switched the talon vscode to use this functionality.