### PR TITLE
improve Talon startup time

### DIFF
--- a/code/switcher.py
+++ b/code/switcher.py
@@ -95,10 +95,6 @@ def update_overrides(name, flags):
         update_lists()
 
 
-update_overrides(None, None)
-fs.watch(overrides_directory, update_overrides)
-
-
 @mod.action_class
 class Actions:
     def get_running_app(name: str) -> ui.App:
@@ -197,6 +193,14 @@ def ui_event(event, arg):
 # to initialize user launch to avoid getting "List not found: user.launch"
 # errors on other platforms.
 ctx.lists["user.launch"] = {}
-update_launch_list()
-ui.register("", ui_event)
 
+
+# Talon starts faster if you don't use the `talon.ui` module during launch
+def on_ready():
+    update_overrides(None, None)
+    fs.watch(overrides_directory, update_overrides)
+    update_launch_list()
+    ui.register("", ui_event)
+# NOTE: please update this from "launch" to "ready" in Talon v0.1.5
+app.register("launch", on_ready)
+# app.register("ready", on_ready)


### PR DESCRIPTION
Talon starts faster if you don't use the `talon.ui` module during startup, so this defers it using `app.register("launch", cb)`.

Note that `launch` is only called once after Talon startup, so editing this script is more awkward momentarily as it won't run the event handler on save. To fix this, I'm adding a new `ready` event in Talon v0.1.5 which will be called immediately (e.g. during script reload) if Talon was already `ready`.