### PR TITLE
Add 'apostrophe' symbol

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -156,6 +156,7 @@ punctuation_words = {
 symbol_key_words = {
     "dot": ".",
     "quote": "'",
+    "apostrophe": "'",
     "L square": "[",
     "left square": "[",
     "square": "[",


### PR DESCRIPTION
For English dialects that don't use the word 'quote' for the existing quote symbol 