### PR TITLE
Explicitly hide windows for wsl background commands.

### DIFF
--- a/apps/platforms/win/wsl/wsl.py
+++ b/apps/platforms/win/wsl/wsl.py
@@ -182,7 +182,11 @@ def _run_cmd(command_line):
         # for testing
         #raise subprocess.CalledProcessError(-4294967295, command_line, termination_error.encode('UTF-16-LE'))
 
-        tmp = subprocess.check_output(command_line, stderr=subprocess.STDOUT)
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = subprocess.SW_HIDE
+
+        tmp = subprocess.check_output(command_line, stderr=subprocess.STDOUT, startupinfo=startupinfo)
         result = _decode(tmp)
         #print(f"RESULT: command: {' '.join(command_line)}, result: {result}")
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
For some reason, every time I switch into a wsl window I am seeing brief flashes of short-lived console windows which correspond to the wsl commands being executed by the file manager for path detection.

It's a recent development, but I haven't been able to pinpoint the cause. I don't know if this is due to a change in my windows configuration or a change in talon perhaps. I have updated both in recent days. I would like to know if anyone else is seeing something similar.

Anyways, I found that the subprocess module provides a means for controlling such things (on windows). This change fixes the problem for me.