### PR TITLE
Add a little help overlay to the mouse grid

### DIFF
--- a/mouse_grid/mouse_grid.py
+++ b/mouse_grid/mouse_grid.py
@@ -1,6 +1,6 @@
 # courtesy of https://github.com/timo/
 # see https://github.com/timo/talon_scripts
-from talon import Module, Context, app, canvas, screen, settings, ui, ctrl, cron
+from talon import Module, Context, app, actions, canvas, screen, settings, ui, ctrl, cron
 from talon.skia import Shader, Color, Paint, Rect
 from talon.types.point import Point2d
 from talon_plugins import eye_mouse, eye_zoom_mouse
@@ -73,6 +73,9 @@ class MouseSnapNine:
         self.mcanvas.register("draw", self.draw)
         self.mcanvas.freeze()
         self.active = True
+
+        actions.user.mouse_grid_help_overlay_show()
+
         return
 
     def close(self):
@@ -82,6 +85,8 @@ class MouseSnapNine:
         self.mcanvas.close()
         self.mcanvas = None
         self.img = None
+
+        actions.user.mouse_grid_help_overlay_close()
 
         self.active = False
         if self.was_control_mouse_active and not eye_mouse.control_mouse.enabled:
@@ -279,7 +284,7 @@ class GridActions:
     def grid_narrow_list(digit_list: typing.List[str]):
         """Choose fields multiple times in a row"""
         for d in digit_list:
-            GridActions.grid_narrow(int(d))
+            actions.user.grid_narrow(int(d))
 
     def grid_narrow(digit: Union[int, str]):
         """Choose a field of the grid and narrow the selection down"""

--- a/mouse_grid/mouse_grid_help_overlay.py
+++ b/mouse_grid/mouse_grid_help_overlay.py
@@ -1,0 +1,77 @@
+from talon import Module, Context, imgui, screen, settings, storage
+
+mod = Module()
+
+@imgui.open()
+def help_overlay(gui: imgui.GUI):
+    gui.text("Mouse Grid Usage")
+    gui.line()
+
+    gui.text("Say any of the nine numbers to narrow down")
+    gui.text("where you want the mouse to go")
+    gui.text("")
+
+    gui.text(" - grid off (hides grid)")
+    gui.text(" - grid reset (go back to the start)")
+    gui.text(" - grid back (go back one step)")
+
+    gui.text("")
+
+    gui.text(" - touch (left click)")
+    gui.text(" - righty (right click)")
+    gui.text(" - mid click (middle click)")
+
+    gui.text("")
+
+    gui.text("combiners like shift, control, etc can")
+    gui.text("go in front of the click commands")
+
+    gui.text("")
+
+    gui.text(" - dub click / duke (double click)")
+    gui.text(" - trip click (triple click)")
+    gui.text(" - drag (to start/stop dragging left mouse button)")
+
+    gui.text("")
+
+    gui.text(" - mouse grid help hide (close this help text)")
+    gui.text(" - mouse grid help disable (not see this help text again)")
+    gui.text(" - mouse grid help enable (to turn this back on)")
+    gui.text(" - mouse grid help (bring this help text back)")
+
+    gui.text("")
+
+    if gui.button("close"):
+        help_overlay.hide()
+
+    if gui.button("disable"):
+        help_overlay.hide()
+        storage.set("mouse_grid_help_overlay_activated", False)
+
+try:
+    storage.get("mouse_grid_help_overlay_activated")
+except KeyError:
+    storage.set("mouse_grid_help_overlay_activated", True)
+
+@mod.action_class
+class MouseGridHelpOverlay:
+    def mouse_grid_help_overlay_force_show():
+        """Bring up the mouse grid help overlay (wether or not it's enabled)"""
+        help_overlay.show()
+    def mouse_grid_help_overlay_show():
+        """Bring up the mouse grid help overlay (if it is enabled)"""
+        if storage.get("mouse_grid_help_overlay_activated"):
+            help_overlay.show()
+
+    def mouse_grid_help_overlay_close():
+        """Hides the mouse grid help overlay"""
+        help_overlay.hide()
+
+    def mouse_grid_help_overlay_disable():
+        """Disables the mouse grid help overlay"""
+        storage.set("mouse_grid_help_overlay_activated", False)
+
+    def mouse_grid_help_overlay_enable():
+        """Enables the mouse grid help overlay"""
+        storage.set("mouse_grid_help_overlay_activated", True)
+

--- a/mouse_grid/mouse_grid_open.talon
+++ b/mouse_grid/mouse_grid_open.talon
@@ -10,3 +10,14 @@ grid reset:
 
 grid back:
     user.grid_go_back()
+
+mouse grid help:
+    user.mouse_grid_help_overlay_force_show()
+mouse grid help close:
+    user.mouse_grid_help_overlay_close()
+mouse grid help disable:
+    user.mouse_grid_help_overlay_disable()
+    user.mouse_grid_help_overlay_close()
+mouse grid help enable:
+    user.mouse_grid_help_overlay_enable()
+    user.mouse_grid_help_overlay_show()


### PR DESCRIPTION
it shows the default mouse commands like lefty, mentions you can
add modifiers, and allows to turn the help overlay off for the
future

![image](https://user-images.githubusercontent.com/25167/108384206-d42eac00-720a-11eb-9da2-0d9da320e92f.png)
