### PR TITLE
Allow `window_next` and `window_last`..

### DIFF
--- a/code/platforms/mac/app.py
+++ b/code/platforms/mac/app.py
@@ -63,3 +63,4 @@ def switch_window_by_offset_from_current(offset):
         if window is active_window:
             index_of_new_window = (index + offset) % len(windows)
             windows[index_of_new_window].focus()
+            return

--- a/code/platforms/mac/app.py
+++ b/code/platforms/mac/app.py
@@ -56,7 +56,7 @@ def switch_window_by_offset_from_current(offset):
     # Handle case where empty windows with no title show up in the results
     windows = list(filter(lambda local_window: len(local_window.title) > 0, windows))
 
-    # Sort by title since they get reordered on every switch and we want to switch windows in a fixed order
+    # Sort by title as the windows get reordered on every switch and we want to switch windows in a fixed order
     windows.sort(key=lambda local_window: local_window.title)
 
     for (index, window) in enumerate(windows):

--- a/code/platforms/mac/app.py
+++ b/code/platforms/mac/app.py
@@ -1,33 +1,45 @@
 from talon import Context, actions, ui
+
 ctx = Context()
 ctx.matches = r"""
 os: mac
 """
 
+
 @ctx.action_class('app')
 class AppActions:
     def preferences():
         actions.key('cmd-,')
+
     def tab_close():
         actions.key('cmd-w')
-        #action(app.tab_detach):
+        # action(app.tab_detach):
         #  Move the current tab to a new window
+
     def tab_next():
         actions.key('cmd-alt-right')
+
     def tab_open():
         actions.key('cmd-t')
+
     def tab_previous():
         actions.key('cmd-alt-left')
+
     def tab_reopen():
         actions.key('cmd-shift-t')
+
     def window_close():
         actions.key('cmd-w')
+
     def window_hide():
         actions.key('cmd-m')
+
     def window_hide_others():
         actions.key('cmd-alt-h')
+
     def window_open():
         actions.key('cmd-n')
+
     def window_previous():
         actions.key('cmd-shift-`')
 
@@ -45,10 +57,10 @@ def switch_window_by_offset_from_current(offset):
     windows = ui.active_app().windows()
 
     # Handle case where empty windows with no title show up in the results
-    windows = list(filter(lambda lambda_window: len(lambda_window.title) > 0, windows))
+    windows = list(filter(lambda local_window: len(local_window.title) > 0, windows))
 
     # Sort by title since they get reordered on every switch and we want to switch windows in a fixed order
-    windows.sort(key=lambda lambda_window: lambda_window.title)
+    windows.sort(key=lambda local_window: local_window.title)
 
     for (index, window) in enumerate(windows):
         if window is active_window:

--- a/code/platforms/mac/app.py
+++ b/code/platforms/mac/app.py
@@ -26,6 +26,10 @@ class AppActions:
         actions.key('cmd-m')
     def window_hide_others():
         actions.key('cmd-alt-h')
+    def window_open():
+        actions.key('cmd-n')
+    def window_previous():
+        actions.key('cmd-shift-`')
 
     # Custom behavior to handle Mac desktop 'Spaces'
     def window_next():
@@ -34,11 +38,6 @@ class AppActions:
     # Custom behavior to handle Mac desktop 'Spaces'
     def window_previous():
         switch_window_by_offset_from_current(-1)
-
-    def window_open():
-        actions.key('cmd-n')
-    def window_previous():
-        actions.key('cmd-shift-`')
 
 
 def switch_window_by_offset_from_current(offset):

--- a/code/platforms/mac/app.py
+++ b/code/platforms/mac/app.py
@@ -40,9 +40,6 @@ class AppActions:
     def window_open():
         actions.key('cmd-n')
 
-    def window_previous():
-        actions.key('cmd-shift-`')
-
     # Custom behavior to handle Mac desktop 'Spaces'
     def window_next():
         switch_window_by_offset_from_current(1)

--- a/code/platforms/mac/app.py
+++ b/code/platforms/mac/app.py
@@ -1,4 +1,4 @@
-from talon import Context, actions
+from talon import Context, actions, ui
 ctx = Context()
 ctx.matches = r"""
 os: mac
@@ -26,9 +26,32 @@ class AppActions:
         actions.key('cmd-m')
     def window_hide_others():
         actions.key('cmd-alt-h')
+
+    # Custom behavior to handle Mac desktop 'Spaces'
     def window_next():
-        actions.key('cmd-`')
+        switch_window_by_offset_from_current(1)
+
+    # Custom behavior to handle Mac desktop 'Spaces'
+    def window_previous():
+        switch_window_by_offset_from_current(-1)
+
     def window_open():
         actions.key('cmd-n')
     def window_previous():
         actions.key('cmd-shift-`')
+
+
+def switch_window_by_offset_from_current(offset):
+    active_window = ui.active_window()
+    windows = ui.active_app().windows()
+
+    # Handle case where empty windows with no title show up in the results
+    windows = list(filter(lambda lambda_window: len(lambda_window.title) > 0, windows))
+
+    # Sort by title since they get reordered on every switch and we want to switch windows in a fixed order
+    windows.sort(key=lambda lambda_window: lambda_window.title)
+
+    for (index, window) in enumerate(windows):
+        if window is active_window:
+            index_of_new_window = (index + offset) % len(windows)
+            windows[index_of_new_window].focus()


### PR DESCRIPTION
..to switch to Mac spaces (fullscreen apps).

Relates to https://github.com/knausj85/knausj_talon/issues/456

Currently when one fullscreens an app into a space, it's quite hard to access again with Talon. This makes it so that it's part of the `window_next`, `window_last` rotation so you can easily switch back and forth between windows even if they use spaces.

If anyone disagrees with altering an existing command like this, we can always make this into a new command.

Apologies for the whitespace editions in the same PR, I needed to format the file it to fix my additions and threw the other fixes in too.