### PR TITLE
Use auto_lang mode to detect if lang is forced or not

### DIFF
--- a/lang/batch.talon
+++ b/lang/batch.talon
@@ -1,5 +1,5 @@
 mode: user.batch
-mode: command
+mode: user.auto_lang
 and code.language: batch
 -
 #tag(): user.code_operators

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -11,7 +11,7 @@ mod.setting(
 ctx = Context()
 ctx.matches = r"""
 mode: user.c
-mode: command
+mode: user.auto_lang
 and code.language: c
 """
 

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -1,5 +1,5 @@
 mode: user.c
-mode: command
+mode: user.auto_lang
 and code.language: c
 -
 tag(): user.code_operators

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -3,7 +3,7 @@ from talon import Context, Module, actions, imgui, settings, ui
 ctx = Context()
 ctx.matches = r"""
 mode: user.csharp
-mode: command
+mode: user.auto_lang
 and code.language: csharp
 """
 ctx.lists["user.code_functions"] = {

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -1,5 +1,5 @@
 mode: user.csharp
-mode: command
+mode: user.auto_lang
 and code.language: csharp
 -
 tag(): user.code_operators

--- a/lang/go.talon
+++ b/lang/go.talon
@@ -1,5 +1,5 @@
 mode: user.go
-mode: command
+mode: user.auto_lang
 and code.language: go
 -
 variadic: "..."

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -1,5 +1,5 @@
 mode: user.java
-mode: command
+mode: user.auto_lang
 and code.language: java
 
 -

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -1,5 +1,5 @@
 mode: user.javascript
-mode: command
+mode: user.auto_lang
 and code.language: javascript
 -
 tag(): user.code_operators

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -6,7 +6,7 @@ mod = Module()
 ctx = Context()
 ctx.matches = r"""
 mode: user.python
-mode: command
+mode: user.auto_lang
 and code.language: python
 """
 ctx.lists["user.code_functions"] = {

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -1,5 +1,5 @@
 mode: user.python
-mode: command
+mode: user.auto_lang
 and code.language: python
 -
 tag(): user.code_operators

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -4,7 +4,7 @@ ctx = Context()
 
 ctx.matches = r"""
 mode: user.r
-mode: command
+mode: user.auto_lang
 and code.language: r
 """
 

--- a/lang/r/r.talon
+++ b/lang/r/r.talon
@@ -1,5 +1,5 @@
 mode: user.r
-mode: command
+mode: user.auto_lang
 and code.language: r
 -
 # TODO: functions

--- a/lang/ruby/ruby.py
+++ b/lang/ruby/ruby.py
@@ -3,7 +3,7 @@ from talon import Context, actions, settings
 ctx = Context()
 ctx.matches = r"""
 mode: user.ruby
-mode: command
+mode: user.auto_lang
 and code.language: ruby
 """
 

--- a/lang/ruby/ruby.talon
+++ b/lang/ruby/ruby.talon
@@ -1,5 +1,5 @@
 mode: user.ruby
-mode: command
+mode: user.auto_lang
 and code.language: ruby
 -
 tag(): user.code_operators

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -1,5 +1,5 @@
 mode: user.talon
-mode: command
+mode: user.auto_lang
 and code.language: talon
 -
 tag(): user.code_operators

--- a/lang/typescript/typescript.talon
+++ b/lang/typescript/typescript.talon
@@ -1,5 +1,5 @@
 mode: user.typescript
-mode: command
+mode: user.auto_lang
 and code.language: typescript
 -
 tag(): user.code_operators

--- a/lang/vimscript/vimscript.talon
+++ b/lang/vimscript/vimscript.talon
@@ -1,6 +1,6 @@
 
 mode: user.vimscript
-mode: command
+mode: user.auto_lang
 and code.language: vimscript
 -
 tag(): user.code_operators


### PR DESCRIPTION
Solves the problem that code.language doesn't update when forcing a language and until you change focus and the app title updates you have 2 language context active at the same time.

This is active if user.javascript OR code.language == javascript.
```
mode: user.javascript
mode: command
and code.language: javascript
```

Change it to this and the problem is solved sine auto_lang and user.javascript is mutex.
```
mode: user.javascript
mode: user.auto_lang
and code.language: javascript
```
