### PR TITLE
Fix broken "panel terminal" command for VS Code

### DIFF
--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -75,7 +75,7 @@ panel control: user.vscode("workbench.panel.repl.view.focus")
 panel output: user.vscode("workbench.panel.output.focus")
 panel problems: user.vscode("workbench.panel.markers.view.focus")
 panel switch: user.vscode("workbench.action.togglePanel")
-panel terminal: user.vscode("workbench.panel.terminal.focus")
+panel terminal: user.vscode("workbench.action.terminal.focus")
 focus editor: user.vscode("workbench.action.focusActiveEditorGroup")
 
 # Settings


### PR DESCRIPTION
See https://github.com/microsoft/vscode/issues/106535. Just started using VS Code and `workbench.panel.terminal.focus` is broken, it does not focus the terminal. The proper command is `workbench.action.terminal.focus`. The other commands with `panel` still work but may break in the future, too.