### PR TITLE
Improve WSL error logging

### DIFF
--- a/apps/platforms/win/wsl/wsl.py
+++ b/apps/platforms/win/wsl/wsl.py
@@ -1,8 +1,17 @@
 from talon import Context, Module, actions, imgui, settings, ui, app
+from talon.debug import log_exception
 import os
 import subprocess
+import logging
+import sys
 
 mod = Module()
+# Note: these context matches are specific to ubuntu, but there are other
+# distros one can run under wsl, e.g. docker. for that matter, there are
+# multiple ubuntu distros available. we need a more general way of detecting
+# the current distro, and a way for the user to specify which distro to use
+# for any particular operation. perhaps implement a generic_wsl module and
+# then layer various distros on top of that?
 mod.apps.ubuntu = """
 os: windows
 and app.name: ubuntu.exe
@@ -57,46 +66,119 @@ if app.platform == "windows":
             "Videos": os.path.join(user_path, "Videos"),
         }
 
-
 def get_win_path(wsl_path):
-    path = ""
-    try:
-        path = (
-            subprocess.check_output(["wsl", "wslpath", "-w", wsl_path])
-            .strip(b"\n")
-            .decode()
-        )
-    except:
-        path = ""
-
-    return path
-
+    # for testing
+    #wsl_path = 'Ubuntu-20.04'
+    #wsl_path = '/mnt/qube/woobee/woobee/woobit'
+    #print(f"WINPATH: {wsl_path}")
+    return run_wslpath(["-w"], wsl_path)
 
 def get_usr_path():
-    path = ""
-    try:
-        path = (
-            subprocess.check_output(["wsl", "wslpath", "-a", "~"]).strip(b"\n").decode()
-        )
-    except:
-        path = ""
-
-    return path
-
+    #print(f'USRPATH: {"~"}')
+    return run_wslpath(["-a"], "~")
 
 def get_wsl_path(win_path):
+    #print(f"WSLPATH: {win_path}")
+    return run_wslpath(["-u"], "'{}'".format(win_path))
+
+# this command fails every once in a while, with no indication why.
+# so, when that happens we just retry.
+MAX_ATTEMPTS = 2
+def run_wslpath(args, in_path):
     path = ""
-    try:
-        path = (
-            subprocess.check_output(["wsl", "wslpath", "-u", "'{}'".format(win_path)])
-            .strip(b"\n")
-            .decode()
-        )
-    except:
-        path = ""
+    loop_num = 0
+
+    while loop_num < MAX_ATTEMPTS:
+        (path, error) = run_wsl(['wslpath', *args, in_path])
+        if error:
+            logging.error(f'run_wslpath(): failed to translate given path - attempt: {loop_num}, error: {error}')
+
+            path = ""
+        elif path:
+            # got it, no need to loop and try again
+            break
+
+        loop_num += 1
 
     return path
 
+# Note: seems WSL itself generates utf-16-le errors, whereas your guest os probably does not.
+# - see https://github.com/microsoft/WSL/issues/4607 and related issures. Not sure how this
+# behavior might differ when the system locale has been changed from the default.
+#
+# Anyways, these WSL errors require special handling so they are logged clearly. This is presumably
+# worthwhile given the likely importance of any such messages. For example, which would you rather
+# see in the log?
+#
+#   1. Nothing at all, even though there might be serious problems.
+#
+#   2. b'T\x00h\x00e\x00 \x00W\x00i\x00n\x00d\x00o\x00w\x00s\x00 \x00S\x00u\x00b\x00s\x00y\x00s\x00t\x00e\x00m\x00 \x00f\x00o\x00r\x00 \x00L\x00i\x00n\x00u\x00x\x00 \x00i\x00n\x00s\x00t\x00a\x00n\x00c\x00e\x00 \x00h\x00a\x00s\x00 \x00t\x00e\x00r\x00m\x00i\x00n\x00a\x00t\x00e\x00d\x00.\x00\r\x00\r\x00\n\x00'
+#
+#   3. The Windows Subsystem for Linux instance has terminated.
+#
+# The error above indicates the WSL distro is hung and this result detection mechanism is offline. When
+# that happens, it takes a while for the command to return and the talon watchdog generates messages
+# in the log that indicate a hang but we can provide more contextual detail. The prime thing to do here
+# is to get word to the user that WSL is not responding normally. Note that, even after reaching this
+# state, existing interactive wsl sessions continue to run and so the user may be unaware of the true
+# source of their "talon problems". For more information, see https://github.com/microsoft/WSL/issues/5110
+# and https://github.com/microsoft/WSL/issues/5318.
+#
+def _decode(value: bytes) -> str:
+    # check to see if the given byte string looks like utf-16-le. results may not be correct for all
+    # possible cases, but if there's a problem this code can be replaced with chardet (once that module
+    # covers utf-16-le - see https://github.com/chardet/chardet/pull/109#discussion_r119149003). of
+    # course, by that time wsl might not have the same problem anyways.
+    if (len(value) % 2 == 0) and sum(value[1::2]) == 0:
+        # looks like utf-16-le, see https://github.com/microsoft/WSL/issues/4607 (and related issues).
+        decoded = value.decode('UTF-16-LE')
+    else:
+        decoded = value.decode()
+    #print(f"_decode(): value is {value}")
+    #print(f"_decode(): decoded is {decoded}.")
+    return decoded.strip()
+
+def _run_cmd(command_line):
+    result = error = ""
+    #print(f"_run_cmd(): RUNNING - command line is {command_line}.")
+    try:
+        # for testing
+        #raise subprocess.CalledProcessError(-4294967295, command_line, 'The Windows Subsystem for Linux instance has terminated.'.encode('UTF-16-LE'))
+
+        tmp = subprocess.check_output(command_line, stderr=subprocess.STDOUT)
+        result = _decode(tmp)
+        #print(f"RESULT: command: {' '.join(command_line)}, result: {result}")
+    except subprocess.CalledProcessError as exc:
+        result = ""
+
+        # decode the error
+        error = _decode(exc.output)
+
+        # log additional info for this particular case
+        if error == 'The Windows Subsystem for Linux instance has terminated.':
+            logging.error(f'_run_cmd(): failed to run command - error: {error}')
+            logging.error(f'_run_cmd(): - wsl path detection is offline')
+            logging.error(f'_run_cmd(): - you need to restart your wsl session, e.g. "wsl --terminate <distro>; wsl"')
+    except:
+        result = ""
+        log_exception(f'[_run_cmd()] {sys.exc_info()[1]}')
+
+    # return results for the last attempt
+    #print(f'_run_cmd(): RETURNING - result: {result}, error: {error}')
+    return [result, error]
+
+def run_wsl(args):
+    # for testing
+    if False:
+        wsl_cmd_str = "nosuchcommand"
+    else:
+        wsl_cmd_str = "wsl"
+
+    # now run the caller's command
+    command_line = [ wsl_cmd_str ] + args
+    result = _run_cmd(command_line)
+    #print(f'run_wsl(): RETURNING - result: {result}')
+    return result
 
 @ctx.action_class('user')
 class UserActions:

--- a/code/file_manager.py
+++ b/code/file_manager.py
@@ -372,10 +372,11 @@ def update_gui():
         gui_files.show()
 
 
-def update_lists():
+def update_lists(path=None):
     global folder_selections, file_selections, current_folder_page, current_file_page
     is_valid_path = False
-    path = actions.user.file_manager_current_path()
+    if not path:
+        path = actions.user.file_manager_current_path()
     directories = {}
     files = {}
     folder_selections = []
@@ -425,7 +426,7 @@ def win_event_handler(window):
         clear_lists()
     elif path:
         if cached_path != path:
-            update_lists()
+            update_lists(path)
     elif cached_path:
         clear_lists()
         actions.user.file_manager_hide_pickers()


### PR DESCRIPTION
The first commit here is a simple optimization.

The second commit exposes error messages that may be generated during wsl path detection and which were previously hidden. Part of the code was refactored in order to provide for common error handling. There is code to detect and decode a class of errors formatted in utf-16-le which may be generated by the wsl engine itself (rather than the guest distros).

This change is the first of several for this module which I would like to contribute.  Primary goals include cleanly supporting multiple distros and integration with the broader terminal/Linux framework present in knausj_talon. In the long run, it would be nice to refactor this code into a more OO implementation.