### PR TITLE
Add a small delay to tab close on Chrome

### DIFF
--- a/apps/chrome/chrome.py
+++ b/apps/chrome/chrome.py
@@ -34,6 +34,10 @@ class user_actions:
         else:
             actions.key("ctrl-9")
 
+    def tab_close_wrapper():
+        actions.sleep("180ms")
+        actions.app.tab_close()
+
 
 @ctx.action_class("browser")
 class browser_actions:

--- a/code/tabs.py
+++ b/code/tabs.py
@@ -9,3 +9,7 @@ class tab_actions:
 
     def tab_final():
         """Jumps to the final tab"""
+
+    def tab_close_wrapper():
+        """Closes the current tab"""
+        actions.app.tab_close()

--- a/misc/tabs.talon
+++ b/misc/tabs.talon
@@ -3,7 +3,7 @@ tag: user.tabs
 tab (open | new): app.tab_open()
 tab last: app.tab_previous()
 tab next: app.tab_next()
-tab close: app.tab_close()
+tab close: user.tab_close_wrapper()
 tab (reopen|restore): app.tab_reopen()
 go tab <number>: user.tab_jump(number)
 go tab final: user.tab_final()


### PR DESCRIPTION
Fixes `tab close` command when repeating across a large number of tabs.

Relates to https://github.com/knausj85/knausj_talon/issues/454.

While this fixes this command for this issue specifically, I'm still supportive of a generic repeat delay framework rather than handling each case individually like this.

For those wondering why there is a wrapper: I had to add an extra layer of abstraction in order to not need to write the specific OS commands (cmd-w vs ctrl-w, etc) while rewriting the function.

https://user-images.githubusercontent.com/9077250/128190337-a8784b91-f11f-46ec-80f7-666415b0416a.mov

