### PR TITLE
make firefox.talon file, move non-OS-specific stuff there

### DIFF
--- a/apps/firefox/firefox.linux.talon
+++ b/apps/firefox/firefox.linux.talon
@@ -2,14 +2,8 @@ os: linux
 app: Firefox
 app: firefox
 -
-tag(): browser
-tag(): user.firefox
-tag(): user.tabs
-
 action(app.tab_next): key(ctrl-pagedown)
 action(app.tab_previous): key(ctrl-pageup)
-
-#action(browser.address):
 
 action(browser.bookmark):
 	key(ctrl-d)
@@ -26,13 +20,7 @@ action(browser.bookmarks_bar):
 action(browser.focus_address):
 	key(ctrl-l)
 
-action(browser.focus_search):
-	browser.focus_address()
-
-action(browser.go):
-	browser.focus_address()
-	insert(url)
-	key(enter)
+#action(browser.focus_page):
 
 action(browser.go_blank):
 	key(ctrl-n)
@@ -68,11 +56,6 @@ action(browser.show_extensions):
 
 action(browser.show_history):
 	key(ctrl-h)
-
-action(browser.submit_form):
-	key(enter)
-
-#action(browser.title)
 
 action(browser.toggle_dev_tools):
 	key(ctrl-shift-i)

--- a/apps/firefox/firefox.mac.talon
+++ b/apps/firefox/firefox.mac.talon
@@ -1,11 +1,6 @@
 os: mac
 app: firefox
 -
-tag(): browser
-tag(): user.tabs
-
-#action(browser.address):
-
 action(browser.bookmark):
 	key(cmd-d)
 
@@ -22,14 +17,6 @@ action(browser.focus_address):
 	key(cmd-l)
 	
 #action(browser.focus_page):
-
-action(browser.focus_search):
-	browser.focus_address()
-
-action(browser.go):
-	browser.focus_address()
-	insert(url)
-	key(enter)
 
 action(browser.go_blank):
 	key(cmd-n)
@@ -66,10 +53,5 @@ action(browser.show_extensions):
 action(browser.show_history):
 	key(cmd-y)
 	
-action(browser.submit_form):
-	key(enter)
-
-#action(browser.title)
-
 action(browser.toggle_dev_tools):
 	key(cmd-alt-i)

--- a/apps/firefox/firefox.talon
+++ b/apps/firefox/firefox.talon
@@ -1,0 +1,19 @@
+app: firefox
+-
+tag(): browser
+tag(): user.tabs
+
+# TODO
+#action(browser.address):
+#action(browser.title):
+
+action(browser.go):
+	browser.focus_address()
+	insert(url)
+	key(enter)
+
+action(browser.focus_search):
+	browser.focus_address()
+
+action(browser.submit_form):
+	key(enter)

--- a/apps/firefox/firefox.win.talon
+++ b/apps/firefox/firefox.win.talon
@@ -1,13 +1,8 @@
 os: windows
 app: firefox
 -
-tag(): browser
-tag(): user.tabs
-
 action(app.tab_next): key(ctrl-pagedown)
 action(app.tab_previous): key(ctrl-pageup)
-
-#action(browser.address):
 
 action(browser.bookmark):
 	key(ctrl-d)
@@ -29,14 +24,6 @@ action(browser.focus_address):
 	key(ctrl-l)
 	
 #action(browser.focus_page):
-
-action(browser.focus_search):
-	browser.focus_address()
-
-action(browser.go):
-	browser.focus_address()
-	insert(url)
-	key(enter)
 
 action(browser.go_blank):
 	key(ctrl-n)
@@ -73,10 +60,5 @@ action(browser.show_extensions):
 action(browser.show_history):
 	key(ctrl-h)
 	
-action(browser.submit_form):
-	key(enter)
-
-#action(browser.title)
-
 action(browser.toggle_dev_tools):
 	key(ctrl-shift-i)


### PR DESCRIPTION
This deduplicates a bunch of firefox stuff by having a non-operating-systems specific .talon file.