### PR TITLE
Add search engines

### DIFF
--- a/code/search_engines.py
+++ b/code/search_engines.py
@@ -1,0 +1,33 @@
+from .user_settings import get_list_from_csv
+from talon import Module, Context
+from urllib.parse import quote_plus
+import webbrowser
+
+mod = Module()
+mod.list(
+    "search_engine",
+    desc="A search engine.  Any instance of %s will be replaced by query text",
+)
+
+_search_engine_defaults = {
+    "amazon": "https://www.amazon.com/s/?field-keywords=%s",
+    "google": "https://www.google.com/search?q=%s",
+    "map": "https://maps.google.com/maps?q=%s",
+    "scholar": "https://scholar.google.com/scholar?q=%s",
+    "wiki": "https://en.wikipedia.org/w/index.php?search=%s",
+}
+
+ctx = Context()
+ctx.lists["self.search_engine"] = get_list_from_csv(
+    "search_engines.csv",
+    headers=("URL Template", "Name"),
+    default=_search_engine_defaults,
+)
+
+
+@mod.action_class
+class Actions:
+    def search_with_search_engine(search_template: str, search_text: str):
+        """Search a search engine for given text"""
+        url = search_template.replace("%s", quote_plus(search_text))
+        webbrowser.open(url)

--- a/misc/search_engines.talon
+++ b/misc/search_engines.talon
@@ -1,0 +1,4 @@
+{user.search_engine} hunt <user.text>: user.search_with_search_engine(search_engine, user.text)
+{user.search_engine} (that|this):
+    text = edit.selected_text()
+    user.search_with_search_engine(search_engine, text)


### PR DESCRIPTION
Adds support for commands such as "google hunt hello world" to search for arbitrary text and "google this" to search for text currently selected by cursor.

Note: the specific search engines might not be generic enough?  For example I'm using Amazon Smile UK

Maybe should use a csv?