### PR TITLE
detect that gnome-terminal is a terminal on linux

### DIFF
--- a/apps/linux/gnome-terminal.talon
+++ b/apps/linux/gnome-terminal.talon
@@ -1,0 +1,5 @@
+os: linux
+app.name: Gnome-terminal
+-
+tag(): terminal
+tag(): user.git


### PR DESCRIPTION
I'm not sure about enabling the user.git tag by default, but it seems to be what termite.talon does.