### PR TITLE
create_spoken_forms: correct file extension regex

### DIFF
--- a/code/create_spoken_forms.py
+++ b/code/create_spoken_forms.py
@@ -22,7 +22,7 @@ mod = Module()
 DEFAULT_MINIMUM_TERM_LENGTH = 3
 FANCY_REGULAR_EXPRESSION = r"[A-Z]?[a-z]+|[A-Z]+(?![a-z])|[0-9]+"
 FILE_EXTENSIONS_REGEX = "|".join(
-    "\\" + file_extension.strip() + "$" for file_extension in file_extensions.values()
+    re.escape(file_extension.strip()) + "$" for file_extension in file_extensions.values()
 )
 SYMBOLS_REGEX = "|".join(re.escape(symbol) for symbol in set(symbol_key_words.values()))
 REGEX_NO_SYMBOLS = re.compile(


### PR DESCRIPTION
The regex was previously matching any character, rather than just the period. This was resulting in some unsupported symbols in the relevant lists and other unintended behavior