### PR TITLE
Change backspace and delete keys

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -210,13 +210,11 @@ simple_keys = [
     "pageup",
     "space",
     "tab",
+    "delete",
+    "backspace",
 ]
 
-alternate_keys = {
-    "delete": "backspace",
-    "forward delete": "delete",
-    #'junk': 'backspace',
-}
+alternate_keys = { }
 # mac apparently doesn't have the menu key.
 if app.platform in ("windows", "linux"):
     alternate_keys["menu key"] = "menu"


### PR DESCRIPTION
Whenever I say 'delete', the backspace key seems to be pressed. I find this unexpected since delete is a dedicated key and I would expect that to be pressed in almost every circumstance. For instance, when in the file explorer and wanting to delete a file, I have to say "forward delete" to delete the file, which is awkward. Even when text editing delete should remove the character in front of the cursor, not behind. 

And I know I can change this myself, but I'd like to stay close to the base to make it easier to merge upstream changes. Moreover, if I find this unexpected I'm sure many other people will run into the same thing. I believe this change would make talon more newbie-friendly.