### PR TITLE
deprecate "m grid" for "mouse grid" forget tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Talon configs for Mac, Windows, and Linux. Very much in progress. This is also intended to work with both Dragon Naturally Speaking and wav2letter.
 
-Notes: 
+Notes:
+
 - commands are subject to change. We do our best to minimize changes, but we are moving to an [object][verb] standard slowly but surely.
 - @knausj85 makes extensive use of Talon's eye tracking features, so the grammar for certain programs may be much smaller than you may require.
 - The repository was mostly developed with Dragon, so commands are mostly still optimized for that speech engine.
@@ -15,7 +16,7 @@ Clone repo into `~/.talon/user`
 cd ~/.talon/user
 git clone https://github.com/knausj85/knausj_talon knausj_talon
 ```
-    
+
 Alternatively, access the directory by right clicking the Talon icon in taskbar, clicking Scripting>Open ~/talon, and navigating to user.
 
 The folder structure should look something like the below:
@@ -35,15 +36,15 @@ The folder structure should look something like the below:
 
 ## Windows setup
 
-Clone repo into `%AppData%\Talon\user` 
+Clone repo into `%AppData%\Talon\user`
 
 ```insert code:
 cd %AppData%\Talon\user
 git clone https://github.com/knausj85/knausj_talon knausj_talon
 ```
-    
+
 Alternatively, access the directory by right clicking the Talon icon in taskbar, clicking Scripting>Open ~/talon, and navigating to user.
-    
+
 The folder structure should look something like the below:
 
 ```insert code:
@@ -61,20 +62,20 @@ The folder structure should look something like the below:
 
 ## Getting started with Talon
 
-1. `help active` will display the available commands for the active application. 
-    - Available commands can change with the application, or even window title that has focus. 
-    - You may navigate help using the displayed numbers. e.g., `help one one` or `help eleven` to open the 11th item in the help list. 
-    - Without opening help first, you can also search for commands e.g. `help search tab` to display all tab-related commands
-    - Without opening help first, you can also jump immediately into a particular help context display by recalling the name displayed in help window (based on the name of the .talon file) e.g. `help symbols` or `help visual studio`
-    - All help-related commands are defined in misc/help.talon and misc/help_open.talon
+1. `help active` will display the available commands for the active application.
+   - Available commands can change with the application, or even window title that has focus.
+   - You may navigate help using the displayed numbers. e.g., `help one one` or `help eleven` to open the 11th item in the help list.
+   - Without opening help first, you can also search for commands e.g. `help search tab` to display all tab-related commands
+   - Without opening help first, you can also jump immediately into a particular help context display by recalling the name displayed in help window (based on the name of the .talon file) e.g. `help symbols` or `help visual studio`
+   - All help-related commands are defined in misc/help.talon and misc/help_open.talon
 2. `help alphabet` will display the alphabet
 3. `command history` will toggle a display of the recent commands
 4. `format help` will display the available formatters with examples.
 5. Many useful, basic commands are defined in https://github.com/knausj85/knausj_talon/blob/master/misc/standard.talon#L36
-    - `undo that` and `redo that` are the default undo/redo commands.
-    - `paste that`, `copy that`, and `cut that` for pasting/copy/cutting, respectively.
+   - `undo that` and `redo that` are the default undo/redo commands.
+   - `paste that`, `copy that`, and `cut that` for pasting/copy/cutting, respectively.
 
-It's recommended to learn the alphabet first, then get familiar with the keys, symbols, formatters, mouse, and generic_editor commands. 
+It's recommended to learn the alphabet first, then get familiar with the keys, symbols, formatters, mouse, and generic_editor commands.
 
 Once you have the basics of text input down, try copying some code from one window to another.
 
@@ -82,7 +83,8 @@ After that, explore using ordinal repetition for easily repeating a command with
 
 If you use vim, just start with the numbers and alphabet, otherwise look at generic_editor.talon as well at jetbrains, vscode, and any other integrations.
 
-###  Alphabet
+### Alphabet
+
 The alphabet is defined here
 https://github.com/knausj85/knausj_talon/blob/master/code/keys.py#L6
 
@@ -90,37 +92,34 @@ https://github.com/knausj85/knausj_talon/blob/master/code/keys.py#L6
 
 Try saying e.g. `air bat cap` to insert abc.
 
-
 ### Keys
+
 Keys are defined in keys.py from line 83 - 182. The alphabet is used for A-Z.
 https://github.com/knausj85/knausj_talon/blob/84c6f637ba8304352aa15e01b030e8fa36f4f1a2/code/keys.py#L83
 
 All key commands are defined in keys.talon
 https://github.com/knausj85/knausj_talon/blob/master/misc/keys.talon
 
-
 For example, say
 
 `shift air` to press `shift-a`, which types a capital `A`.
 
-
-On Windows, try commands such as 
+On Windows, try commands such as
 
 `control air` to press `control-a` and select all.
 
 `super-shift-sun` to press `windows-shift-s` to trigger the screenshot application (Windows 10). Then try `escape` to exit the screenshot application.
 
-
-On Mac, try commands such as 
+On Mac, try commands such as
 
 `command air` to press `command-a` and select all.
 
 `control shift command 4` to press ` ctrl-shift-cmd-4` to trigger the screenshot application. Then try `escape` to exit the screenshot application. Please note the order of the modifiers doesn't matter.
 
-
-Any combination of the modifiers, symbols, alphabet, numbers and function keys can be executed via voice to execute shorcuts. Out of the box, only the modifier keys (command, shift, alt, super) cannot be triggered by themselves. 
+Any combination of the modifiers, symbols, alphabet, numbers and function keys can be executed via voice to execute shorcuts. Out of the box, only the modifier keys (command, shift, alt, super) cannot be triggered by themselves.
 
 ### Symbols
+
 Some symbols are defined in keys.py, so you can say e.g. `control colon` to press those keys.
 https://github.com/knausj85/knausj_talon/blob/master/code/keys.py#L93
 
@@ -128,6 +127,7 @@ Some other symbols are defined here:
 https://github.com/knausj85/knausj_talon/blob/master/text/symbols.talon
 
 ### Formatters
+
 `format help` will display the available formatters with examples of the output.
 
 Try using formatters by saying e.g. `snake hello world`, which will insert hello_world
@@ -140,16 +140,18 @@ https://github.com/knausj85/knausj_talon/blob/master/code/formatters.py#L146
 All formatter-related commands are defined here
 https://github.com/knausj85/knausj_talon/blob/master/misc/formatters.talon#L2
 
-
 ### Mouse commands
+
 See https://github.com/knausj85/knausj_talon/blob/master/misc/mouse.talon
 
 ### Generic editor
+
 https://github.com/knausj85/knausj_talon/blob/master/text/generic_editor.talon#L7
 
-These generic commands are global. Commands such as `go word left` will work in any text box.  
+These generic commands are global. Commands such as `go word left` will work in any text box.
 
 ### Repeating commands
+
 For repeating commands, useful voice commands are defined here:
 https://github.com/knausj85/knausj_talon/blob/ced46aee4b59e6ec5e8545bb01434e27792c830e/misc/repeater.talon#L2
 
@@ -157,6 +159,7 @@ Try saying e.g. `go up fifth` will go up five lines.
 Try saying e.g. `select up third` to hit `shift-up` three times to select some lines in a text field.
 
 ### Window management
+
 Global window managment commands are defined here:
 https://github.com/knausj85/knausj_talon/blob/master/misc/window_management.talon#L1
 
@@ -174,12 +177,13 @@ Specific programming languages may be activated by voice commands, or via title 
 
 Activating languages via commands will enable the commands globally, e.g. they'll work in any application. This will also disable the title tracking method (code.language in .talon files) until the "clear language modes" voice command is used.
 
-The commands for enabling languages are defined here: 
+The commands for enabling languages are defined here:
 https://github.com/knausj85/knausj_talon/blob/master/modes/language_modes.talon
 
-By default, title tracking activates coding languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++. 
+By default, title tracking activates coding languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++.
 
-To enable title tracking for your application: 
+To enable title tracking for your application:
+
 1. The active filename (including extension) must be included in the editor's title
 2. Implement the required Talon-defined `filename` action to correctly extract the filename from the programs's title. See https://github.com/knausj85/knausj_talon/blob/8fc3ca75874398806b42d972c28dad91f1399653/apps/vscode/vscode.py#L109 for an example.
 
@@ -195,10 +199,9 @@ Python, C#, Talon and javascript language support is currently broken up into ~f
 
 To start support for a new language, ensure the appropriate extension is added to code.py's extension_lang_map (https://github.com/knausj85/knausj_talon/blob/12229e932d9d3de85fa2f9d9a7c4f31ed6b6445b/code/code.py#L32) and then follow an existing language as appropriate. You may want to add a force command to `language_modes.talon` as well.
 
-
 ## File Manager commands
-For the following file manager commands to work, your file manager must display the full folder path in the title bar. https://github.com/knausj85/knausj_talon/blob/baa323fcd34d8a1124658a425abe8eed59cf2ee5/apps/file_manager.talon
 
+For the following file manager commands to work, your file manager must display the full folder path in the title bar. https://github.com/knausj85/knausj_talon/blob/baa323fcd34d8a1124658a425abe8eed59cf2ee5/apps/file_manager.talon
 
 For Mac OS X's Finder, run this command in terminal to display the full path in the title.
 
@@ -211,19 +214,20 @@ https://www.howtogeek.com/121218/beginner-how-to-make-explorer-always-show-the-f
 
 For the Windows command line, the `refresh title` command will force the title to the current directory, and all directory commands (`follow 1`) will automatically update the title.
 
-Notes: 
+Notes:
 
-• Both Windows Explorer and Finder hide certain files and folder by default, so it's often best to use the imgui to list the options before issuing commands. 
+• Both Windows Explorer and Finder hide certain files and folder by default, so it's often best to use the imgui to list the options before issuing commands.
 
 • If there no hidden files or folders, and the items are displayed in alphabetical order, you can typically issue the `follow <number>`, `file <number>` and `open <number>` commands based on the displayed order.
 
 To implement support for a new program, you need to implement the relevant file manager actions for your application and assert the user.file_manager tag.
-- There are a number of example implementations in the repository. Finder is a good example to copy and customize to your application as needed. 
-https://github.com/knausj85/knausj_talon/blob/5eae0b6a8f2269f24265e77feddbcc4bcf437c36/apps/mac/finder/finder.py#L16
+
+- There are a number of example implementations in the repository. Finder is a good example to copy and customize to your application as needed.
+  https://github.com/knausj85/knausj_talon/blob/5eae0b6a8f2269f24265e77feddbcc4bcf437c36/apps/mac/finder/finder.py#L16
 
 ## Terminal commands
 
-Many terminal programs are supported out of the box, but you may not want all the commands enabled. 
+Many terminal programs are supported out of the box, but you may not want all the commands enabled.
 
 To disable various commandsets in your terminal, find the relevant talon file and enable/disable the tags for command sets as appropriate.
 
@@ -236,7 +240,6 @@ tag(): user.tabs
 
 For instance, kubectl commands (kubernetes) aren't relevant to everyone.
 
-
 ## Jetbrains commands
 
 For Jetbrains commands to work you must install https://plugins.jetbrains.com/plugin/10504-voice-code-idea
@@ -244,10 +247,9 @@ into each editor.
 
 ## Settings
 
-Several options are configurable via a single settings file out of the box. Any setting can be made context specific as needed (e.g., per-OS, per-app, etc). 
+Several options are configurable via a single settings file out of the box. Any setting can be made context specific as needed (e.g., per-OS, per-app, etc).
 
 https://github.com/knausj85/knausj_talon/blob/master/settings.talon
-
 
 ```
 #adjust the scale of the imgui to my liking
@@ -280,15 +282,13 @@ The most commonly adjusted settings are probably
 
 • `user.mouse_wheel_down_amount` and `user.mouse_continuous_scroll_amount` for adjusting the scroll amounts for the various scroll commands.
 
-• Uncomment `tag(): user.mouse_grid_enabled` to enable the mouse grid.
-
-
 # Collaborators
 
 This repository is now officially a team effort. The following contributors have direct access:
+
 - @dwiel
 - @fidgetingbits
-- @knausj85 
+- @knausj85
 - @rntz
 - @splondike
 - @pokey
@@ -303,7 +303,7 @@ Collaborators will reply to issues and pull requests as time and health permits.
 
 # Contributing
 
-Anyone is welcome to submit PRs and report issues. 
+Anyone is welcome to submit PRs and report issues.
 
 ## Guidelines for contributions
 
@@ -311,12 +311,12 @@ Anyone is welcome to submit PRs and report issues.
 
 - New grammars should follow the [subject][verb] standard where-ever possible.
 
-- For Mac OS X, the bundle id should be used for defining app contexts, rather than the name. 
+- For Mac OS X, the bundle id should be used for defining app contexts, rather than the name.
 
 - For Windows, both the friendly app name and exe name should be used for defining app contexts when they are different. For some people, the MUICache breaks.
 
 - For new web apps, ensure the domain is used to minimize potential mismatches
-https://github.com/knausj85/knausj_talon/blob/master/apps/web/window_titles.md
+  https://github.com/knausj85/knausj_talon/blob/master/apps/web/window_titles.md
 
 - New applications should support the appropriate 'generic' grammars where possible
 
@@ -332,6 +332,7 @@ generic_terminal.talon
 ```
 
 - New programming languages should support the appropriate 'generic' grammars where possible as well
+
 ```
 operators.talon
 programming.talon
@@ -346,13 +347,14 @@ user.code_functions
 user.code_libraries
 ```
 
-where appropriate. See e.g. csharp.py/csharp.talon. At least, until we come up with something better 👍 
+where appropriate. See e.g. csharp.py/csharp.talon. At least, until we come up with something better 👍
 
 ## Automated tests
 
 There are a number of automated tests in the repository which are run outside of the Talon environment. To run them make sure you have the `pytest` python package installed. You can then just run the `pytest` command from the repository root to execute all the tests.
 
 # Talon documentation
-For official documentation on Talon's API and features, please visit https://talonvoice.com/docs/. 
+
+For official documentation on Talon's API and features, please visit https://talonvoice.com/docs/.
 
 For community-generated documentation on Talon, please visit https://talon.wiki/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Talon configs for Mac, Windows, and Linux. Very much in progress. This is also intended to work with both Dragon Naturally Speaking and wav2letter.
 
-Notes:
-
+Notes: 
 - commands are subject to change. We do our best to minimize changes, but we are moving to an [object][verb] standard slowly but surely.
 - @knausj85 makes extensive use of Talon's eye tracking features, so the grammar for certain programs may be much smaller than you may require.
 - The repository was mostly developed with Dragon, so commands are mostly still optimized for that speech engine.
@@ -16,7 +15,7 @@ Clone repo into `~/.talon/user`
 cd ~/.talon/user
 git clone https://github.com/knausj85/knausj_talon knausj_talon
 ```
-
+    
 Alternatively, access the directory by right clicking the Talon icon in taskbar, clicking Scripting>Open ~/talon, and navigating to user.
 
 The folder structure should look something like the below:
@@ -36,15 +35,15 @@ The folder structure should look something like the below:
 
 ## Windows setup
 
-Clone repo into `%AppData%\Talon\user`
+Clone repo into `%AppData%\Talon\user` 
 
 ```insert code:
 cd %AppData%\Talon\user
 git clone https://github.com/knausj85/knausj_talon knausj_talon
 ```
-
+    
 Alternatively, access the directory by right clicking the Talon icon in taskbar, clicking Scripting>Open ~/talon, and navigating to user.
-
+    
 The folder structure should look something like the below:
 
 ```insert code:
@@ -62,20 +61,20 @@ The folder structure should look something like the below:
 
 ## Getting started with Talon
 
-1. `help active` will display the available commands for the active application.
-   - Available commands can change with the application, or even window title that has focus.
-   - You may navigate help using the displayed numbers. e.g., `help one one` or `help eleven` to open the 11th item in the help list.
-   - Without opening help first, you can also search for commands e.g. `help search tab` to display all tab-related commands
-   - Without opening help first, you can also jump immediately into a particular help context display by recalling the name displayed in help window (based on the name of the .talon file) e.g. `help symbols` or `help visual studio`
-   - All help-related commands are defined in misc/help.talon and misc/help_open.talon
+1. `help active` will display the available commands for the active application. 
+    - Available commands can change with the application, or even window title that has focus. 
+    - You may navigate help using the displayed numbers. e.g., `help one one` or `help eleven` to open the 11th item in the help list. 
+    - Without opening help first, you can also search for commands e.g. `help search tab` to display all tab-related commands
+    - Without opening help first, you can also jump immediately into a particular help context display by recalling the name displayed in help window (based on the name of the .talon file) e.g. `help symbols` or `help visual studio`
+    - All help-related commands are defined in misc/help.talon and misc/help_open.talon
 2. `help alphabet` will display the alphabet
 3. `command history` will toggle a display of the recent commands
 4. `format help` will display the available formatters with examples.
 5. Many useful, basic commands are defined in https://github.com/knausj85/knausj_talon/blob/master/misc/standard.talon#L36
-   - `undo that` and `redo that` are the default undo/redo commands.
-   - `paste that`, `copy that`, and `cut that` for pasting/copy/cutting, respectively.
+    - `undo that` and `redo that` are the default undo/redo commands.
+    - `paste that`, `copy that`, and `cut that` for pasting/copy/cutting, respectively.
 
-It's recommended to learn the alphabet first, then get familiar with the keys, symbols, formatters, mouse, and generic_editor commands.
+It's recommended to learn the alphabet first, then get familiar with the keys, symbols, formatters, mouse, and generic_editor commands. 
 
 Once you have the basics of text input down, try copying some code from one window to another.
 
@@ -83,8 +82,7 @@ After that, explore using ordinal repetition for easily repeating a command with
 
 If you use vim, just start with the numbers and alphabet, otherwise look at generic_editor.talon as well at jetbrains, vscode, and any other integrations.
 
-### Alphabet
-
+###  Alphabet
 The alphabet is defined here
 https://github.com/knausj85/knausj_talon/blob/master/code/keys.py#L6
 
@@ -92,34 +90,37 @@ https://github.com/knausj85/knausj_talon/blob/master/code/keys.py#L6
 
 Try saying e.g. `air bat cap` to insert abc.
 
-### Keys
 
+### Keys
 Keys are defined in keys.py from line 83 - 182. The alphabet is used for A-Z.
 https://github.com/knausj85/knausj_talon/blob/84c6f637ba8304352aa15e01b030e8fa36f4f1a2/code/keys.py#L83
 
 All key commands are defined in keys.talon
 https://github.com/knausj85/knausj_talon/blob/master/misc/keys.talon
 
+
 For example, say
 
 `shift air` to press `shift-a`, which types a capital `A`.
 
-On Windows, try commands such as
+
+On Windows, try commands such as 
 
 `control air` to press `control-a` and select all.
 
 `super-shift-sun` to press `windows-shift-s` to trigger the screenshot application (Windows 10). Then try `escape` to exit the screenshot application.
 
-On Mac, try commands such as
+
+On Mac, try commands such as 
 
 `command air` to press `command-a` and select all.
 
 `control shift command 4` to press ` ctrl-shift-cmd-4` to trigger the screenshot application. Then try `escape` to exit the screenshot application. Please note the order of the modifiers doesn't matter.
 
-Any combination of the modifiers, symbols, alphabet, numbers and function keys can be executed via voice to execute shorcuts. Out of the box, only the modifier keys (command, shift, alt, super) cannot be triggered by themselves.
+
+Any combination of the modifiers, symbols, alphabet, numbers and function keys can be executed via voice to execute shorcuts. Out of the box, only the modifier keys (command, shift, alt, super) cannot be triggered by themselves. 
 
 ### Symbols
-
 Some symbols are defined in keys.py, so you can say e.g. `control colon` to press those keys.
 https://github.com/knausj85/knausj_talon/blob/master/code/keys.py#L93
 
@@ -127,7 +128,6 @@ Some other symbols are defined here:
 https://github.com/knausj85/knausj_talon/blob/master/text/symbols.talon
 
 ### Formatters
-
 `format help` will display the available formatters with examples of the output.
 
 Try using formatters by saying e.g. `snake hello world`, which will insert hello_world
@@ -140,18 +140,16 @@ https://github.com/knausj85/knausj_talon/blob/master/code/formatters.py#L146
 All formatter-related commands are defined here
 https://github.com/knausj85/knausj_talon/blob/master/misc/formatters.talon#L2
 
-### Mouse commands
 
+### Mouse commands
 See https://github.com/knausj85/knausj_talon/blob/master/misc/mouse.talon
 
 ### Generic editor
-
 https://github.com/knausj85/knausj_talon/blob/master/text/generic_editor.talon#L7
 
-These generic commands are global. Commands such as `go word left` will work in any text box.
+These generic commands are global. Commands such as `go word left` will work in any text box.  
 
 ### Repeating commands
-
 For repeating commands, useful voice commands are defined here:
 https://github.com/knausj85/knausj_talon/blob/ced46aee4b59e6ec5e8545bb01434e27792c830e/misc/repeater.talon#L2
 
@@ -159,7 +157,6 @@ Try saying e.g. `go up fifth` will go up five lines.
 Try saying e.g. `select up third` to hit `shift-up` three times to select some lines in a text field.
 
 ### Window management
-
 Global window managment commands are defined here:
 https://github.com/knausj85/knausj_talon/blob/master/misc/window_management.talon#L1
 
@@ -177,13 +174,12 @@ Specific programming languages may be activated by voice commands, or via title 
 
 Activating languages via commands will enable the commands globally, e.g. they'll work in any application. This will also disable the title tracking method (code.language in .talon files) until the "clear language modes" voice command is used.
 
-The commands for enabling languages are defined here:
+The commands for enabling languages are defined here: 
 https://github.com/knausj85/knausj_talon/blob/master/modes/language_modes.talon
 
-By default, title tracking activates coding languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++.
+By default, title tracking activates coding languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++. 
 
-To enable title tracking for your application:
-
+To enable title tracking for your application: 
 1. The active filename (including extension) must be included in the editor's title
 2. Implement the required Talon-defined `filename` action to correctly extract the filename from the programs's title. See https://github.com/knausj85/knausj_talon/blob/8fc3ca75874398806b42d972c28dad91f1399653/apps/vscode/vscode.py#L109 for an example.
 
@@ -199,9 +195,10 @@ Python, C#, Talon and javascript language support is currently broken up into ~f
 
 To start support for a new language, ensure the appropriate extension is added to code.py's extension_lang_map (https://github.com/knausj85/knausj_talon/blob/12229e932d9d3de85fa2f9d9a7c4f31ed6b6445b/code/code.py#L32) and then follow an existing language as appropriate. You may want to add a force command to `language_modes.talon` as well.
 
-## File Manager commands
 
+## File Manager commands
 For the following file manager commands to work, your file manager must display the full folder path in the title bar. https://github.com/knausj85/knausj_talon/blob/baa323fcd34d8a1124658a425abe8eed59cf2ee5/apps/file_manager.talon
+
 
 For Mac OS X's Finder, run this command in terminal to display the full path in the title.
 
@@ -214,20 +211,19 @@ https://www.howtogeek.com/121218/beginner-how-to-make-explorer-always-show-the-f
 
 For the Windows command line, the `refresh title` command will force the title to the current directory, and all directory commands (`follow 1`) will automatically update the title.
 
-Notes:
+Notes: 
 
-• Both Windows Explorer and Finder hide certain files and folder by default, so it's often best to use the imgui to list the options before issuing commands.
+• Both Windows Explorer and Finder hide certain files and folder by default, so it's often best to use the imgui to list the options before issuing commands. 
 
 • If there no hidden files or folders, and the items are displayed in alphabetical order, you can typically issue the `follow <number>`, `file <number>` and `open <number>` commands based on the displayed order.
 
 To implement support for a new program, you need to implement the relevant file manager actions for your application and assert the user.file_manager tag.
-
-- There are a number of example implementations in the repository. Finder is a good example to copy and customize to your application as needed.
-  https://github.com/knausj85/knausj_talon/blob/5eae0b6a8f2269f24265e77feddbcc4bcf437c36/apps/mac/finder/finder.py#L16
+- There are a number of example implementations in the repository. Finder is a good example to copy and customize to your application as needed. 
+https://github.com/knausj85/knausj_talon/blob/5eae0b6a8f2269f24265e77feddbcc4bcf437c36/apps/mac/finder/finder.py#L16
 
 ## Terminal commands
 
-Many terminal programs are supported out of the box, but you may not want all the commands enabled.
+Many terminal programs are supported out of the box, but you may not want all the commands enabled. 
 
 To disable various commandsets in your terminal, find the relevant talon file and enable/disable the tags for command sets as appropriate.
 
@@ -240,6 +236,7 @@ tag(): user.tabs
 
 For instance, kubectl commands (kubernetes) aren't relevant to everyone.
 
+
 ## Jetbrains commands
 
 For Jetbrains commands to work you must install https://plugins.jetbrains.com/plugin/10504-voice-code-idea
@@ -247,9 +244,10 @@ into each editor.
 
 ## Settings
 
-Several options are configurable via a single settings file out of the box. Any setting can be made context specific as needed (e.g., per-OS, per-app, etc).
+Several options are configurable via a single settings file out of the box. Any setting can be made context specific as needed (e.g., per-OS, per-app, etc). 
 
 https://github.com/knausj85/knausj_talon/blob/master/settings.talon
+
 
 ```
 #adjust the scale of the imgui to my liking
@@ -282,13 +280,13 @@ The most commonly adjusted settings are probably
 
 • `user.mouse_wheel_down_amount` and `user.mouse_continuous_scroll_amount` for adjusting the scroll amounts for the various scroll commands.
 
+
 # Collaborators
 
 This repository is now officially a team effort. The following contributors have direct access:
-
 - @dwiel
 - @fidgetingbits
-- @knausj85
+- @knausj85 
 - @rntz
 - @splondike
 - @pokey
@@ -303,7 +301,7 @@ Collaborators will reply to issues and pull requests as time and health permits.
 
 # Contributing
 
-Anyone is welcome to submit PRs and report issues.
+Anyone is welcome to submit PRs and report issues. 
 
 ## Guidelines for contributions
 
@@ -311,12 +309,12 @@ Anyone is welcome to submit PRs and report issues.
 
 - New grammars should follow the [subject][verb] standard where-ever possible.
 
-- For Mac OS X, the bundle id should be used for defining app contexts, rather than the name.
+- For Mac OS X, the bundle id should be used for defining app contexts, rather than the name. 
 
 - For Windows, both the friendly app name and exe name should be used for defining app contexts when they are different. For some people, the MUICache breaks.
 
 - For new web apps, ensure the domain is used to minimize potential mismatches
-  https://github.com/knausj85/knausj_talon/blob/master/apps/web/window_titles.md
+https://github.com/knausj85/knausj_talon/blob/master/apps/web/window_titles.md
 
 - New applications should support the appropriate 'generic' grammars where possible
 
@@ -332,7 +330,6 @@ generic_terminal.talon
 ```
 
 - New programming languages should support the appropriate 'generic' grammars where possible as well
-
 ```
 operators.talon
 programming.talon
@@ -347,14 +344,13 @@ user.code_functions
 user.code_libraries
 ```
 
-where appropriate. See e.g. csharp.py/csharp.talon. At least, until we come up with something better 👍
+where appropriate. See e.g. csharp.py/csharp.talon. At least, until we come up with something better 👍 
 
 ## Automated tests
 
 There are a number of automated tests in the repository which are run outside of the Talon environment. To run them make sure you have the `pytest` python package installed. You can then just run the `pytest` command from the repository root to execute all the tests.
 
 # Talon documentation
-
-For official documentation on Talon's API and features, please visit https://talonvoice.com/docs/.
+For official documentation on Talon's API and features, please visit https://talonvoice.com/docs/. 
 
 For community-generated documentation on Talon, please visit https://talon.wiki/

--- a/mouse_grid/mouse_grid.py
+++ b/mouse_grid/mouse_grid.py
@@ -19,7 +19,7 @@ narrow_expansion = mod.setting(
 )
 
 mod.tag("mouse_grid_showing", desc="Tag indicates whether the mouse grid is showing")
-mod.tag("mouse_grid_enabled", desc="Tag enables the mouse grid commands.")
+mod.tag("mouse_grid_enabled", desc="Deprecated: do not use.  Activates legacy m grid command")
 ctx = Context()
 
 

--- a/mouse_grid/mouse_grid.talon
+++ b/mouse_grid/mouse_grid.talon
@@ -1,17 +1,6 @@
 tag: user.mouse_grid_enabled
 -
 M grid:
+    app.notify("please use the voice command 'mouse grid' instead of 'm grid'")
     user.grid_select_screen(1)
-    user.grid_activate()
-
-grid win:
-    user.grid_place_window()
-    user.grid_activate()
-
-grid <user.number_key>+:
-    user.grid_activate()
-    user.grid_narrow_list(number_key_list)
-
-grid screen [<number>]:
-    user.grid_select_screen(number or 1)
     user.grid_activate()

--- a/mouse_grid/mouse_grid_always.talon
+++ b/mouse_grid/mouse_grid_always.talon
@@ -1,0 +1,15 @@
+mouse grid:
+    user.grid_select_screen(1)
+    user.grid_activate()
+
+grid win:
+    user.grid_place_window()
+    user.grid_activate()
+
+grid <user.number_key>+:
+    user.grid_activate()
+    user.grid_narrow_list(number_key_list)
+
+grid screen [<number>]:
+    user.grid_select_screen(number or 1)
+    user.grid_activate()

--- a/settings.talon
+++ b/settings.talon
@@ -46,6 +46,3 @@ settings():
     # work in some applications. You may wish to enable this on a
     # per-application basis.
     # user.context_sensitive_dictation = 1
-
-# uncomment tag to enable mouse grid
-# tag(): user.mouse_grid_enabled


### PR DESCRIPTION
the tag for activating "m grid" proved to be a very bad idea.