### PR TITLE
Fix issue with initial continuous scroll speed

### DIFF
--- a/code/mouse.py
+++ b/code/mouse.py
@@ -181,7 +181,6 @@ class Actions:
     def mouse_scroll_down_continuous():
         """Scrolls down continuously"""
         global continuous_scoll_mode
-        stop_scroll()
         continuous_scoll_mode = "scroll down continuous"
         mouse_scroll(setting_mouse_continuous_scroll_amount.get())()
 
@@ -198,7 +197,6 @@ class Actions:
     def mouse_scroll_up_continuous():
         """Scrolls up continuously"""
         global continuous_scoll_mode
-        stop_scroll()
         continuous_scoll_mode = "scroll up continuous"
         mouse_scroll(-setting_mouse_continuous_scroll_amount.get())()
 
@@ -289,10 +287,11 @@ noise.register("pop", on_pop)
 def mouse_scroll(amount):
     def scroll():
         global scroll_amount
-        if (scroll_amount >= 0) == (amount >= 0):
-            scroll_amount += amount
-        else:
-            scroll_amount = amount
+        if continuous_scoll_mode:
+            if (scroll_amount >= 0) == (amount >= 0):
+                scroll_amount += amount
+            else:
+                scroll_amount = amount
         actions.mouse_scroll(y=int(amount))
 
     return scroll
@@ -346,7 +345,7 @@ def gaze_scroll():
 
 
 def stop_scroll():
-    global scroll_amount, scroll_job, gaze_job
+    global scroll_amount, scroll_job, gaze_job, continuous_scoll_mode
     scroll_amount = 0
     if scroll_job:
         cron.cancel(scroll_job)
@@ -362,6 +361,8 @@ def stop_scroll():
     scroll_job = None
     gaze_job = None
     gui_wheel.hide()
+
+    continuous_scoll_mode = ""
 
     # if eye_zoom_mouse.zoom_mouse.enabled and eye_mouse.mouse.attached_tracker is not None:
     #    eye_zoom_mouse.zoom_mouse.sleep(False)

--- a/code/mouse.py
+++ b/code/mouse.py
@@ -181,6 +181,7 @@ class Actions:
     def mouse_scroll_down_continuous():
         """Scrolls down continuously"""
         global continuous_scoll_mode
+        stop_scroll()
         continuous_scoll_mode = "scroll down continuous"
         mouse_scroll(setting_mouse_continuous_scroll_amount.get())()
 
@@ -197,6 +198,7 @@ class Actions:
     def mouse_scroll_up_continuous():
         """Scrolls up continuously"""
         global continuous_scoll_mode
+        stop_scroll()
         continuous_scoll_mode = "scroll up continuous"
         mouse_scroll(-setting_mouse_continuous_scroll_amount.get())()
 


### PR DESCRIPTION
Currently the initial speed of the continuous scroll can be increased if you do any manual "wheel up/down" actions.
For example call "wheel down 20 times" and then start "wheel downer". It will go a lot faster. 

This change should fix that. This change is consistent with the code for starting the gaze scroll.