### PR TITLE
switcher menu

### DIFF
--- a/code/switcher.py
+++ b/code/switcher.py
@@ -303,6 +303,13 @@ class Actions:
         else:
             ui.launch(path=path)
 
+    def switcher_menu():
+        """Open a menu of running apps to switch to"""
+        if app.platform == "windows":
+            actions.key("alt-ctrl-tab")
+        else:
+            print("Persistent Switcher Menu not supported on " + app.platform)
+
     def switcher_toggle_running():
         """Shows/hides all running applications"""
         if gui.showing:

--- a/misc/window_management.talon
+++ b/misc/window_management.talon
@@ -4,7 +4,7 @@ window last: app.window_previous()
 window close: app.window_close()
 focus <user.running_applications>: user.switcher_focus(running_applications)
 # following only works on windows. Can't figure out how to make it work for mac. No idea what the equivalent for linux would be.
-focus: user.switcher_menu()
+focus$: user.switcher_menu()
 running list: user.switcher_toggle_running()
 launch <user.launch_applications>: user.switcher_launch(launch_applications)
 

--- a/misc/window_management.talon
+++ b/misc/window_management.talon
@@ -3,6 +3,8 @@ window next: app.window_next()
 window last: app.window_previous()
 window close: app.window_close()
 focus <user.running_applications>: user.switcher_focus(running_applications)
+# following only works on windows. Can't figure out how to make it work for mac. No idea what the equivalent for linux would be.
+focus: user.switcher_menu()
 running list: user.switcher_toggle_running()
 launch <user.launch_applications>: user.switcher_launch(launch_applications)
 


### PR DESCRIPTION
DONOTMERGE - Only works on Windows currently.

Throwing my 2c into the ring on this cause I needed it locally. The problem is that it's challenging to switch between two windows with the same name (e.g. two instances of chrome with different tabs, or two instances of vscode with different repos open). This merely opens up the same `alt-tab` menu and let's you choose with your voice.

I would LOVE to get this working on mac, but I couldn't figure out how. I'm not sure what the equivalent for linux would be.

See also: https://github.com/knausj85/knausj_talon/pull/73 https://github.com/knausj85/knausj_talon/issues/373