### PR TITLE
Stop help active from crashing when changing windows

### DIFF
--- a/code/help.py
+++ b/code/help.py
@@ -178,6 +178,8 @@ def gui_context_help(gui: imgui.GUI):
     global total_page_count
     global search_phrase
 
+    refresh_context_command_map(show_enabled_contexts_only)
+
     # if no selected context, draw the contexts
     if selected_context is None and search_phrase is None:
         total_page_count = get_total_context_pages()


### PR DESCRIPTION
In master, having 'help context' open and changing windows caused it to crash because it didn't have the new window in its dictionary (I think?).

Here is an example:
```
2021-08-05 08:43:33 ERROR cron interval error <bound method GUI._tick of <talon.imgui.GUI object at 0x0000000031682AF0>>
   10:                   threading.py:912* # cron thread
    9:                   threading.py:954*
    8:                   threading.py:892*
    7:                  talon\cron.py:155|
    6:                  talon\cron.py:103|
    5:        talon\scripting\rctx.py:233| # 'cron' user.knausj_talon.code.help:call()
    4:                  talon\cron.py:178| # [stack splice]
    3:                 talon\imgui.py:894|
    2:                 talon\imgui.py:920|
    1: user\knausj_talon\code\help.py:204| context_name = display_name_to_context_name_map[display_name]
KeyError: 'draft global'
```

This change makes it regenerate it's dictionary before it renders, for me fixing this crash. 

This is probably the wrong way to do it! I'm not sure why `display_name_to_context_name_map` doesn't contain all the help pages and not just the active ones. I don't know much python (or much talon scripting) but would it be better to generate this once with everything in it and rely on something else to detect what is and isn't active?