### PR TITLE
standard.talon: make "scroll up/down" use edit.page_up/down actions

### DIFF
--- a/apps/linux/terminal.talon
+++ b/apps/linux/terminal.talon
@@ -12,11 +12,11 @@ action(edit.paste):
   key(ctrl-shift-v)
 action(edit.copy):
   key(ctrl-shift-c)
-
-scroll up:
+action(edit.page_up):
   key(shift-pageup)
-scroll down:
+action(edit.page_down):
   key(shift-pagedown)
+
 run last:
   key(up)
   key(enter)

--- a/code/keys.py
+++ b/code/keys.py
@@ -223,6 +223,8 @@ alternate_keys = {
     "delete": "backspace",
     "forward delete": "delete",
     #'junk': 'backspace',
+    "page up": "pageup",
+    "page down": "pagedown",
 }
 # mac apparently doesn't have the menu key.
 if app.platform in ("windows", "linux"):

--- a/misc/standard.talon
+++ b/misc/standard.talon
@@ -12,8 +12,8 @@
 #word shell: "shell".
 zoom in: edit.zoom_in()
 zoom out: edit.zoom_out()
-(page | scroll) up: key(pgup)
-(page | scroll) down: key(pgdown)
+scroll up: edit.page_up()
+scroll down: edit.page_down()
 copy that: edit.copy()
 cut that: edit.cut()
 paste that: edit.paste()


### PR DESCRIPTION
I think we're not supposed to be overriding voice commands based on context, but only actions. This makes "scroll up/down" run edit.page_up/down, and overrides this appropriately in linux terminals.

I thought about also changing "page up/down" for consistency, but this could make the actual page up/down keys inaccessible, which seems bad. Instead I added "page up" as a synonym for the "pageup" key, which should cover all previous uses of the command.