### PR TITLE
make talon_* lists opt-in

### DIFF
--- a/apps/talon_repl.talon
+++ b/apps/talon_repl.talon
@@ -3,6 +3,12 @@ win.title:/Talon - REPL/
 -
 tag(): user.talon_python
 
+# uncomment user.talon_populate_lists tag to activate talon-specific lists of actions, scopes, modes etcetera. 
+# Do not enable this tag with dragon, as it will be unusable.
+# with conformer, the latency increase may also be unacceptable depending on your cpu
+# see https://github.com/knausj85/knausj_talon/issues/600
+# tag(): user.talon_populate_lists
+
 ^test last$:
     phrase = user.history_get(1)
     command = "sim('{phrase}')"
@@ -18,9 +24,11 @@ tag(): user.talon_python
     #user.paste("sim({phrase})")
     insert(command)
     key(enter)
+# requires user.talon_populate_lists tag. do not use with dragon
 ^debug action {user.talon_actions}$:
     insert("actions.find('{user.talon_actions}')")
     key(enter)
+# requires user.talon_populate_lists tag. do not use with dragon
 ^debug list {user.talon_lists}$:
     insert("actions.user.talon_pretty_print(registry.lists['{talon_lists}'])")
     key(enter)
@@ -33,6 +41,7 @@ tag(): user.talon_python
 ^debug modes$:
     insert("actions.user.talon_pretty_print(scope.get('mode'))")
     key(enter)
+# requires user.talon_populate_lists tag. do not use with dragon
 ^debug scope {user.talon_scopes}$:
     insert("actions.user.talon_pretty_print(scope.get('{talon_scopes}'))")
     key(enter)    

--- a/lang/talon/talon.py
+++ b/lang/talon/talon.py
@@ -2,8 +2,21 @@ from talon import Module, Context, actions, ui, imgui, clip, settings, registry,
 
 mod = Module()
 ctx = Context()
-ctx_global = Context()
+
+
+ctx_talon_lists = Context()
+
+# restrict all the talon_* lists to when the user.talon_populate_lists tag 
+# is active to prevent them from being active in contexts where they are not wanted.
+# Do not enable this tag with dragon, as it will be unusable.
+# with conformer, the latency increase may also be unacceptable depending on your cpu
+# see https://github.com/knausj85/knausj_talon/issues/600
+ctx_talon_lists.matches = r"""
+tag: user.talon_populate_lists
+"""
+
 mod.tag("talon_python", "Tag to activate talon-specific python commands")
+mod.tag("talon_populate_lists", "Tag to activate talon-specific lists of actions, scopes, modes etcetera. Do not use this tag with dragon")
 mod.list("talon_actions")
 mod.list("talon_lists")
 mod.list("talon_captures")
@@ -41,13 +54,13 @@ def update_lists(decls):
         "modes",
     ]:
         l = getattr(decls, thing)
-        ctx_global.lists[
+        ctx_talon_lists.lists[
             f"user.talon_{thing}"
         ] = actions.user.create_spoken_forms_from_list(
             l.keys(), generate_subsequences=False
         )
         # print(
-        #     "List: {} \n {}".format(thing, str(ctx_global.lists[f"user.talon_{thing}"]))
+        #     "List: {} \n {}".format(thing, str(ctx_talon_lists.lists[f"user.talon_{thing}"]))
         # )
 
 

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -6,6 +6,11 @@ and code.language: talon
 -
 tag(): user.code_operators
 tag(): user.code_comment
+# uncomment user.talon_populate_lists tag to activate talon-specific lists of actions, scopes, modes etcetera. 
+# Do not enable this tag with dragon, as it will be unusable.
+# with conformer, the latency increase may also be unacceptable depending on your cpu
+# see https://github.com/knausj85/knausj_talon/issues/600
+# tag(): user.talon_populate_lists
 
 dot talon: insert(".talon")
 #defintion blocks for the context
@@ -38,7 +43,9 @@ tag require [{user.talon_tags}]:
 tag set [{user.talon_tags}]: 
     tag = talon_tags or ""
     user.paste("tag(): {tag}")
+# requires user.talon_populate_lists tag. do not use with dragon
 list {user.talon_lists}: "{{{talon_lists}}}"
+# requires user.talon_populate_lists tag. do not use with dragon
 capture {user.talon_captures}: "<{talon_captures}>"
 
 #commands for dictating key combos


### PR DESCRIPTION
#600.

This is an interim solution until someone can dedicate more time.

These lists make dragon unusable, and may adversely impact performance with Conformer depending on the CPU