### PR TITLE
Add Evernote module to Talon

### DIFF
--- a/apps/evernote/evernote.talon
+++ b/apps/evernote/evernote.talon
@@ -2,5 +2,5 @@ app: evernote
 -
 settings():
     # Necessary to stop commands like 'slap' getting jumbled
-    key_wait = 4.0
+    key_wait = 6.0
 

--- a/apps/evernote/evernote.talon
+++ b/apps/evernote/evernote.talon
@@ -1,0 +1,6 @@
+app: evernote
+-
+settings():
+    # Necessary to stop commands like 'slap' getting jumbled
+    key_wait = 4.0
+

--- a/apps/evernote/mac.talon
+++ b/apps/evernote/mac.talon
@@ -1,4 +1,5 @@
 app: evernote
+os: mac
 -
 settings():
     # Necessary to stop commands like 'slap' getting jumbled


### PR DESCRIPTION
There are a couple of things I'd like to add to this module eventually, but the main pain point of using Talon with Evernote is that it's a text editor but `slap` often gets jumbled. Adding the key delay fixes that. Hopefully this helps others.

I played around with different delays for a while to try to find one that made slap always work while introducing minimal delay. If anyone else ends up having issues with this though, we can always increase it later on.

Note that this is an issue that I have on Evernote for Mac. In the past I found the Windows app to be much faster and we may end up wanting to split this into a Mac-only delay.