### PR TITLE
Context sensitive dictation

### DIFF
--- a/code/dictation.py
+++ b/code/dictation.py
@@ -95,7 +95,7 @@ class DictationFormat:
     def __init__(self):
         self.reset()
 
-    def reset(self, before=None):
+    def reset(self):
         self.before = ""
         self.state = "sentence start"
 

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -1,102 +1,229 @@
-from talon import Module, Context, ui, actions
+# Descended from https://github.com/dwiel/talon_community/blob/master/misc/dictation.py
+from talon import Module, Context, ui, actions, clip, app, grammar
+from typing import Optional, Tuple, Literal
 
 mod = Module()
-ctx = Context()
-# Courtesy of https://github.com/dwiel/talon_community/blob/master/misc/dictation.py
-# Port for Talon's new api + wav2letter
 
-# dictionary of sentence ends. No space should appear before these.
-sentence_ends = {
-    ".": ".",
-    "?": "?",
-    "!": "!",
-    # these are mapped with names since passing "\n" didn't work for reasons
-    "new-paragraph": "\n\n",
-    "new-line": "\n",
-}
+setting_dictation_context_sensitive = mod.setting(
+    "dictation_context_sensitive",
+    type=bool,
+    default=False,
+    desc="Look at surrounding text to improve auto-capitalization/spacing in dictation mode. By default, this works by selecting that text & copying it to the clipboard, so it may be slow or fail in some applications.",
+)
 
-# dictionary of punctuation. no space before these.
-punctuation = {
-    ",": ",",
-    ":": ":",
-    ";": ";",
-    "-": "-",
-    "/": "/",
-    "-": "-",
-    ")": ")",
-}
+@mod.capture(rule="({user.vocabulary} | <word>)")
+def word(m) -> str:
+    """A single word, including user-defined vocabulary."""
+    try:
+        return m.vocabulary
+    except AttributeError:
+        return " ".join(actions.dictate.replace_words(actions.dictate.parse_words(m.word)))
 
-no_space_after_these = set("-/(")
+@mod.capture(rule="({user.vocabulary} | <phrase>)+")
+def text(m) -> str:
+    """A sequence of words, including user-defined vocabulary."""
+    return format_phrase(m)
 
+@mod.capture(rule="({user.vocabulary} | {user.punctuation} | <phrase>)+")
+def prose(m) -> str:
+    """Mixed words and punctuation, auto-spaced & capitalized."""
+    text, *_state = auto_capitalize(format_phrase(m))
+    return text
 
-class AutoFormat:
+
+# ---------- FORMATTING ---------- #
+def format_phrase(m):
+    words = capture_to_words(m)
+    result = ""
+    for i, word in enumerate(words):
+        if i > 0 and needs_space_between(words[i-1], word):
+            result += " "
+        result += word
+    return result
+
+def capture_to_words(m):
+    words = []
+    for item in m:
+        words.extend(
+            actions.dictate.replace_words(actions.dictate.parse_words(item))
+            if isinstance(item, grammar.vm.Phrase) else
+            item.split(" "))
+    return words
+
+no_space_before = set("\n .,!?;:-/%)]}\"")
+no_space_after = set("\n -/#@([{$£€¥₩₽₹\"")
+def needs_space_between(before: str, after: str) -> bool:
+    return (before != "" and after != ""
+            and before[-1] not in no_space_after
+            and after[0] not in no_space_before)
+
+def auto_capitalize(text, state = None):
+    """
+    Auto-capitalizes text. `state` argument means:
+
+    - None: Don't capitalize initial word.
+    - "sentence start": Capitalize initial word.
+    - "after newline": Don't capitalize initial word, but we're after a newline.
+      Used for double-newline detection.
+
+    Returns (capitalized text, updated state).
+    """
+    output = ""
+    # Imagine a metaphorical "capitalization charge" travelling through the
+    # string left-to-right.
+    charge = state == "sentence start"
+    newline = state == "after newline"
+    for c in text:
+        # Sentence endings & double newlines create a charge.
+        if c in ".!?" or (newline and c == "\n"):
+            charge = True
+        # Alphanumeric characters and commas/colons absorb charge & try to
+        # capitalize (for numbers & punctuation this does nothing, which is what
+        # we want).
+        elif charge and (c.isalnum() or c in ",:"):
+            charge = False
+            c = c.capitalize()
+        # Otherwise the charge passes through (charge is unchanged).
+        output += c
+        newline = c == "\n"
+    return output, ("sentence start" if charge else
+                    "after newline" if newline else None)
+
+
+# ---------- DICTATION AUTO FORMATTING ---------- #
+class DictationFormat:
     def __init__(self):
         self.reset()
-        self.paused = False
-        ui.register("app_deactivate", lambda app: self.reset())
-        ui.register("win_focus", lambda win: self.reset())
 
-    def reset(self):
-        self.caps = True
-        self.space = False
+    def reset(self, before=None):
+        self.before = ""
+        self.state = "sentence start"
 
-    def pause(self, paused):
-        self.paused = paused
+    def update_context(self, before):
+        if before is None: return
+        self.reset()
+        self.pass_through(before)
+
+    def pass_through(self, text):
+        _, self.state = auto_capitalize(text, self.state)
+        self.before = text or self.before
 
     def format(self, text):
-        if self.paused:
-            return text
-
-        result = ""
-        for word in text.split():
-            is_sentence_end = False
-            is_punctuation = False
-            if word in sentence_ends:
-                word = sentence_ends[word]
-                is_sentence_end = True
-
-            elif word in punctuation:
-                word = punctuation[word]
-                # do  nothing
-                is_punctuation = True
-
-            elif self.space:
-                result += " "
-
-            if self.caps:
-                word = word.capitalize()
-
-            result += word
-            self.space = "\n" not in word and word[-1] not in no_space_after_these
-            self.caps = is_sentence_end
-
-        return result
-
-
-auto_formatter = AutoFormat()
-ctx.matches = r"""
-mode: dictation 
-"""
-
-
-@ctx.action_class("main")
-class main_action:
-    def auto_format(text: str) -> str:
-        text = auto_formatter.format(text)
-        actions.user.add_phrase_to_history(text)
+        if needs_space_between(self.before, text):
+            text = " " + text
+        text, self.state = auto_capitalize(text, self.state)
+        self.before = text or self.before
         return text
 
+dictation_formatter = DictationFormat()
+ui.register("app_deactivate", lambda app: dictation_formatter.reset())
+ui.register("win_focus", lambda win: dictation_formatter.reset())
 
 @mod.action_class
 class Actions:
-    def auto_format_pause():
-        """Pauses the autoformatter"""
-        return auto_formatter.pause(True)
+    def dictation_format_reset():
+        """Resets the dictation formatter"""
+        return dictation_formatter.reset()
 
-    def auto_format_resume():
-        """Resumes the autoformatter"""
-        return auto_formatter.pause(False)
+    def dictation_insert_raw(text: str):
+        """Inserts text as-is, without invoking the dictation formatter."""
+        dictation_formatter.pass_through(text)
+        actions.insert(text)
 
-    def auto_format_reset():
-        """Resumes the autoformatter"""
-        return auto_formatter.reset()
+    def dictation_insert(text: str) -> str:
+        """Inserts dictated text, formatted appropriately."""
+        # do_the_dance = whether we should try to be context-sensitive. Since
+        # whitespace is not affected by formatter state, if text.isspace() is
+        # True we don't need context-sensitivity.
+        do_the_dance = (setting_dictation_context_sensitive.get()
+                        and not text.isspace())
+        if do_the_dance:
+            dictation_formatter.update_context(
+                actions.user.dictation_peek_left(clobber=True))
+        text = dictation_formatter.format(text)
+        actions.user.add_phrase_to_history(text)
+        actions.insert(text)
+        # Add a space after cursor if necessary.
+        if not do_the_dance or not text or text[-1] in no_space_after:
+            return
+        char = actions.user.dictation_peek_right()
+        if char is not None and needs_space_between(text, char):
+            actions.insert(" ")
+            actions.edit.left()
+
+    def dictation_peek_left(clobber: bool = False) -> Optional[str]:
+        """
+        Tries to get some text before the cursor, ideally a word or two, for the
+        purpose of auto-spacing & -capitalization. Results are not guaranteed;
+        dictation_peek_left() may return None to indicate no information. (Note
+        that returning the empty string "" indicates there is nothing before
+        cursor, ie. we are at the beginning of the document.)
+
+        If there is currently a selection, dictation_peek_left() must leave it
+        unchanged unless `clobber` is true, in which case it may clobber it.
+        """
+        # Get rid of the selection if it exists.
+        if clobber: actions.user.clobber_selection_if_exists()
+        # Otherwise, if there's a selection, fail.
+        elif "" != actions.edit.selected_text(): return None
+
+        # In principle the previous word should suffice, but some applications
+        # have a funny concept of what the previous word is (for example, they
+        # may only take the "`" at the end of "`foo`"). To be double sure we
+        # take two words left. I also tried taking a line up + a word left, but
+        # edit.extend_up() = key(shift-up) doesn't work consistently in the
+        # Slack webapp (sometimes escapes the text box).
+        actions.edit.extend_word_left()
+        actions.edit.extend_word_left()
+        text = actions.edit.selected_text()
+        # if we're at the beginning of the document/text box, we may not have
+        # selected any text, in which case we shouldn't move the cursor.
+        if text:
+            # Unfortunately, in web Slack, if our selection ends at newline,
+            # this will go right over the newline. Argh.
+            actions.edit.right()
+        return text
+
+    def clobber_selection_if_exists():
+        """Deletes the currently selected text if it exists; otherwise does nothing."""
+        actions.key("space backspace")
+        # This space-backspace trick is fast and reliable but has the
+        # side-effect of cluttering the undo history. Other options:
+        #
+        # 1. Call edit.cut() inside a clip.revert() block. This assumes
+        #    edit.cut() is supported AND will be a no-op if there's no
+        #    selection. Unfortunately, sometimes one or both of these is false,
+        #    eg. the notion webapp makes ctrl-x cut the current block by default
+        #    if nothing is selected.
+        #
+        # 2. Test whether a selection exists by asking whether
+        #    edit.selected_text() is empty; if it does, use edit.delete(). This
+        #    usually uses the clipboard, which can be quite slow. Also, not sure
+        #    how this would interact with switching edit.selected_text() to use
+        #    the selection clipboard on linux, which can be nonempty even if no
+        #    text is selected in the current application.
+        #
+        # Perhaps this ought to be configurable by a setting.
+
+    def dictation_peek_right() -> Optional[str]:
+        """
+        Tries to get the character after the cursor for auto-spacing purposes.
+        Results are not guaranteed; dictation_peek_right() may return None to
+        indicate no information. (Note that returning the empty string ""
+        indicates there is nothing after cursor, ie. we are at the end of the
+        document.)
+        """
+        actions.edit.extend_right()
+        char = actions.edit.selected_text()
+        if char: actions.edit.left()
+        return char
+
+# Use the dictation formatter in dictation mode.
+dictation_ctx = Context()
+dictation_ctx.matches = r"""
+mode: dictation
+"""
+
+@dictation_ctx.action_class("main")
+class main_action:
+    def auto_insert(text): actions.user.dictation_insert(text)

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -27,7 +27,7 @@ def text(m) -> str:
 @mod.capture(rule="({user.vocabulary} | {user.punctuation} | <phrase>)+")
 def prose(m) -> str:
     """Mixed words and punctuation, auto-spaced & capitalized."""
-    text, *_state = auto_capitalize(format_phrase(m))
+    text, _state = auto_capitalize(format_phrase(m))
     return text
 
 

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -4,8 +4,8 @@ from typing import Optional, Tuple, Literal
 
 mod = Module()
 
-setting_dictation_context_sensitive = mod.setting(
-    "dictation_context_sensitive",
+setting_context_sensitive_dictation = mod.setting(
+    "context_sensitive_dictation",
     type=bool,
     default=False,
     desc="Look at surrounding text to improve auto-capitalization/spacing in dictation mode. By default, this works by selecting that text & copying it to the clipboard, so it may be slow or fail in some applications.",
@@ -135,7 +135,7 @@ class Actions:
         # do_the_dance = whether we should try to be context-sensitive. Since
         # whitespace is not affected by formatter state, if text.isspace() is
         # True we don't need context-sensitivity.
-        do_the_dance = (setting_dictation_context_sensitive.get()
+        do_the_dance = (setting_context_sensitive_dictation.get()
                         and not text.isspace())
         if do_the_dance:
             dictation_formatter.update_context(

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -83,7 +83,7 @@ def auto_capitalize(text, state = None):
         elif charge and (c.isalnum() or c in ",:"):
             charge = False
             c = c.capitalize()
-        # Otherwise the charge passes through (charge is unchanged).
+        # Otherwise the charge just passes through.
         output += c
         newline = c == "\n"
     return output, ("sentence start" if charge else

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -1,49 +1,15 @@
-from talon import Context, Module, actions, grammar
+from talon import Module
 from .user_settings import bind_list_to_csv, bind_word_map_to_csv
 
 mod = Module()
-ctx = Context()
 
 mod.list("vocabulary", desc="additional vocabulary words")
 
-@mod.capture(rule="({user.vocabulary} | <word>)")
-def word(m) -> str:
-    try:
-        return m.vocabulary
-    except AttributeError:
-        return " ".join(actions.dictate.replace_words(actions.dictate.parse_words(m.word)))
-
-@mod.capture(rule="({user.vocabulary} | <phrase>)+")
-def text(m) -> str: return format_phrase(m)
-
-@mod.capture(rule="({user.vocabulary} | {user.punctuation} | <phrase>)+")
-def prose(m) -> str: return format_phrase(m)
-
-# TODO: unify this formatting code with the dictation formatting code, so that
-# user.prose behaves the same way as dictation mode.
-no_space_before = set("\n .,!?;:-/%)]}")
-no_space_after = set("\n -/#([{$£€¥₩₽₹")
-def format_phrase(m):
-    words = capture_to_word_list(m)
-    result = ""
-    for i, word in enumerate(words):
-        if i > 0 and word not in no_space_before and words[i - 1][-1] not in no_space_after:
-            result += " "
-        result += word
-    return result
-
-def capture_to_word_list(m):
-    words = []
-    for item in m:
-        words.extend(
-            actions.dictate.replace_words(actions.dictate.parse_words(item))
-            if isinstance(item, grammar.vm.Phrase) else
-            item.split(" "))
-    return words
-
-
-# ---------- LISTS (punctuation, additional/replacement words) ----------
 # Default words that will need to be capitalized (particularly under w2l).
+# NB. These defaults and those later in this file are ONLY used when
+# auto-creating the corresponding settings/*.csv files. Those csv files
+# determine the contents of user.vocabulary and dictate.word_map. Once they
+# exist, the contents of the lists/dictionaries below are irrelevant.
 _capitalize_defaults = [
     "I",
     "I'm",

--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -3,10 +3,9 @@ mode: dictation
 ^press <user.keys>$: key("{keys}")
 
 # Everything here should call auto_insert to preserve the state to correctly auto-capitalize/auto-space.
-<user.text>: auto_insert(text)
-{user.punctuation}: auto_insert(punctuation)
-new line: auto_insert("new-line")
-new paragraph: auto_insert("new-paragraph")
+<user.prose>: auto_insert(prose)
+new line: "\n"
+new paragraph: "\n\n"
 cap <user.word>:
     result = user.formatted_text(word, "CAPITALIZE_FIRST_WORD")
     auto_insert(result)
@@ -59,9 +58,7 @@ clear right <number_small> (character|characters):
 
 # Formatting
 formatted <user.format_text>:
-    user.auto_format_pause()
-    auto_insert(format_text)
-    user.auto_format_resume()
+    user.dictation_insert_raw(format_text)
 ^format selection <user.formatters>$:
     user.formatters_reformat_selection(formatters)
 

--- a/settings.talon
+++ b/settings.talon
@@ -27,6 +27,13 @@ settings():
     # the number of lines of command history to keep in total;
     # "command history more" to display all of them, "command history less" to restore
     user.command_history_size = 50
+
+    # Uncomment the below to enable context-sensitive dictation. This determines
+    # how to format (capitalize, space) dictation-mode speech by selecting &
+    # copying surrounding text before inserting. This can be slow and may not
+    # work in some applications. You may wish to enable this on a
+    # per-application basis.
+    user.context_sensitive_dictation = 1
 	
 # uncomment tag to enable mouse grid
 # tag(): user.mouse_grid_enabled

--- a/settings.talon
+++ b/settings.talon
@@ -33,7 +33,7 @@ settings():
     # copying surrounding text before inserting. This can be slow and may not
     # work in some applications. You may wish to enable this on a
     # per-application basis.
-    user.context_sensitive_dictation = 1
+    #user.context_sensitive_dictation = 1
 	
 # uncomment tag to enable mouse grid
 # tag(): user.mouse_grid_enabled


### PR DESCRIPTION
This implements context sensitive dictation, which determines how to space and capitalize dictated text by examining the text around the cursor before inserting.

I suggest reading this diff in the following order:

1. `modes/dictation_mode.talon`
2. `code/vocabulary.py`
3. `code/dictation.py`
4. `settings.talon`

The `word`, `text`, and `prose` captures got moved from vocabulary.py to dictation.py. This is because `text` & `prose` both need `format_text` and `prose` needs `auto_capitalize` and dictation needs `auto_capitalize`. We could split this by making something (eg. `auto_capitalize`) a talon action, but it seems like all this text-formatting code wants to be in the same place anyways. Open to other ways to organize this.

The capitalization code all became character based instead of word based, to avoid mangling whitespace. This makes it slightly more complex.

The PR leaves context sensitive dictation off by default, since, though useful, it is flaky and invasive; in some apps the copy-to-clipboard dance is unreliable or it doesn't work. I think it merits more testing before/if we decide to turn it on by default. Since it uses a setting, we can enable it on a per-application basis too.

It is possible to have a command that does context sensitive dictation in command mode, `dictate <user.prose>$: user.dictation_insert(prose)`. Should we add a command for this? I've been using `say` for it, but that is a big change in behavior from current knausj `say` (eg. if context-sensitivity is off, it will often make wrong guesses about capitalization & spacing; if context-sensitivity is on it does the clipboard dance a lot).