### PR TITLE
implement user.code_default_function() for funky

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -295,6 +295,10 @@ class Actions:
     def code_try_catch():
         """Inserts try/catch. If selection is true, does so around the selecion"""
 
+    def code_default_function(text: str):
+        """Inserts function declaration"""
+        actions.user.code_private_function(text)
+
     def code_private_function(text: str):
         """Inserts private function declaration"""
 

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -105,7 +105,7 @@ action(user.code_block_comment):
 action(user.code_block_comment_prefix): "/*"
 action(user.code_block_comment_suffix): "*/"
 
-^funky <user.text>$: user.code_private_function(text)
+^funky <user.text>$: user.code_default_function(text)
 ^static funky <user.text>$: user.code_private_static_function(text)
 
 

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -103,7 +103,7 @@ action(user.code_include_system): insert("using ")
 action(user.code_include_local): insert('using ')
 action(user.code_comment): "//"
 
-^funky <user.text>$: user.code_private_function(text)
+^funky <user.text>$: user.code_default_function(text)
 ^pro funky <user.text>$: user.code_protected_function(text)
 ^pub funky <user.text>$: user.code_public_function(text)
 ^static funky <user.text>$: user.code_private_static_function(text)

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -152,6 +152,6 @@ state reduce:
 
 state spread: "..."
 
-^funky <user.text>$: user.code_private_function(text)
+^funky <user.text>$: user.code_default_function(text)
 ^pro funky <user.text>$: user.code_protected_function(text)
 ^pub funky <user.text>$: user.code_public_function(text)

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -147,6 +147,9 @@ class user_actions:
         actions.user.paste(text)
         actions.edit.left()
 
+    def code_default_function(text: str):
+        actions.user.code_public_function(text)
+
     def code_private_function(text: str):
         """Inserts private function declaration"""
         result = "def _{}():".format(

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -100,7 +100,7 @@ self taught: "self."
 pie test: "pytest"
 state past: "pass"
 
-^funky <user.text>$: user.code_private_function(text)
+^funky <user.text>$: user.code_default_function(text)
 #^pro funky <user.text>$: user.code_protected_function(text)
 ^pub funky <user.text>$: user.code_public_function(text)
 #^static funky <user.text>$: user.code_private_static_function(text)

--- a/lang/typescript/typescript.talon
+++ b/lang/typescript/typescript.talon
@@ -155,6 +155,6 @@ state reduce:
 
 state spread: "..."
 
-^funky <user.text>$: user.code_private_function(text)
+^funky <user.text>$: user.code_default_function(text)
 ^pro funky <user.text>$: user.code_protected_function(text)
 ^pub funky <user.text>$: user.code_public_function(text)


### PR DESCRIPTION
1. this allows each language to have their own default visibility for function declarations
2. this change overrides the default visibility for python to be public

the motivation for this change is twofold:
1. it's pretty rare to declare a function as private in python, so the default should be public (no underscore)
2. changing the underlying action instead of just the python.talon voice command keeps the implementation uniform across languages and makes overrides easy