### PR TITLE
`quote that` and `inside quotes` changes

### DIFF
--- a/text/symbols.talon
+++ b/text/symbols.talon
@@ -41,7 +41,7 @@ inside (bracket | braces):
 inside percent:
 	insert("%%")
 	key(left)
-inside quotes:
+inside (quotes | string):
 	insert("''")
 	key(left)
 inside (double quotes | dubquotes):

--- a/text/symbols.talon
+++ b/text/symbols.talon
@@ -41,7 +41,7 @@ inside (bracket | braces):
 inside percent:
 	insert("%%")
 	key(left)
-inside (quotes | string):
+inside quotes:
 	insert("''")
 	key(left)
 inside (double quotes | dubquotes):

--- a/text/symbols.talon
+++ b/text/symbols.talon
@@ -65,7 +65,7 @@ angle that:
 percent that:
     text = edit.selected_text()
     user.paste("%{text}%")
-(quote | string) that:
+quote that:
     text = edit.selected_text()
     user.paste("'{text}'")
 (double quote | dubquote) that:

--- a/text/symbols.talon
+++ b/text/symbols.talon
@@ -41,8 +41,11 @@ inside (bracket | braces):
 inside percent:
 	insert("%%")
 	key(left)
-inside quotes:
-	insert('""')
+inside (quotes | string):
+	insert("''")
+	key(left)
+inside (double quotes | dubquotes):
+    insert('""')
 	key(left)
 inside (graves | back ticks):
 	insert("``")
@@ -62,7 +65,10 @@ angle that:
 percent that:
     text = edit.selected_text()
     user.paste("%{text}%")
-quote that:
+(quote | string) that:
+    text = edit.selected_text()
+    user.paste("'{text}'")
+(double quote | dubquote) that:
     text = edit.selected_text()
     user.paste('"{text}"')
 (grave | back tick) that:


### PR DESCRIPTION
1. Adds a command to insert single quotes around text
2. Makes the command for single quotes and double quotes consistent with [keys.py](https://github.com/knausj85/knausj_talon/blob/master/code/keys.py#L159-L201)
3. Adds a 'string' option when making single quotes in order to be consistent with the 'string' command


Because this changes the behavior of the existing `quote that` and `inside quotes` commands, I'd love to get a few reviews and some discussion.