### PR TITLE
python: Add match statement support

### DIFF
--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -187,11 +187,11 @@ class UserActions:
         actions.insert('else:')
         actions.key('enter')
     def code_state_switch():
-        actions.insert('switch ()')
+        actions.insert('match :')
         actions.edit.left()
     def code_state_case():
-        actions.insert('case \nbreak;')
-        actions.edit.up()
+        actions.insert('case :')
+        actions.edit.left()
     def code_state_for(): actions.auto_insert('for ')
     def code_state_for_each():
         actions.insert('for in ')


### PR DESCRIPTION
This changes `state switch` and `state case` to insert the keywords for [PEP 634: Structural Pattern Matching](https://docs.python.org/3/whatsnew/3.10.html#pep-634-structural-pattern-matching), added in Python 3.10.