### PR TITLE
Fix macOS Slack unread command

### DIFF
--- a/apps/slack/slack_mac.talon
+++ b/apps/slack/slack_mac.talon
@@ -19,7 +19,7 @@ workspace <number>: key("cmd-{number}")
 (slack | lack) (my stuff | activity): key(cmd-shift-m)
 (slack | lack) directory: key(cmd-shift-e)
 (slack | lack) (starred [items] | stars): key(cmd-shift-s)
-(slack | lack) unread [messages]: key(cmd-j)
+(slack | lack) unread [messages]: key(cmd-shift-a)
 (go | undo | toggle) full: key(ctrl-cmd-f)
 # Messaging
 grab left: key(shift-up)


### PR DESCRIPTION
cmd-j doesn't seem to do anything, and I presume this is meant to jump to "all unreads" like I think the Windows/Linux one does?

https://github.com/knausj85/knausj_talon/blob/4ac7ba1f6b72f79d6e463b88a288f553627ae446/apps/slack/slack_win.talon#L24