### PR TITLE
Fix context help crash

### DIFF
--- a/code/help.py
+++ b/code/help.py
@@ -405,7 +405,6 @@ def refresh_context_command_map(enabled_only=False):
                     local_context_map[context_name] = context
 
 
-    local_rule_word_map = refresh_rule_word_map(local_context_command_map)
 
     # Update all the global state after we've performed our calculations
     global context_map
@@ -413,12 +412,14 @@ def refresh_context_command_map(enabled_only=False):
     global sorted_display_list
     global show_enabled_contexts_only
     global display_name_to_context_name_map
+    global rule_word_map
 
     context_map = local_context_map
     context_command_map = local_context_command_map
     sorted_display_list = sorted(local_display_name_to_context_name_map.keys())
     show_enabled_contexts_only = enabled_only
     display_name_to_context_name_map = local_display_name_to_context_name_map
+    rule_word_map = refresh_rule_word_map(local_context_command_map)
 
     ctx.lists["self.help_contexts"] = cached_short_context_names
     update_active_contexts_cache(active_contexts)


### PR DESCRIPTION
The issue was the help context window would crash when the context changed. The reason was the `refresh_context_command_map` function seemed to operate asynchronously with the imgui refresh (and took a few hundred ms to run). The latter used two variables which could get out of sync and hence violate an assumption of the logic.

This PR removes some unused code and also shifts all the refresh global state change to happen after the main logic of the function. This is both more clear as to what's going on (IMO) and also means the state change happens in a much shorter period of time, avoiding the inconsistent variables problem.

It's possible the crash could still happen if imgui refresh is implemented as a separate thread to the main action or event listener threads, but I haven't run into it. If this was a concern we would either have to take out some kind of lock (a traditional one or a 'show help UI as empty until I'm done updating' one), or put the state into a dictionary to make swapping it atomic.