### PR TITLE
dictation mode: replace "enter" w/ "new line", add "new paragraph"

### DIFF
--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -4,8 +4,9 @@ mode: dictation
 
 # Everything here should call auto_insert to preserve the state to correctly auto-capitalize/auto-space.
 <user.text>: auto_insert(text)
-enter: auto_insert("new-line")
 {user.punctuation}: auto_insert(punctuation)
+new line: auto_insert("new-line")
+new paragraph: auto_insert("new-paragraph")
 cap <user.text>:
     result = user.formatted_text(user.text, "CAPITALIZE_FIRST_WORD")
     auto_insert(result)


### PR DESCRIPTION
Enter is a fairly common english word, so I prefer "new line", although that is itself fairly common so other suggestions are appreciated. It's also more consistent with "new paragraph", which this adds.