### PR TITLE
Do not redefine the `keys` symbol

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -233,9 +233,9 @@ if app.platform in ("windows", "linux"):
     alternate_keys["menu key"] = "menu"
     alternate_keys["print screen"] = "printscr"
 
-keys = {k: k for k in simple_keys}
-keys.update(alternate_keys)
-ctx.lists["self.special_key"] = keys
+special_keys = {k: k for k in simple_keys}
+special_keys.update(alternate_keys)
+ctx.lists["self.special_key"] = special_keys
 ctx.lists["self.function_key"] = {
     f"F {default_f_digits[i]}": f"f{i + 1}" for i in range(12)
 }


### PR DESCRIPTION
The `keys` capture on line 102 and the `keys` dictionary on line 240
were being conflated, such that I could not use `key(escape)` in
a `.talon` file