### PR TITLE
Workspace switching support

### DIFF
--- a/code/platforms/mac/workspaces.py
+++ b/code/platforms/mac/workspaces.py
@@ -1,0 +1,19 @@
+from talon import Context, Module, actions
+ctx = Context()
+ctx.matches = r"""
+os: mac
+"""
+
+@ctx.action_class('user')
+class UserActions:
+    def workspace_next():
+        """Move to next workspace"""
+        actions.key('ctrl-right')
+
+    def workspace_last():
+        """Move to previous workspace"""
+        actions.key('ctrl-left')
+
+    def workspace_show():
+        """Show / manage workspaces"""
+        actions.key('ctrl-up')

--- a/code/platforms/win/workspaces.py
+++ b/code/platforms/win/workspaces.py
@@ -1,0 +1,19 @@
+from talon import Context, Module, actions
+ctx = Context()
+ctx.matches = r"""
+os: windows
+"""
+
+@ctx.action_class('user')
+class UserActions:
+    def workspace_next():
+        """Move to next workspace"""
+        actions.key('ctrl-super-right')
+
+    def workspace_last():
+        """Move to previous workspace"""
+        actions.key('ctrl-super-left')
+
+    def workspace_show():
+        """Show / manage workspaces"""
+        actions.key('super-tab')

--- a/code/workspaces.py
+++ b/code/workspaces.py
@@ -1,0 +1,14 @@
+from talon import Module, actions
+
+mod = Module()
+
+@mod.action_class
+class Actions:
+    def workspace_next():
+        """Move to next workspace"""
+
+    def workspace_last():
+        """Move to previous workspace"""
+
+    def workspace_show():
+        """Show / manage workspaces"""

--- a/misc/workspaces.talon
+++ b/misc/workspaces.talon
@@ -1,0 +1,3 @@
+workspace next: user.workspace_next()
+workspace last: user.workspace_last()
+workspace show: user.workspace_show()


### PR DESCRIPTION
Basic support for moving between workspaces.

Comes with Mac and Windows keybindings. Ideally we'd also add linux ones (though I imagine they'll be different between WDMs, which is problematic), as well as other commands in richer environments, eg moving windows between workspaces.