### PR TITLE
generic_browser.talon: add "go to <website>" command

### DIFF
--- a/apps/generic_browser.talon
+++ b/apps/generic_browser.talon
@@ -4,6 +4,7 @@ tag: browser
 go home: browser.go_home()
 [go] forward: browser.go_forward()
 go (back | backward): browser.go_back()
+go to {user.website}: browser.go(website)
 
 go private: browser.open_private_window()
 


### PR DESCRIPTION
Adds a `go to <website>` command when we're in a browser. The difference from `open <website>` is that it only works if you've already got a browser focused and it visits the website in the current tab instead of opening a new one.