### PR TITLE
simple plural support

### DIFF
--- a/code/homophones.py
+++ b/code/homophones.py
@@ -90,6 +90,8 @@ def raise_homophones(word_to_find_homophones_for, forced=False, selection=False)
 
     word_to_find_homophones_for = word_to_find_homophones_for.lower()
 
+    # We support plurals, but very naively. If we can't find your word but your word ends in an s, presume its plural
+    # and attempt to find the singular, then present the presumed plurals back. This could be improved!
     if word_to_find_homophones_for in all_homophones:
         valid_homophones = all_homophones[word_to_find_homophones_for]
     elif word_to_find_homophones_for[-1] == 's' and word_to_find_homophones_for[:-1] in all_homophones:


### PR DESCRIPTION
If the word you are looking is not found, but ends in an s, hope that it's a plural and check to see if the singular form exists so you can use those (with s's added on).

This only affects words that end in an s and don't otherwise exist in the homophones csv.

This gives us "cursors/cursers", "duals/duels", "minors/miners" etc for free, instead of having to carefully select the singular form or bloating the homophones list. It will obviously get stuff wrong, but imo it's better to have some wrong choices in your list then no choices at all.