### PR TITLE
Add repeater command that makes more sense (for newbies anyway)

### DIFF
--- a/misc/repeater.talon
+++ b/misc/repeater.talon
@@ -1,4 +1,5 @@
 # -1 because we are repeating, so the initial command counts as one
 <user.ordinals>: core.repeat_command(ordinals-1)
+<number_small> times: core.repeat_command(number_small-1)
 (repeat that|twice): core.repeat_command(1)
 repeat that <number_small> [times]: core.repeat_command(number_small)


### PR DESCRIPTION
Add a "n times" repeater command that is easier to pronounce for most people and makes more sense naturally. It is also more consistent with the `repeat that` command.