### PR TITLE
Add Pound Sterling (£) Sign

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -171,7 +171,6 @@ symbol_key_words = {
     "plus": "+",
     "tilde": "~",
     "bang": "!",
-    "dollar": "$",
     "down score": "_",
     "under score": "_",
     "paren": "(",
@@ -191,7 +190,6 @@ symbol_key_words = {
     "right angle": ">",
     "greater than": ">",
     "star": "*",
-    "pound": "#",
     "hash": "#",
     "percent": "%",
     "caret": "^",
@@ -199,6 +197,12 @@ symbol_key_words = {
     "pipe": "|",
     "dubquote": '"',
     "double quote": '"',
+
+    # Currencies
+    "dollar": "$",
+    "dollar sign": "$",
+    "pound": "£",
+    "pound sign": "£",
 }
 
 # make punctuation words also included in {user.symbol_keys}

--- a/code/keys.py
+++ b/code/keys.py
@@ -125,10 +125,8 @@ ctx.lists["self.modifier_key"] = modifier_keys
 alphabet = dict(zip(default_alphabet, letters_string))
 ctx.lists["self.letter"] = alphabet
 
-# `punctuation_words` is for words you want available BOTH in dictation and as
-# key names in command mode.
-# `symbol_key_words` is for key names that should be
-# available in command mode, but NOT during dictation.
+# `punctuation_words` is for words you want available BOTH in dictation and as key names in command mode.
+# `symbol_key_words` is for key names that should be available in command mode, but NOT during dictation.
 punctuation_words = {
     # TODO: I'm not sure why we need these, I think it has something to do with
     # Dragon. Possibly it has been fixed by later improvements to talon? -rntz

--- a/code/keys.py
+++ b/code/keys.py
@@ -130,6 +130,8 @@ ctx.lists["self.letter"] = alphabet
 # `symbol_key_words` is for key names that should be
 # available in command mode, but NOT during dictation.
 punctuation_words = {
+    # TODO: I'm not sure why we need these, I think it has something to do with
+    # Dragon. Possibly it has been fixed by later improvements to talon? -rntz
     "`": "`",
     ",": ",",  # <== these things
     "back tick": "`",

--- a/code/keys.py
+++ b/code/keys.py
@@ -126,11 +126,10 @@ alphabet = dict(zip(default_alphabet, letters_string))
 ctx.lists["self.letter"] = alphabet
 
 # `punctuation_words` is for words you want available BOTH in dictation and as
-# key names in command mode. `symbol_key_words` is for key names that should be
+# key names in command mode.
+# `symbol_key_words` is for key names that should be
 # available in command mode, but NOT during dictation.
 punctuation_words = {
-    # TODO: I'm not sure why we need these, I think it has something to do with
-    # Dragon. Possibly it has been fixed by later improvements to talon? -rntz
     "`": "`",
     ",": ",",  # <== these things
     "back tick": "`",
@@ -144,7 +143,6 @@ punctuation_words = {
     "question mark": "?",
     "exclamation mark": "!",
     "exclamation point": "!",
-    "dollar sign": "$",
     "asterisk": "*",
     "hash sign": "#",
     "number sign": "#",
@@ -152,6 +150,10 @@ punctuation_words = {
     "at sign": "@",
     "and sign": "&",
     "ampersand": "&",
+
+    # Currencies
+    "dollar sign": "$",
+    "pound sign": "£",
 }
 symbol_key_words = {
     "dot": ".",
@@ -200,9 +202,7 @@ symbol_key_words = {
 
     # Currencies
     "dollar": "$",
-    "dollar sign": "$",
     "pound": "£",
-    "pound sign": "£",
 }
 
 # make punctuation words also included in {user.symbol_keys}


### PR DESCRIPTION
This adds a symbol for the british currency, the pound sterling.

Relates to https://github.com/knausj85/knausj_talon/issues/512

This also sets us up as @rntz suggested to be able to use the term `{currency} sign` for various other currencies.

Since this removes one of the commands which creates a `#` symbol, I'd love to get multiple approvals and welcome any discussion.