### PR TITLE
Change command client keyboard shortcut

### DIFF
--- a/apps/vscode/command_client/command_client.py
+++ b/apps/vscode/command_client/command_client.py
@@ -350,10 +350,10 @@ class Actions:
     def trigger_command_server_command_execution():
         """Issue keystroke to trigger command server to execute command that
         was written to the file.  For internal use only"""
-        actions.key("ctrl-shift-alt-p")
+        actions.key("ctrl-shift-f17")
 
 
 @mac_ctx.action_class("user")
 class MacUserActions:
     def trigger_command_server_command_execution():
-        actions.key("cmd-shift-alt-p")
+        actions.key("cmd-shift-f17")


### PR DESCRIPTION
Avoids issues on Windows with non-US keyboard layouts with using alt key