### PR TITLE
Make sure homophones always retain case

### DIFF
--- a/code/homophones.py
+++ b/code/homophones.py
@@ -61,11 +61,11 @@ PHONES_FORMATTERS = [
     lambda word: word.upper(),
 ]
 
-def determine_format_function_to_apply(word_to_find_phones_for, formatters):
-    """ Find the formatter used for the word being 'phoned' in order to know how to format its homophones """
+def determine_format_function_to_apply(word_to_find_formatter_for, formatters):
+    """ Find the formatter used for the word being 'phoned'"""
     for formatter in formatters:
-        formatted_word = formatter(word_to_find_phones_for)
-        if word_to_find_phones_for == formatted_word:
+        formatted_word = formatter(word_to_find_formatter_for)
+        if word_to_find_formatter_for == formatted_word:
             return formatter
 
     # If no formatters work, don't format the options

--- a/code/homophones.py
+++ b/code/homophones.py
@@ -69,7 +69,6 @@ def find_matching_format_function(word_with_formatting, format_functions):
         if word_with_formatting == formatted_word:
             return formatter
 
-    # If no formatters work, don't format the options
     return lambda word: word
 
 

--- a/code/homophones.py
+++ b/code/homophones.py
@@ -61,11 +61,12 @@ PHONES_FORMATTERS = [
     lambda word: word.upper(),
 ]
 
-def determine_format_function_to_apply(word_to_find_formatter_for, formatters):
-    """ Find the formatter used for the word being 'phoned'"""
-    for formatter in formatters:
-        formatted_word = formatter(word_to_find_formatter_for)
-        if word_to_find_formatter_for == formatted_word:
+def find_matching_format_function(word_with_formatting, format_functions):
+    """ Finds the formatter function from a list of formatter functions which transforms a word into itself.
+     Returns an identity function if none exists """
+    for formatter in format_functions:
+        formatted_word = formatter(word_with_formatting)
+        if word_with_formatting == formatted_word:
             return formatter
 
     # If no formatters work, don't format the options
@@ -85,7 +86,8 @@ def raise_homophones(word, forced=False, selection=False):
     if is_selection:
         word = word.strip()
 
-    formatter = determine_format_function_to_apply(word, PHONES_FORMATTERS)
+    # Find the formatter used for the word being 'phoned'
+    formatter = find_matching_format_function(word, PHONES_FORMATTERS)
 
     word = word.lower()
 
@@ -95,7 +97,7 @@ def raise_homophones(word, forced=False, selection=False):
 
     # Lookup valid homophones and format them to match the current selection
     valid_homophones = all_homophones[word]
-    active_word_list = list(map(lambda homophone: formatter(homophone), valid_homophones))
+    active_word_list = list(map(formatter, valid_homophones))
 
     if (
             is_selection

--- a/code/homophones.py
+++ b/code/homophones.py
@@ -1,8 +1,6 @@
 from talon import Context, Module, app, clip, cron, imgui, actions, ui, fs
 import os
 
-# from formatters import formatters_words, format_phrase
-
 ########################################################################
 # global settings
 ########################################################################

--- a/code/homophones.py
+++ b/code/homophones.py
@@ -96,9 +96,8 @@ def raise_homophones(word, forced=False, selection=False):
         return
 
     # Lookup valid homophones and format them to match the current selection
-    valid_homophones = all_homophones[word];
-    valid_homophones = list(map(lambda homophone: formatter(homophone), valid_homophones))
-    active_word_list = valid_homophones
+    valid_homophones = all_homophones[word]
+    active_word_list = list(map(lambda homophone: formatter(homophone), valid_homophones))
 
     if (
             is_selection


### PR DESCRIPTION
There is an edge case in https://github.com/knausj85/knausj_talon/issues/501 where homophones picked from the GUI always became lower case no matter what the case of the original word was.

**Example of new case matching when picking from the GUI**
![image](https://user-images.githubusercontent.com/9077250/128162048-eb2d3539-f325-4518-b1a7-880486b54ae4.png)


**In terms of integration with Talon formatters:**
I spent a bit of time working on making this work with formatters from format.py, but ultimately decided that it was unnecessary since the basic `capitalise` and `upper` formatters cover most (all?) `phones` use cases for now. It shouldn't be very hard to extend to use the Talon formatters later if we ever see a need.