### PR TITLE
Let windows with 'VIM' in title be recognized as vim.

### DIFF
--- a/code/application_matches.py
+++ b/code/application_matches.py
@@ -76,3 +76,6 @@ os: windows
 and app.exe: powershell.exe
 """
 
+apps.vim = """
+win.title:/VIM/
+"""


### PR DESCRIPTION
Happy to adopt some other unique token other than 'VIM'.