### PR TITLE
FixVisualStudioCodeLinuxBug

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -11,7 +11,7 @@ and app.bundle: com.microsoft.VSCode
 """
 mod.apps.vscode = """
 os: linux
-and app.name: Code - OSS
+and app.name: Code
 """
 mod.apps.vscode = """
 os: windows


### PR DESCRIPTION
After a recent updates, my visual studio code stopped being recognized. Meaning I only had access to the generic editor commands within my visual studio code.

This fixed my problem.

Ubuntu 20.04.1 LTS