### PR TITLE
fix tab_next and tab_right shortcuts for MacOS

### DIFF
--- a/code/platforms/mac/app.py
+++ b/code/platforms/mac/app.py
@@ -13,11 +13,11 @@ class AppActions:
         #action(app.tab_detach):
         #  Move the current tab to a new window
     def tab_next():
-        actions.key('cmd-alt-right')
+        actions.key('cmd-shift-]')
     def tab_open():
         actions.key('cmd-t')
     def tab_previous():
-        actions.key('cmd-alt-left')
+        actions.key('cmd-shift-[')
     def tab_reopen():
         actions.key('cmd-shift-t')
     def window_close():


### PR DESCRIPTION
`cmd-alt-right` and `cmd-alt-left` work to switch tabs in Firefox and Chrome on MacOS, but not in Safari or Finder.

The 'native' keyboard shortcut for stepping through tabs on MacOS is Control-Tab or Shift-Command-] (for next) and Control-Shift-Tab or Shift-Command -[ (for previous). See the [Safari](https://support.apple.com/en-gb/guide/safari/cpsh003/mac#ibrwc08c3c09) and [MacOS](https://support.apple.com/guide/mac-help/use-tabs-in-windows-mchla4695cce/mac#mchl7799ee89) docs.

Thankfully, the 'native' shortcuts work in Chrome and Firefox as well (in addition to Safari, Finder, etc)