### PR TITLE
Make "command" and "option" keys mac-specific

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -111,15 +111,17 @@ def letters(m) -> str:
 
 
 ctx = Context()
-ctx.lists["self.modifier_key"] = {
+modifier_keys = {
     # If you find 'alt' is often misrecognized, try using 'alter'.
     "alt": "alt",  #'alter': 'alt',
-    "command": "cmd",
     "control": "ctrl",  #'troll':   'ctrl',
-    "option": "alt",
     "shift": "shift",  #'sky':     'shift',
     "super": "super",
 }
+if app.platform  == "mac":
+    modifier_keys["command"] = "cmd"
+    modifier_keys["option"] = "alt"
+ctx.lists["self.modifier_key"] = modifier_keys
 alphabet = dict(zip(default_alphabet, letters_string))
 ctx.lists["self.letter"] = alphabet
 


### PR DESCRIPTION
Fixes #351. I also made the "option" key name mac-specific, since I don't think other platforms call it that.  