### PR TITLE
Fix 'select word' on mac

### DIFF
--- a/code/platforms/mac/edit.py
+++ b/code/platforms/mac/edit.py
@@ -125,7 +125,7 @@ class EditActions:
         #action(edit.select_paragraph):
         #action(edit.select_sentence):
     def select_word():
-        actions.key('right')
+        actions.edit.right()
         actions.edit.word_left()
         actions.edit.extend_word_right()
         #action(edit.selected_text): -> str

--- a/code/platforms/mac/edit.py
+++ b/code/platforms/mac/edit.py
@@ -125,6 +125,7 @@ class EditActions:
         #action(edit.select_paragraph):
         #action(edit.select_sentence):
     def select_word():
+        actions.key('right')
         actions.edit.word_left()
         actions.edit.extend_word_right()
         #action(edit.selected_text): -> str


### PR DESCRIPTION
Fixes https://github.com/knausj85/knausj_talon/issues/499 by moving one character to the right before selecting the current word.

This handles both the edge case where you are on the left-most character of a word and where you are on the right-most character of a word