### PR TITLE
add "press <user.keys>" for pressing keys in dictation mode

### DIFF
--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -1,5 +1,6 @@
 mode: dictation
 -
+^press <user.keys>$: key("{keys}")
 #everything here should call auto_insert to preserve the state to correctly auto-capitalize/auto-space.
 <user.text>: auto_insert(text)
 enter: auto_insert("new-line")


### PR DESCRIPTION
Sometimes you just need to press some keys in dictation mode. This makes that possible by adding an anchored "press" command:

```
^press <user.keys>$: key("{keys}")
```