### PR TITLE
Adds strikethrough functionality to Talon..

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -103,6 +103,7 @@ def every_word(word_func):
     return formatter_function
 
 
+# TODO - these tuples getting quite complicated, we should make a class with a clear, documented structure instead
 formatters_dict = {
     "NOOP": (SEP, lambda i, word, _: word),
     "DOUBLE_UNDERSCORE": (NOSEP, first_vs_rest(lambda w: "__%s__" % w)),
@@ -297,25 +298,30 @@ class Actions:
 def strikethrough_character(character):
     return character + u'\u0336'
 
+
 def strikethrough_word(word):
     return "".join([strikethrough_character(character) for character in word])
 
+
 symbols_to_ignore_when_unformatting = [
-    u'\u0336' # Strikethrough character
+    u'\u0336'  # Strikethrough character
 ]
+
 
 def unformat_text(text: str) -> str:
     """Remove format from text"""
 
     # Remove certain symbols which don't signify a new word
+    unformatted = text
     for symbol in symbols_to_ignore_when_unformatting:
         unformatted = text.replace(symbol, '')
 
-    # Replace all remaining symbols with spaces
+    # Replace symbols with spaces
     unformatted = re.sub(r"[^a-zA-Z0-9]+", " ", unformatted)
 
     # Split on camelCase, including numbers
-    unformatted = re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-zA-Z])(?=[0-9])|(?<=[0-9])(?=[a-zA-Z])", " ", unformatted)
+    unformatted = re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-zA-Z])(?=[0-9])|(?<=[0-9])(?=[a-zA-Z])",
+                         " ", unformatted)
     # TODO: Separate out studleycase vars
     return unformatted.lower()
 

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -103,7 +103,7 @@ def every_word(word_func):
     return formatter_function
 
 
-# TODO - these tuples getting quite complicated, we should make a class with a clear, documented structure instead
+# TODO - these tuples getting quite complicated, we should make a formatter class instead
 formatters_dict = {
     "NOOP": (SEP, lambda i, word, _: word),
     "DOUBLE_UNDERSCORE": (NOSEP, first_vs_rest(lambda w: "__%s__" % w)),
@@ -156,6 +156,7 @@ formatters_words = {
     "allcaps": formatters_dict["ALL_CAPS"],
     "alldown": formatters_dict["ALL_LOWERCASE"],
     "camel": formatters_dict["PRIVATE_CAMEL_CASE"],
+    "no format": formatters_dict["NOOP"],
     "dotted": formatters_dict["DOT_SEPARATED"],
     "dubstring": formatters_dict["DOUBLE_QUOTED_STRING"],
     "dunder": formatters_dict["DOUBLE_UNDERSCORE"],
@@ -280,7 +281,7 @@ class Actions:
         # selected text (e.g. Emacs)
         edit.delete()
 
-        text = actions.user.formatted_text(selected, formatters)
+        text = actions.user.formatted_text(unformatted, formatters)
         actions.user.paste(text)
         return text
 
@@ -311,10 +312,10 @@ symbols_to_ignore_when_unformatting = [
 def unformat_text(text: str) -> str:
     """Remove format from text"""
 
-    # Remove certain symbols which don't signify a new word
+    # Remove symbols which should be ignored rather than used as word splits
     unformatted = text
     for symbol in symbols_to_ignore_when_unformatting:
-        unformatted = text.replace(symbol, '')
+        unformatted = unformatted.replace(symbol, "")
 
     # Replace symbols with spaces
     unformatted = re.sub(r"[^a-zA-Z0-9]+", " ", unformatted)

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -293,20 +293,32 @@ class Actions:
         for string in strings:
             actions.user.paste(string)
 
-def unformat_text(text: str) -> str:
-    """Remove format from text"""
-    # Strip all symbols and replace with spaces
-    unformatted = re.sub(r"[^a-zA-Z0-9]+", " ", text)
-    # Split on camelCase, including numbers
-    unformatted = re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-zA-Z])(?=[0-9])|(?<=[0-9])(?=[a-zA-Z])", " ", unformatted)
-    # TODO: Separate out studleycase vars
-    return unformatted.lower()
 
 def strikethrough_character(character):
     return character + u'\u0336'
 
 def strikethrough_word(word):
     return "".join([strikethrough_character(character) for character in word])
+
+symbols_to_ignore_when_unformatting = [
+    u'\u0336' # Strikethrough character
+]
+
+def unformat_text(text: str) -> str:
+    """Remove format from text"""
+
+    # Remove certain symbols which don't signify a new word
+    for symbol in symbols_to_ignore_when_unformatting:
+        unformatted = text.replace(symbol, '')
+
+    # Replace all remaining symbols with spaces
+    unformatted = re.sub(r"[^a-zA-Z0-9]+", " ", unformatted)
+
+    # Split on camelCase, including numbers
+    unformatted = re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-zA-Z])(?=[0-9])|(?<=[0-9])(?=[a-zA-Z])", " ", unformatted)
+    # TODO: Separate out studleycase vars
+    return unformatted.lower()
+
 
 ctx.lists["self.formatters"] = formatters_words.keys()
 ctx.lists["self.prose_formatter"] = {

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -112,6 +112,13 @@ formatters_dict = {
         first_vs_rest(lambda w: w, lambda w: w.capitalize()),
     ),
     "PUBLIC_CAMEL_CASE": (NOSEP, every_word(lambda w: w.capitalize())),
+    "STRIKETHROUGH": (
+        NOSEP,
+        first_vs_rest(
+            lambda w: strikethrough_word(w),
+            lambda w: strikethrough_character(" ") + strikethrough_word(w),
+        )
+    ),
     "SNAKE_CASE": (
         NOSEP,
         first_vs_rest(lambda w: w.lower(), lambda w: "_" + w.lower()),
@@ -162,6 +169,7 @@ formatters_words = {
     "snake": formatters_dict["SNAKE_CASE"],
     # "speak": formatters_dict["NOOP"],
     "string": formatters_dict["SINGLE_QUOTED_STRING"],
+    "strikethrough": formatters_dict["STRIKETHROUGH"],
     "title": formatters_dict["CAPITALIZE_ALL_WORDS"],
     # disable a few formatters for now
     # "tree": formatters_dict["FIRST_THREE"],
@@ -281,6 +289,8 @@ class Actions:
 
     def insert_many(strings: List[str]) -> None:
         """Insert a list of strings, sequentially."""
+        print("strings xd")
+        print(strings)
         for string in strings:
             actions.insert(string)
 
@@ -292,6 +302,11 @@ def unformat_text(text: str) -> str:
     # TODO: Separate out studleycase vars
     return unformatted.lower()
 
+def strikethrough_character(character):
+    return character + u'\u0336'
+
+def strikethrough_word(word):
+    return "".join([strikethrough_character(character) for character in word])
 
 ctx.lists["self.formatters"] = formatters_words.keys()
 ctx.lists["self.prose_formatter"] = {

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -278,8 +278,9 @@ class Actions:
         # Delete separately for compatibility with programs that don't overwrite
         # selected text (e.g. Emacs)
         edit.delete()
-        text = actions.self.formatted_text(unformatted, formatters)
-        actions.insert(text)
+
+        text = actions.user.formatted_text(selected, formatters)
+        actions.user.paste(text)
         return text
 
     def reformat_text(text: str, formatters: str) -> str:
@@ -289,15 +290,14 @@ class Actions:
 
     def insert_many(strings: List[str]) -> None:
         """Insert a list of strings, sequentially."""
-        print("strings xd")
-        print(strings)
         for string in strings:
-            actions.insert(string)
+            actions.user.paste(string)
 
 def unformat_text(text: str) -> str:
     """Remove format from text"""
+    # Strip all symbols and replace with spaces
     unformatted = re.sub(r"[^a-zA-Z0-9]+", " ", text)
-    # Split on camelCase, including numbes
+    # Split on camelCase, including numbers
     unformatted = re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-zA-Z])(?=[0-9])|(?<=[0-9])(?=[a-zA-Z])", " ", unformatted)
     # TODO: Separate out studleycase vars
     return unformatted.lower()


### PR DESCRIPTION
..as a formatter

Relates to https://github.com/knausj85/knausj_talon/issues/528

**Example**

> This is regular text
> t̶h̶i̶s̶ ̶i̶s̶ ̶t̶e̶x̶t̶ ̶w̶i̶t̶h̶ ̶t̶h̶e̶ ̶s̶t̶r̶i̶k̶e̶t̶h̶r̶o̶u̶g̶h̶ ̶f̶o̶r̶m̶a̶t̶t̶e̶r̶ 

**Of note:**

1. Pasting has to be used for writing formatters (`actions.user.paste()`) since Talon can't insert special characters in some cases. This is generally fine and we do it all over the place, but may be slightly vexing for those with clipboard history managers. 
I have an [issue](https://github.com/knausj85/knausj_talon/issues/539) open to make formatters specify whether they need pasting or are happy with insertion.

2. This adds the `no format` formatter in order to undo strikethrough (and other future formatters)
3. The formatter doesn't yet preserve case (since all formatters call `unformat` by default which clears case). We can track this as future work.
I have an [issue](https://github.com/knausj85/knausj_talon/issues/539) open to make formatters specify whether they need `unformat` applied.
