### PR TITLE
macOS edit.zoom_in is incorrect (adds shift)

### DIFF
--- a/apps/mac/edit.talon
+++ b/apps/mac/edit.talon
@@ -199,7 +199,7 @@ action(edit.word_right):
 	key(alt-right)
 
 action(edit.zoom_in):
-	key(cmd-+)
+	key(cmd-=)
 
 action(edit.zoom_out):
 	key(cmd--)


### PR DESCRIPTION
key(cmd-+) outputs command-shift-=, however macOS zoom is generally command-=.