### PR TITLE
Added screens module and command to capture screen by number

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -113,7 +113,6 @@ class Actions:
 
     def code_clear_language_mode():
         """Clears the active language mode, and re-enables code.language: extension matching"""
-        print("code_clear_language_mode")
         actions.mode.enable("user.auto_lang")
         for __, lang in extension_lang_map.items():
             actions.mode.disable("user.{}".format(lang))

--- a/code/screen.py
+++ b/code/screen.py
@@ -1,0 +1,74 @@
+from talon import Module, actions, ui, cron
+from talon.canvas import Canvas
+
+mod = Module()
+
+
+@mod.action_class
+class Actions:
+    def screens_show_numbering():
+        """Show screen number on each screen"""
+        screens = get_sorted_screens()
+        number = 1
+        for screen in screens:
+            show_screen_number(screen, number)
+            number += 1
+
+    def screens_get_by_number(screen_number: int) -> ui.Screen:
+        """Get screen by number"""
+        screens = get_sorted_screens()
+        length = len(screens)
+        if screen_number < 1 or screen_number > length:
+            raise Exception(
+                f"Non-existing screen {screen_number} in range [1, {length}]"
+            )
+        return screens[screen_number - 1]
+
+    def screens_get_previous(screen: ui.Screen) -> ui.Screen:
+        """Get the screen before this one"""
+        return get_screen_by_offset(screen, -1)
+
+    def screens_get_next(screen: ui.Screen) -> ui.Screen:
+        """Get the screen after this one"""
+        return get_screen_by_offset(screen, 1)
+
+
+def get_screen_by_offset(screen: ui.Screen, offset: int) -> ui.Screen:
+    screens = get_sorted_screens()
+    index = (screens.index(screen) + offset) % len(screens)
+    return screens[index]
+
+
+def get_sorted_screens():
+    """Return screens sorted by their topmost, then leftmost, edge.
+    Screens will be sorted leftto-right, then top-to-bottom as a tiebreak.
+    """
+    return sorted(
+        sorted(ui.screens(), key=lambda screen: screen.visible_rect.top),
+        key=lambda screen: screen.visible_rect.left,
+    )
+
+
+def show_screen_number(screen: ui.Screen, number: int):
+    def on_draw(c):
+        c.paint.typeface = "arial"
+        # The min(width, height) is to not get gigantic size on portrait screens
+        c.paint.textsize = round(min(c.width, c.height) / 2)
+        text = f"{number}"
+        rect = c.paint.measure_text(text)[1]
+        x = c.x + c.width / 2 - rect.x - rect.width / 2
+        y = c.y + c.height / 2 + rect.height / 2
+
+        c.paint.style = c.paint.Style.FILL
+        c.paint.color = "eeeeee"
+        c.draw_text(text, x, y)
+
+        c.paint.style = c.paint.Style.STROKE
+        c.paint.color = "000000"
+        c.draw_text(text, x, y)
+
+        cron.after("3s", canvas.close)
+
+    canvas = Canvas.from_rect(screen.rect)
+    canvas.register("draw", on_draw)
+    canvas.freeze()

--- a/code/window_snap.py
+++ b/code/window_snap.py
@@ -14,19 +14,6 @@ from typing import Optional
 from talon import ui, Module, Context, actions
 
 
-def sorted_screens():
-    """Return screens sorted by their topmost, then leftmost, edge.
-
-    Screens will be sorted left-to-right, then top-to-bottom as a tiebreak.
-
-    """
-
-    return sorted(
-        sorted(ui.screens(), key=lambda screen: screen.visible_rect.top),
-        key=lambda screen: screen.visible_rect.left,
-    )
-
-
 def _set_window_pos(window, x, y, width, height):
     """Helper to set the window position."""
     # TODO: Special case for full screen move - use os-native maximize, rather
@@ -70,14 +57,15 @@ def _move_to_screen(
     ), "Provide exactly one of `screen_number` or `offset`."
 
     src_screen = window.screen
-    screens = sorted_screens()
-    if offset:
-        screen_number = (screens.index(src_screen) + offset) % len(screens)
-    else:
-        # Human to array index
-        screen_number -= 1
 
-    dest_screen = screens[screen_number]
+    if offset:
+        if offset < 0:
+            dest_screen = actions.user.screens_get_previous(src_screen)
+        else:
+            dest_screen = actions.user.screens_get_next(src_screen)
+    else:
+        dest_screen = actions.user.screens_get_by_number(screen_number)
+
     if src_screen == dest_screen:
         return
 

--- a/misc/screens.talon
+++ b/misc/screens.talon
@@ -1,0 +1,1 @@
+screen numbers:   user.screens_show_numbering()

--- a/misc/screenshot.talon
+++ b/misc/screenshot.talon
@@ -1,6 +1,8 @@
-^grab screen$:      user.screenshot()
-^grab window$:      user.screenshot_window()
-^grab selection$:   user.screenshot_selection()
+^grab screen$:                       user.screenshot()
+^grab screen <number_small>$:        user.screenshot(number_small)
+^grab window$:                       user.screenshot_window()
+^grab selection$:                    user.screenshot_selection()
 
-^grab screen clip$: user.screenshot_clipboard()
-^grab window clip$: user.screenshot_window_clipboard()
+^grab screen clip$:                  user.screenshot_clipboard()
+^grab screen <number_small> clip$:   user.screenshot_clipboard(number_small)
+^grab window clip$:                  user.screenshot_window_clipboard()


### PR DESCRIPTION
* Created screens module to have a unified ordering and management of screens
* Added command `screen numbers` to show screen numbering on each screen. 
* Added commands `grab screen <number_small>` and `grab screen <number_small> clip` to grab a specific screen by a number
     - Issue #491
* Updated window_snap to use the same screen ordering