### PR TITLE
Fix select word on Windows and Linux

### DIFF
--- a/code/platforms/linux/edit.py
+++ b/code/platforms/linux/edit.py
@@ -125,12 +125,9 @@ class EditActions:
         #action(edit.select_paragraph):
         #action(edit.select_sentence):
     def select_word():
-        actions.key('ctrl-left ctrl-shift-right')
-        #action(edit.selected_text): -> str
-        #action(edit.sentence_end):
-        #action(edit.sentence_next):
-        #action(edit.sentence_previous):
-        #action(edit.sentence_start):
+        actions.edit.right()
+        actions.edit.word_left()
+        actions.edit.extend_word_right()
     def undo():
         actions.key('ctrl-z')
     def up():

--- a/code/platforms/mac/edit.py
+++ b/code/platforms/mac/edit.py
@@ -128,11 +128,6 @@ class EditActions:
         actions.edit.right()
         actions.edit.word_left()
         actions.edit.extend_word_right()
-        #action(edit.selected_text): -> str
-        #action(edit.sentence_end):
-        #action(edit.sentence_next):
-        #action(edit.sentence_previous):
-        #action(edit.sentence_start):
     def undo():
         actions.key('cmd-z')
     def up():

--- a/code/platforms/win/edit.py
+++ b/code/platforms/win/edit.py
@@ -125,12 +125,9 @@ class EditActions:
         #action(edit.select_paragraph):
         #action(edit.select_sentence):
     def select_word():
-        actions.key('ctrl-left ctrl-shift-right')
-        #action(edit.selected_text): -> str
-        #action(edit.sentence_end):
-        #action(edit.sentence_next):
-        #action(edit.sentence_previous):
-        #action(edit.sentence_start):
+        actions.edit.right()
+        actions.edit.word_left()
+        actions.edit.extend_word_right()
     def undo():
         actions.key('ctrl-z')
     def up():


### PR DESCRIPTION
Fixes the select word edge case [here](https://github.com/knausj85/knausj_talon/issues/526).

The edge case involves having the cursor just before the very first character of the word and the `select word` command selecting the word before the current word.

It would be great if any windows or linux users could give this a quick test since I'm not able to run it.
