### PR TITLE
Fix some warnings about unknown tokens

### DIFF
--- a/apps/kubectl/kubectl.talon
+++ b/apps/kubectl/kubectl.talon
@@ -15,7 +15,7 @@ cube edit:           "kubectl edit "
 cube delete:         "kubectl delete "
 
 cube rollout:        "kubectl rollout "
-cube rolling-update: "kubectl rolling-update "
+cube rolling update: "kubectl rolling-update "
 cube scale:          "kubectl scale "
 cube auto scale:     "kubectl autoscale "
 

--- a/code/homophones.csv
+++ b/code/homophones.csv
@@ -376,7 +376,7 @@ mill,mil
 mince,mints
 mind,mined
 minor,miner
-Mrs.,misses
+Mrs,misses
 missile,missal
 missed,mist
 might,mite


### PR DESCRIPTION
This removes some of the warning spam caused by including characters other than a-z in the command graph. There are still some left in keys.py but I didn't touch those since I don't know whether or not dragon users need them.