### PR TITLE
Add tabby alias (for tab).

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -235,6 +235,7 @@ alternate_keys = {
     #'junk': 'backspace',
     "page up": "pageup",
     "page down": "pagedown",
+    "tabby": "tab",
 }
 # mac apparently doesn't have the menu key.
 if app.platform in ("windows", "linux"):


### PR DESCRIPTION
For me, talon often turns "tab" into "ten". This alternative always seems to work.