### PR TITLE
generic_browser.talon: allow "go forward" for consistency with "go back"

### DIFF
--- a/apps/generic_browser.talon
+++ b/apps/generic_browser.talon
@@ -2,8 +2,8 @@ tag: browser
 -
 (address bar | go address | go url): browser.focus_address()
 go home: browser.go_home()
-forward: browser.go_forward()
-go back[ward]: browser.go_back()
+[go] forward: browser.go_forward()
+go (back | backward): browser.go_back()
 
 go private: browser.open_private_window()
 


### PR DESCRIPTION
This allows saying "go forward" (instead of just "forward") in generic_browser, for consistency with "go back" and "go home".

Also fixes a small bug, `back[ward]` (equivalent to `back | back ward`) instead of `(back | backward)`.

If nobody objects I'll just merge this by default in a few days.