### PR TITLE
Prevent talonscript language files from being active in sleep mode

### DIFF
--- a/lang/batch/batch.talon
+++ b/lang/batch/batch.talon
@@ -1,5 +1,7 @@
-mode: user.batch
-mode: user.auto_lang
+mode: command
+and mode: user.batch
+mode: command
+and mode: user.auto_lang
 and code.language: batch
 -
 #tag(): user.code_operators

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -1,5 +1,7 @@
-mode: user.c
-mode: user.auto_lang
+mode: command
+and mode: user.c
+mode: command
+and mode: user.auto_lang
 and code.language: c
 -
 tag(): user.code_operators

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -1,5 +1,7 @@
-mode: user.csharp
-mode: user.auto_lang
+mode: command
+and mode: user.csharp
+mode: command
+and mode: user.auto_lang
 and code.language: csharp
 -
 tag(): user.code_operators

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -1,5 +1,7 @@
-mode: user.javascript
-mode: user.auto_lang
+mode: command
+and mode: user.javascript
+mode: command
+and mode: user.auto_lang
 and code.language: javascript
 -
 tag(): user.code_operators

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -1,5 +1,7 @@
-mode: user.python
-mode: user.auto_lang
+mode: command
+and mode: user.python
+mode: command
+and mode: user.auto_lang
 and code.language: python
 -
 tag(): user.code_operators

--- a/lang/r/r.talon
+++ b/lang/r/r.talon
@@ -1,5 +1,7 @@
-mode: user.r
-mode: user.auto_lang
+mode: command
+and mode: user.r
+mode: command
+and mode: user.auto_lang
 and code.language: r
 -
 # TODO: functions

--- a/lang/ruby/ruby.talon
+++ b/lang/ruby/ruby.talon
@@ -1,5 +1,7 @@
-mode: user.ruby
-mode: user.auto_lang
+mode: command
+and mode: user.ruby
+mode: command
+and mode: user.auto_lang
 and code.language: ruby
 -
 tag(): user.code_operators

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -1,5 +1,7 @@
-mode: user.talon
-mode: user.auto_lang
+mode: command
+and mode: user.talon
+mode: command
+and mode: user.auto_lang
 and code.language: talon
 -
 tag(): user.code_operators

--- a/lang/typescript/typescript.talon
+++ b/lang/typescript/typescript.talon
@@ -1,5 +1,7 @@
-mode: user.typescript
-mode: user.auto_lang
+mode: command
+and mode: user.typescript
+mode: command
+and mode: user.auto_lang
 and code.language: typescript
 -
 tag(): user.code_operators

--- a/lang/vimscript/vimscript.talon
+++ b/lang/vimscript/vimscript.talon
@@ -1,5 +1,7 @@
-mode: user.vimscript
-mode: user.auto_lang
+mode: command
+and mode: user.vimscript
+mode: command
+and mode: user.auto_lang
 and code.language: vimscript
 -
 tag(): user.code_operators


### PR DESCRIPTION
Adding `mode: command` to all talonscript language files to prevent them from being active in sleep mode.