### PR TITLE
generic_editor.talon: use "all" consistently, add "clear all" command

### DIFF
--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -51,7 +51,7 @@ go page up:
 select line:
     edit.select_line()
 
-select all:
+select everything:
     edit.select_all()
 
 select left:
@@ -140,7 +140,7 @@ clear way down:
     edit.delete()
 
 #copy commands
-copy all:
+copy everything:
     edit.select_all()
     edit.copy()
 #to do: do we want these variants, seem to conflict

--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -139,6 +139,10 @@ clear way down:
     edit.extend_file_end()
     edit.delete()
 
+clear everything:
+    edit.select_all()
+    edit.delete()
+
 #copy commands
 copy everything:
     edit.select_all()

--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -51,7 +51,7 @@ go page up:
 select line:
     edit.select_line()
 
-select everything:
+select all:
     edit.select_all()
 
 select left:
@@ -139,12 +139,12 @@ clear way down:
     edit.extend_file_end()
     edit.delete()
 
-clear everything:
+clear all:
     edit.select_all()
     edit.delete()
 
 #copy commands
-copy everything:
+copy all:
     edit.select_all()
     edit.copy()
 #to do: do we want these variants, seem to conflict
@@ -178,7 +178,7 @@ copy line:
     edit.copy()
 
 #cut commands
-cut everything:
+cut all:
     edit.select_all()
     edit.cut()
 #to do: do we want these variants


### PR DESCRIPTION
EDIT: PR now uses option (2), using *all* consistently.

I noticed that generic_editor was inconsistent between "select _all_", "copy _all_" vs "cut _everything_". This PR makes them all use "everything" for consistency (easier to memorise) and adds a "clear everything" command. I chose "everything" over "all" because `cut everything` and `clear everything` are slightly dangerous commands, and I figure "everything" is less likely to be accidentally recognized than "all". But I have no strong preference if folks prefer otherwise. Options:

1. Use 'everything' consistently: `select everything`, `copy everything`, `cut everything`, `clear everything`. 

2. Use 'all' consistently: `select all`, `copy all`, `cut all`, `clear all`.

3. Use `all|everything` for the common commands, `everything` for the dangerous ones: `select (all|everything)`, `copy (all|everything)`, `cut everything`, `clear everything`.

4. Leave it as is: `select all`, `copy all`, `cut everything`, `clear everything`.

Preferences?
