### PR TITLE
Add right-drag command to Talon

### DIFF
--- a/code/mouse.py
+++ b/code/mouse.py
@@ -148,20 +148,25 @@ class Actions:
         if eye_zoom_mouse.zoom_mouse.enabled:
             eye_zoom_mouse.zoom_mouse.on_pop(eye_zoom_mouse.zoom_mouse.state)
 
-    def mouse_drag():
+    def mouse_drag(button: int):
         """(TEMPORARY) Press and hold/release button 0 depending on state for dragging"""
         # todo: fixme temporary fix for drag command
         button_down = len(list(ctrl.mouse_buttons_down())) > 0
         # print(str(ctrl.mouse_buttons_down()))
         if not button_down:
             # print("start drag...")
-            ctrl.mouse_click(button=0, down=True)
+            ctrl.mouse_click(button=button, down=True)
             # app.notify("drag started")
         else:
+            # End any active drags
             # print("end drag...")
-            ctrl.mouse_click(button=0, up=True)
+            self.end_drag(0)
+            self.end_drag(1)
 
         # app.notify("drag stopped")
+    def end_drag(button: int):
+        """ Releases the specified mouse button """
+        ctrl.mouse_click(button=button, up=True)
 
     def mouse_sleep():
         """Disables control mouse, zoom mouse, and re-enables cursor"""

--- a/code/mouse.py
+++ b/code/mouse.py
@@ -150,20 +150,8 @@ class Actions:
 
     def mouse_drag(button: int):
         """(TEMPORARY) Press and hold/release button 0 depending on state for dragging"""
-        # todo: fixme temporary fix for drag command
-        button_down = len(list(ctrl.mouse_buttons_down())) > 0
-        # print(str(ctrl.mouse_buttons_down()))
-        if not button_down:
-            # print("start drag...")
-            ctrl.mouse_click(button=button, down=True)
-            # app.notify("drag started")
-        else:
-            # End any active drags
-            # print("end drag...")
-            self.end_drag(0)
-            self.end_drag(1)
+        ctrl.mouse_click(button=button, down=True)
 
-        # app.notify("drag stopped")
     def end_drag(button: int):
         """ Releases the specified mouse button """
         ctrl.mouse_click(button=button, up=True)

--- a/code/mouse.py
+++ b/code/mouse.py
@@ -150,11 +150,17 @@ class Actions:
 
     def mouse_drag(button: int):
         """(TEMPORARY) Press and hold/release button 0 depending on state for dragging"""
+        # Clear any existing drags
+        self.mouse_drag_end()
+
+        # Start drag
         ctrl.mouse_click(button=button, down=True)
 
-    def end_mouse_drag(button: int):
-        """ Releases the specified mouse button """
-        ctrl.mouse_click(button=button, up=True)
+    def mouse_drag_end():
+        """ Releases any held mouse buttons """
+        buttons_held_down = list(ctrl.mouse_buttons_down())
+        for button in buttons_held_down:
+            ctrl.mouse_click(button=button, up=True)
 
     def mouse_sleep():
         """Disables control mouse, zoom mouse, and re-enables cursor"""

--- a/code/mouse.py
+++ b/code/mouse.py
@@ -152,7 +152,7 @@ class Actions:
         """(TEMPORARY) Press and hold/release button 0 depending on state for dragging"""
         ctrl.mouse_click(button=button, down=True)
 
-    def end_drag(button: int):
+    def end_mouse_drag(button: int):
         """ Releases the specified mouse button """
         ctrl.mouse_click(button=button, up=True)
 

--- a/code/mouse.py
+++ b/code/mouse.py
@@ -149,7 +149,7 @@ class Actions:
             eye_zoom_mouse.zoom_mouse.on_pop(eye_zoom_mouse.zoom_mouse.state)
 
     def mouse_drag(button: int):
-        """(TEMPORARY) Press and hold/release button 0 depending on state for dragging"""
+        """Press and hold/release a specific mouse button for dragging"""
         # Clear any existing drags
         self.mouse_drag_end()
 

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -6,7 +6,8 @@ touch:
 	mouse_click(0)
 	# close the mouse grid if open
 	user.grid_close()
-    	# End any open drags. Touch automatically ends left drags so this is for right-drags specifically.
+    	# End any open drags
+	# Touch automatically ends left drags so this is for right-drags specifically
 	user.mouse_drag_end()
 
 righty:

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -6,8 +6,10 @@ touch:
 	mouse_click(0)
 	# close the mouse grid if open
 	user.grid_close()
+    # End right drag if open so that touch ends both types of drags
+	user.end_drag(1)
 
-righty: 
+righty:
 	mouse_click(1)
 	# close the mouse grid if open
 	user.grid_close()
@@ -47,8 +49,12 @@ midclick:
 	mouse_click()
 	# close the mouse grid
 	user.grid_close()
-drag: 
-	user.mouse_drag()
+drag:
+	user.mouse_drag(0)
+	# close the mouse grid
+	user.grid_close()
+right drag:
+	user.mouse_drag(1)
 	# close the mouse grid
 	user.grid_close()
 wheel down: user.mouse_scroll_down()

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -6,7 +6,7 @@ touch:
 	mouse_click(0)
 	# close the mouse grid if open
 	user.grid_close()
-    # End right drag if open so that touch ends both types of drags
+    	# End any open drags. Touch automatically ends left drags so this is for right-drags specifically.
 	user.mouse_drag_end()
 
 righty:

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -57,6 +57,9 @@ right drag:
 	user.mouse_drag(1)
 	# close the mouse grid
 	user.grid_close()
+end (left | right) drag:
+    user.end_drag(0)
+    user.end_drag(1)
 wheel down: user.mouse_scroll_down()
 wheel down here:
     user.mouse_move_center_active_window()

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -7,7 +7,7 @@ touch:
 	# close the mouse grid if open
 	user.grid_close()
     # End right drag if open so that touch ends both types of drags
-	user.end_drag(1)
+	user.end_mouse_drag(1)
 
 righty:
 	mouse_click(1)
@@ -58,8 +58,8 @@ right drag:
 	# close the mouse grid
 	user.grid_close()
 end (left | right) drag:
-    user.end_drag(0)
-    user.end_drag(1)
+    user.end_mouse_drag(0)
+    user.end_mouse_drag(1)
 wheel down: user.mouse_scroll_down()
 wheel down here:
     user.mouse_move_center_active_window()

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -49,7 +49,7 @@ midclick:
 	mouse_click()
 	# close the mouse grid
 	user.grid_close()
-drag:
+(left) drag:
 	user.mouse_drag(0)
 	# close the mouse grid
 	user.grid_close()

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -7,7 +7,7 @@ touch:
 	# close the mouse grid if open
 	user.grid_close()
     # End right drag if open so that touch ends both types of drags
-	user.end_mouse_drag(1)
+	user.mouse_drag_end()
 
 righty:
 	mouse_click(1)
@@ -49,17 +49,16 @@ midclick:
 	mouse_click()
 	# close the mouse grid
 	user.grid_close()
-(left drag) | drag:
+left drag | drag:
 	user.mouse_drag(0)
 	# close the mouse grid
 	user.grid_close()
-right drag:
+right drag | righty drag:
 	user.mouse_drag(1)
 	# close the mouse grid
 	user.grid_close()
-end (left | right) drag:
-    user.end_mouse_drag(0)
-    user.end_mouse_drag(1)
+end drag | drag end:
+    user.mouse_drag_end()
 wheel down: user.mouse_scroll_down()
 wheel down here:
     user.mouse_move_center_active_window()

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -7,7 +7,7 @@ touch:
 	# close the mouse grid if open
 	user.grid_close()
     	# End any open drags
-	# Touch automatically ends left drags so this is for right-drags specifically
+	# Touch automatically ends left drags so this is for right drags specifically
 	user.mouse_drag_end()
 
 righty:

--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -49,7 +49,7 @@ midclick:
 	mouse_click()
 	# close the mouse grid
 	user.grid_close()
-(left) drag:
+(left drag) | drag:
 	user.mouse_drag(0)
 	# close the mouse grid
 	user.grid_close()


### PR DESCRIPTION
Adds a command to hold down right-click. This is useful for things like games where right click is used to pan the camera.

Some thoughts/design decisions here:
* the `mouse_drag` function was quite complicated since it had several responsibilities: starting drags and ending drags. Once you add a second type of drag this logic gets quite complex since the function now needs to start two types of drags, be able to end two types of drags and be able to switch between two types of drags in the case where one is enabled but not the one requested.
* In order to simplify it and keep functions as modular as possible, I moved ending drags into a separate function. Now `mouse_drag` is purely responsible for starting mouse drags. Drags can now be ended by calling `end drag` and with `touch`