### PR TITLE
Fix editor commands being sent when popup windows are open

### DIFF
--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -138,6 +138,28 @@ and app.exe: rider64.exe
 """
 
 
+@mod.scope
+def is_real_jetbrains_editor():
+
+    window = ui.active_window()
+    active_app = ui.active_app()
+    is_editor = False
+    bundle = active_app.bundle or active_app.name
+    if bundle in port_mapping:
+        # XXX Expose "does editor have focus" as plugin endpoint.
+        # XXX Window title empty in full screen.
+        title = window.title
+        if len(title) == 0 or title == " ":
+            print(f"Window is Jetbrains product but not an editor: {window}")
+        else:
+            is_editor = True
+
+    return {"is_jetbrains_editor": is_editor}
+
+
+ui.register('', is_real_jetbrains_editor.update)
+
+
 @mod.action_class
 class Actions:
     def idea(commands: str):
@@ -162,6 +184,7 @@ class Actions:
 
 ctx.matches = r"""
 app: jetbrains
+user.is_jetbrains_editor: True
 """
 
 

--- a/apps/jetbrains/jetbrains.talon
+++ b/apps/jetbrains/jetbrains.talon
@@ -1,5 +1,6 @@
 # Requires https://plugins.jetbrains.com/plugin/10504-voice-code-idea
 app: jetbrains
+user.is_jetbrains_editor: True
 -
 tag(): user.line_commands
 tag(): user.multiple_cursors


### PR DESCRIPTION
As related to this issue
https://github.com/anonfunc/intellij-voicecode/issues/7
when a non-editor window of a Jetbrains product is open we still
mark Jetbrains commands as active, meaning things like copy/paste
or 'clear line' go to the editor, rather than the popup window.

This was previously implemented using callbacks for the context in
the original Talon.
https://github.com/anonfunc/talon-user/blob/master/apps/jetbrains.py#L303

These have been replaced with scopes. The current scope updates when
the UI fires an event. This does mean if you open the 'actions' dialogue
(via the command 'please') then it doesn't trigger a UI event and the Jetbrains
context is still active. Other popups do trigger a UI event. I'm not sure what the performance hit
would be running the check every second or two via cron so opted for this
instead. Happy for this to be changed if there is no performance issue :-)