### PR TITLE
homophones: use "pick" instead of "choose" to avoid conflict with "pit"

### DIFF
--- a/code/homophones.py
+++ b/code/homophones.py
@@ -116,7 +116,7 @@ def gui(gui: imgui.GUI):
         gui.line()
         index = 1
         for word in active_word_list:
-            gui.text("Pick {}: {} ".format(index, word))
+            gui.text("Choose {}: {} ".format(index, word))
             index = index + 1
 
 

--- a/text/homophones_open.talon
+++ b/text/homophones_open.talon
@@ -1,10 +1,10 @@
 mode: user.homophones
 -
-pick <number_small>:
+choose <number_small>:
     result = user.homophones_select(number_small)
     insert(result)
     user.homophones_hide()
-pick <user.formatters> <number_small>:
+choose <user.formatters> <number_small>:
     result = user.homophones_select(number_small)
     insert(user.formatted_text(result, formatters))
     user.homophones_hide()


### PR DESCRIPTION
I'm not sure if this is a problem that only affects me, but when using homophones and saying "pick", Talon (w2l, sconv-b6) often hears "pit" instead. This PR changes homophones to use "choose" instead of "pick". Open to other suggestions, or if nobody else has this problem I can just keep this a local change.