### PR TITLE
Fix command server

### DIFF
--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -1,0 +1,7 @@
+# VSCode support
+
+It is recommended to install the [VSCode talon extension pack](https://marketplace.visualstudio.com/items?itemName=pokey.talon), which will enable a couple advanced commands and improve the speed / robustness of VSCode commands.
+
+## Cursorless
+
+If you'd like to use Cursorless, follow the instructions in the [cursorless-talon repo](https://github.com/pokey/cursorless-talon).

--- a/apps/vscode/command_client.py
+++ b/apps/vscode/command_client.py
@@ -1,126 +1,235 @@
-import requests
-import time
+import getpass
+from dataclasses import dataclass
 import json
-from typing import Any
-from talon import Module, actions, app
+import time
 from pathlib import Path
 from tempfile import gettempdir
+from typing import Any, List
+from uuid import uuid4
 
-is_mac = app.platform == "mac"
+from talon import Module, actions, Context
+
+
+STALE_TIMEOUT_MS = 10_000
 
 mod = Module()
+
+ctx = Context()
+mac_ctx = Context()
+
+ctx.matches = r"""
+app: vscode
+"""
+mac_ctx.matches = r"""
+os: mac
+app: vscode
+"""
 
 
 class NotSet:
     def __repr__(self):
         return "<argument not set>"
 
-def run_vscode_command_by_command_palette(command: str):
-    """Execute command via command palette. Preserves the clipboard."""
-    # Clip is noticeably faster than insert
-    if not is_mac:
-        actions.key("ctrl-shift-p")
-    else:
-        actions.key("cmd-shift-p")
 
-    actions.user.paste(f"{command}")
+def run_vscode_command_by_command_palette(command_id: str):
+    """Execute command via command palette. Preserves the clipboard."""
+    actions.user.command_palette()
+    actions.user.paste(command_id)
     actions.key("enter")
 
 
+def write_json_exclusive(path: Path, body: Any):
+    """Writes jsonified object to file, failing if the file already exists
+
+    Args:
+        path (Path): The path of the file to write
+        body (Any): The object to convert to json and write
+    """
+    with path.open("x") as out_file:
+        out_file.write(json.dumps(body))
+
+
+@dataclass
+class Request:
+    command_id: str
+    args: List[Any]
+    wait_for_finish: bool
+    return_command_output: bool
+    uuid: str
+
+    def to_dict(self):
+        return {
+            "commandId": self.command_id,
+            "args": self.args,
+            "waitForFinish": self.wait_for_finish,
+            "returnCommandOutput": self.return_command_output,
+            "uuid": self.uuid,
+        }
+
+
+def write_request(request: Request, path: Path):
+    """Converts the given request to json and writes it to the file, failing if
+    the file already exists unless it is stale in which case it replaces it
+
+    Args:
+        request (Request): The request to serialize
+        path (Path): The path to write to
+
+    Raises:
+        Exception: If another process has an active request file
+    """
+    try:
+        write_json_exclusive(path, request.to_dict())
+    except FileExistsError:
+        stats = path.stat()
+
+        modified_time_ms = stats.st_mtime_ns / 1e6
+        current_time_ms = time.time() * 1e3
+
+        if abs(modified_time_ms - current_time_ms) < STALE_TIMEOUT_MS:
+            raise Exception("Another process has an active request file")
+        else:
+            print("Removing stale request file")
+            path.unlink()
+            write_json_exclusive(path, request.to_dict())
+
+
 def run_vscode_command(
-    command: str,
+    command_id: str,
     *args: str,
     wait_for_finish: bool = False,
-    expect_response: bool = False,
+    return_command_output: bool = False,
     decode_json_arguments: bool = False,
 ):
-    """Execute command via vscode command server."""
+    """Runs a VSCode command, using command server if available
+
+    Args:
+        command (str): The ID of the VSCode command to run
+        wait_for_finish (bool, optional): Whether to wait for the command to finish before returning. Defaults to False.
+        return_command_output (bool, optional): Whether to return the output of the command. Defaults to False.
+        decode_json_arguments (bool, optional): Whether to decode JSON arguments. Defaults to False.
+
+    Raises:
+        Exception: If there is an issue with the file-based communication
+
+    Returns:
+        Object: The response from the command, if requested.
+    """
     # NB: This is a hack to work around the fact that talon doesn't support
     # variable argument lists
-    args = list(
-        filter(
-            lambda x: x is not NotSet,
-            args,
-        )
-    )
+    args = [x for x in args if x is not NotSet]
+
     if decode_json_arguments:
         args = [json.loads(arg) for arg in args]
 
-    port_file_path = Path(gettempdir()) / "vscode-port"
+    username = getpass.getuser()
 
-    if not port_file_path.exists():
-        if args or expect_response or decode_json_arguments:
+    communication_dir_path = Path(gettempdir()) / f"vscode-command-server-{username}"
+
+    if not communication_dir_path.exists():
+        if args or return_command_output or decode_json_arguments:
             raise Exception("Must use command-server extension for advanced commands")
         print("Port file not found; using command palette")
-        run_vscode_command_by_command_palette(command)
+        run_vscode_command_by_command_palette(command_id)
         return
 
-    original_contents = port_file_path.read_text()
+    request_path = communication_dir_path / "request.json"
+    response_path = communication_dir_path / "response.json"
+
+    uuid = str(uuid4())
+
+    unlink_if_exists(response_path)
+
+    request = Request(
+        command_id=command_id,
+        args=args,
+        wait_for_finish=wait_for_finish,
+        return_command_output=return_command_output,
+        uuid=uuid,
+    )
+
+    write_request(
+        request,
+        request_path,
+    )
 
     # Issue command to VSCode telling it to update the port file.  Because only
     # the active VSCode instance will accept keypresses, we can be sure that
     # the active VSCode instance will be the one to write the port.
-    if is_mac:
-        actions.key("cmd-shift-alt-p")
-    else:
-        actions.key("ctrl-shift-alt-p")
+    actions.user.trigger_command_server_command_execution()
 
-    # Wait for the VSCode instance to update the port file.  This generally
-    # happens within the first millisecond, but we give it 3 seconds just in
-    # case.
-    start_time = time.monotonic()
-    new_contents = port_file_path.read_text()
-    sleep_time = 0.0005
-    while True:
-        if new_contents != original_contents:
-            try:
-                decoded_contents = json.loads(new_contents)
-                # If we're successful, we break out of the loop
-                break
-            except ValueError:
-                # If we're not successful, we keep waiting; we assume it was a
-                # partial write from VSCode
-                pass
-        time.sleep(sleep_time)
-        sleep_time *= 2
-        if time.monotonic() - start_time > 3.0:
-            raise Exception("Timed out waiting for VSCode to update port file")
-        new_contents = port_file_path.read_text()
+    try:
+        decoded_contents = read_json_with_timeout(response_path)
+    finally:
+        unlink_if_exists(request_path)
+        unlink_if_exists(response_path)
 
-    port = decoded_contents["port"]
-    nonce = decoded_contents["nonce"]
+    if decoded_contents["uuid"] != uuid:
+        raise Exception("uuids did not match")
 
-    response = requests.post(
-        f"http://localhost:{port}/execute-command",
-        json={
-            "commandId": command,
-            "args": args,
-            "waitForFinish": wait_for_finish,
-            "expectResponse": expect_response,
-            "nonce": nonce,
-        },
-        timeout=(0.05, 3.05),
-    )
-    response.raise_for_status()
+    if decoded_contents["error"] is not None:
+        raise Exception(decoded_contents["error"])
 
     actions.sleep("25ms")
 
-    if expect_response:
-        return response.json()
+    return decoded_contents["returnValue"]
+
+
+def unlink_if_exists(path):
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def read_json_with_timeout(path: str) -> Any:
+    """Repeatedly tries to read a json object from the given path, waiting until there is a trailing new line indicating that the write is complete
+
+    Args:
+        path (str): The path to write to
+
+    Raises:
+        Exception: If we timeout waiting for a response
+
+    Returns:
+        Any: The json-decoded contents of the file
+    """
+    start_time = time.perf_counter()
+    sleep_time = 0.0005
+    while True:
+        try:
+            raw_text = path.read_text()
+
+            if raw_text.endswith("\n"):
+                break
+        except FileNotFoundError:
+            # If not found, keep waiting
+            pass
+
+        actions.sleep(sleep_time)
+        sleep_time *= 2
+        if time.perf_counter() - start_time > 3.0:
+            raise Exception("Timed out waiting for response")
+
+    return json.loads(raw_text)
 
 
 @mod.action_class
 class Actions:
-    def vscode(command: str):
+    def vscode(command_id: str):
         """Execute command via vscode command server, if available."""
-        run_vscode_command(command)
+        run_vscode_command(command_id)
 
-    def vscode_and_wait(command: str):
+    def trigger_command_server_command_execution():
+        """Issue keystroke to trigger command server to execute command that was written to the file."""
+        actions.key("ctrl-shift-alt-p")
+
+    def vscode_and_wait(command_id: str):
         """Execute command via vscode command server, if available, and wait for command to finish."""
-        run_vscode_command(command, wait_for_finish=True)
+        run_vscode_command(command_id, wait_for_finish=True)
 
     def vscode_with_plugin(
-        command: str,
+        command_id: str,
         arg1: Any = NotSet,
         arg2: Any = NotSet,
         arg3: Any = NotSet,
@@ -129,7 +238,7 @@ class Actions:
     ):
         """Execute command via vscode command server."""
         run_vscode_command(
-            command,
+            command_id,
             arg1,
             arg2,
             arg3,
@@ -138,7 +247,7 @@ class Actions:
         )
 
     def vscode_with_plugin_and_wait(
-        command: str,
+        command_id: str,
         arg1: Any = NotSet,
         arg2: Any = NotSet,
         arg3: Any = NotSet,
@@ -147,37 +256,17 @@ class Actions:
     ):
         """Execute command via vscode command server and wait for command to finish."""
         run_vscode_command(
-            command,
+            command_id,
             arg1,
             arg2,
             arg3,
             arg4,
             arg5,
             wait_for_finish=True,
-        )
-
-    def vscode_json_and_wait(
-        command: str,
-        arg1: Any = NotSet,
-        arg2: Any = NotSet,
-        arg3: Any = NotSet,
-        arg4: Any = NotSet,
-        arg5: Any = NotSet,
-    ):
-        """Execute command via vscode command server and wait for command to finish."""
-        run_vscode_command(
-            command,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            wait_for_finish=True,
-            decode_json_arguments=True,
         )
 
     def vscode_get(
-        command: str,
+        command_id: str,
         arg1: Any = NotSet,
         arg2: Any = NotSet,
         arg3: Any = NotSet,
@@ -186,11 +275,17 @@ class Actions:
     ) -> Any:
         """Execute command via vscode command server and return command output."""
         return run_vscode_command(
-            command,
+            command_id,
             arg1,
             arg2,
             arg3,
             arg4,
             arg5,
-            expect_response=True,
+            return_command_output=True,
         )
+
+
+@mac_ctx.action_class("user")
+class MacUserActions:
+    def trigger_command_server_command_execution():
+        actions.key("cmd-shift-alt-p")

--- a/apps/vscode/command_client.py
+++ b/apps/vscode/command_client.py
@@ -1,15 +1,13 @@
-import getpass
-from dataclasses import dataclass
 import json
 import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import gettempdir
 from typing import Any, List
 from uuid import uuid4
 
-from talon import Module, actions, Context
-
+from talon import Context, Module, actions
 
 # How old a request file needs to be before we declare it stale and are willing
 # to remove it
@@ -141,8 +139,6 @@ def run_vscode_command(
     # NB: This is a hack to work around the fact that talon doesn't support
     # variable argument lists
     args = [x for x in args if x is not NotSet]
-
-    username = getpass.getuser()
 
     communication_dir_path = get_communication_dir_path()
 

--- a/apps/vscode/command_client.py
+++ b/apps/vscode/command_client.py
@@ -160,8 +160,6 @@ def run_vscode_command(
     # sanity checking
     uuid = str(uuid4())
 
-    unlink_if_exists(response_path)
-
     request = Request(
         command_id=command_id,
         args=args,

--- a/apps/vscode/command_client.py
+++ b/apps/vscode/command_client.py
@@ -1,0 +1,188 @@
+import requests
+import time
+import json
+from typing import Any
+from talon import Module, actions, app
+from pathlib import Path
+from tempfile import gettempdir
+
+is_mac = app.platform == "mac"
+
+mod = Module()
+
+
+class NotSet:
+    def __repr__(self):
+        return "<argument not set>"
+
+def run_vscode_command_by_command_palette(command: str):
+    """Execute command via command palette. Preserves the clipboard."""
+    # Clip is noticeably faster than insert
+    if not is_mac:
+        actions.key("ctrl-shift-p")
+    else:
+        actions.key("cmd-shift-p")
+
+    actions.user.paste(f"{command}")
+    actions.key("enter")
+
+
+def run_vscode_command(
+    command: str,
+    *args: str,
+    wait_for_finish: bool = False,
+    expect_response: bool = False,
+    decode_json_arguments: bool = False,
+):
+    """Execute command via vscode command server."""
+    # NB: This is a hack to work around the fact that talon doesn't support
+    # variable argument lists
+    args = list(
+        filter(
+            lambda x: x is not NotSet,
+            args,
+        )
+    )
+    if decode_json_arguments:
+        args = [json.loads(arg) for arg in args]
+
+    port_file_path = Path(gettempdir()) / "vscode-port"
+
+    if not port_file_path.exists():
+        if args or wait_for_finish or expect_response or decode_json_arguments:
+            raise Exception("Must use command-server extension for advanced commands")
+        print("Port file not found; using command palette")
+        run_vscode_command_by_command_palette(command)
+        return
+
+    original_contents = port_file_path.read_text()
+
+    # Issue command to VSCode telling it to update the port file.  Because only
+    # the active VSCode instance will accept keypresses, we can be sure that
+    # the active VSCode instance will be the one to write the port.
+    if is_mac:
+        actions.key("cmd-shift-alt-p")
+    else:
+        actions.key("ctrl-shift-alt-p")
+
+    # Wait for the VSCode instance to update the port file.  This generally
+    # happens within the first millisecond, but we give it 3 seconds just in
+    # case.
+    start_time = time.monotonic()
+    new_contents = port_file_path.read_text()
+    sleep_time = 0.0005
+    while True:
+        if new_contents != original_contents:
+            try:
+                decoded_contents = json.loads(new_contents)
+                # If we're successful, we break out of the loop
+                break
+            except ValueError:
+                # If we're not successful, we keep waiting; we assume it was a
+                # partial write from VSCode
+                pass
+        time.sleep(sleep_time)
+        sleep_time *= 2
+        if time.monotonic() - start_time > 3.0:
+            raise Exception("Timed out waiting for VSCode to update port file")
+        new_contents = port_file_path.read_text()
+
+    port = decoded_contents["port"]
+    nonce = decoded_contents["nonce"]
+
+    response = requests.post(
+        f"http://localhost:{port}/execute-command",
+        json={
+            "commandId": command,
+            "args": args,
+            "waitForFinish": wait_for_finish,
+            "expectResponse": expect_response,
+            "nonce": nonce,
+        },
+        timeout=(0.05, 3.05),
+    )
+    response.raise_for_status()
+
+    actions.sleep("25ms")
+
+    if expect_response:
+        return response.json()
+
+
+@mod.action_class
+class Actions:
+    def vscode(
+        command: str,
+        arg1: Any = NotSet,
+        arg2: Any = NotSet,
+        arg3: Any = NotSet,
+        arg4: Any = NotSet,
+        arg5: Any = NotSet,
+    ):
+        """Execute command via vscode command server."""
+        run_vscode_command(
+            command,
+            arg1,
+            arg2,
+            arg3,
+            arg4,
+            arg5,
+        )
+
+    def vscode_and_wait(
+        command: str,
+        arg1: Any = NotSet,
+        arg2: Any = NotSet,
+        arg3: Any = NotSet,
+        arg4: Any = NotSet,
+        arg5: Any = NotSet,
+    ):
+        """Execute command via vscode command server and wait for command to finish."""
+        run_vscode_command(
+            command,
+            arg1,
+            arg2,
+            arg3,
+            arg4,
+            arg5,
+            wait_for_finish=True,
+        )
+
+    def vscode_json_and_wait(
+        command: str,
+        arg1: Any = NotSet,
+        arg2: Any = NotSet,
+        arg3: Any = NotSet,
+        arg4: Any = NotSet,
+        arg5: Any = NotSet,
+    ):
+        """Execute command via vscode command server and wait for command to finish."""
+        run_vscode_command(
+            command,
+            arg1,
+            arg2,
+            arg3,
+            arg4,
+            arg5,
+            wait_for_finish=True,
+            decode_json_arguments=True,
+        )
+
+    def vscode_get(
+        command: str,
+        arg1: Any = NotSet,
+        arg2: Any = NotSet,
+        arg3: Any = NotSet,
+        arg4: Any = NotSet,
+        arg5: Any = NotSet,
+    ) -> Any:
+        """Execute command via vscode command server and return command output."""
+        return run_vscode_command(
+            command,
+            arg1,
+            arg2,
+            arg3,
+            arg4,
+            arg5,
+            expect_response=True,
+        )

--- a/apps/vscode/command_client.py
+++ b/apps/vscode/command_client.py
@@ -49,7 +49,7 @@ def run_vscode_command(
     port_file_path = Path(gettempdir()) / "vscode-port"
 
     if not port_file_path.exists():
-        if args or wait_for_finish or expect_response or decode_json_arguments:
+        if args or expect_response or decode_json_arguments:
             raise Exception("Must use command-server extension for advanced commands")
         print("Port file not found; using command palette")
         run_vscode_command_by_command_palette(command)
@@ -111,7 +111,15 @@ def run_vscode_command(
 
 @mod.action_class
 class Actions:
-    def vscode(
+    def vscode(command: str):
+        """Execute command via vscode command server, if available."""
+        run_vscode_command(command)
+
+    def vscode_and_wait(command: str):
+        """Execute command via vscode command server, if available, and wait for command to finish."""
+        run_vscode_command(command, wait_for_finish=True)
+
+    def vscode_with_plugin(
         command: str,
         arg1: Any = NotSet,
         arg2: Any = NotSet,
@@ -129,7 +137,7 @@ class Actions:
             arg5,
         )
 
-    def vscode_and_wait(
+    def vscode_with_plugin_and_wait(
         command: str,
         arg1: Any = NotSet,
         arg2: Any = NotSet,

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -73,27 +73,6 @@ class edit_actions:
 
 @mod.action_class
 class Actions:
-    def vscode(command: str):
-        """Execute command via command palette. Preserves the clipboard."""
-        # Clip is noticeably faster than insert
-        if not is_mac:
-            actions.key("ctrl-shift-p")
-        else:
-            actions.key("cmd-shift-p")
-
-        actions.user.paste(f"{command}")
-        actions.key("enter")
-
-    def vscode_ignore_clipboard(command: str):
-        """Execute command via command palette. Does NOT preserve the clipboard for commands like copyFilePath"""
-        clip.set_text(f"{command}")
-        if not is_mac:
-            actions.key("ctrl-shift-p")
-        else:
-            actions.key("cmd-shift-p")
-        actions.edit.paste()
-        actions.key("enter")
-
     def vscode_terminal(number: int):
         """Activate a terminal by number"""
         actions.user.vscode(f"workbench.action.terminal.focusAtIndex{number}")

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -3,6 +3,7 @@ from talon import Context, actions, ui, Module, app, clip
 is_mac = app.platform == "mac"
 
 ctx = Context()
+mac_ctx = Context()
 mod = Module()
 mod.apps.vscode = """
 os: mac
@@ -22,6 +23,10 @@ and app.exe: Code.exe
 """
 
 ctx.matches = r"""
+app: vscode
+"""
+mac_ctx.matches = r"""
+os: mac
 app: vscode
 """
 
@@ -47,7 +52,7 @@ class win_actions:
 
 @ctx.action_class("edit")
 class edit_actions:
-    def find(text = None):
+    def find(text=None):
         if is_mac:
             actions.key("cmd-f")
         else:
@@ -76,6 +81,16 @@ class Actions:
     def vscode_terminal(number: int):
         """Activate a terminal by number"""
         actions.user.vscode(f"workbench.action.terminal.focusAtIndex{number}")
+
+    def command_palette():
+        """Show command palette"""
+        actions.key("ctrl-shift-p")
+
+
+@mac_ctx.action_class("user")
+class MacUserActions:
+    def command_palette():
+        actions.key("cmd-shift-p")
 
 
 @ctx.action_class("user")


### PR DESCRIPTION
This PR switches to file-based RPC for the VSCode command server to improve security, and enables fallback commands using the command palette so that no extension is strictly necessary

Works with https://github.com/pokey/command-server/pull/3 on the VSCode side