### PR TITLE
Add page navigation for reader apps

### DIFF
--- a/apps/adobe/adobe_acrobat_reader_dc.py
+++ b/apps/adobe/adobe_acrobat_reader_dc.py
@@ -1,0 +1,15 @@
+from talon import Module
+
+# --- App definition ---
+mod = Module()
+mod.apps.adobe_acrobat_reader_dc = """
+os: windows
+and app.name: Adobe Acrobat DC
+os: windows
+and app.exe: Acrobat.exe
+os: windows
+and app.name: Adobe Acrobat Reader DC
+os: windows
+and app.exe: AcroRd32.exe
+"""
+# TODO: mac context and implementation

--- a/apps/adobe/adobe_acrobat_reader_dc.talon
+++ b/apps/adobe/adobe_acrobat_reader_dc.talon
@@ -1,0 +1,5 @@
+app: adobe_acrobat_reader_dc
+-
+# Set tags
+tag(): user.tabs
+tag(): user.pages

--- a/apps/adobe/win.py
+++ b/apps/adobe/win.py
@@ -1,0 +1,41 @@
+from talon import Context, actions
+
+# Context matching
+ctx = Context()
+ctx.matches = """
+os: windows
+app: adobe_acrobat_reader_dc
+"""
+
+
+# --- Implement actions ---
+@ctx.action_class('app')
+class AppActions:
+    # app.tabs
+    def tab_next(): actions.key('ctrl-tab')
+    def tab_previous(): actions.key('ctrl-shift-tab')
+
+
+@ctx.action_class('edit')
+class EditActions:
+    def zoom_in(): actions.key("ctrl-0")
+    def zoom_out(): actions.key("ctrl-1")
+    def zoom_reset(): actions.key("ctrl-2")
+
+
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_current():
+        actions.key("ctrl-shift-n")
+        page = actions.edit.selected_text()
+        actions.key("tab:2 enter")
+        return int(page)
+    def page_next(): actions.key("right")
+    def page_previous(): actions.key("left")
+    def page_jump(number: int):
+        if number > 0:
+            actions.key("ctrl-shift-n")
+            actions.insert(str(number))
+            actions.key("enter")
+    def page_final(): actions.key("end")

--- a/apps/adobe/win.py
+++ b/apps/adobe/win.py
@@ -18,8 +18,8 @@ class AppActions:
 
 @ctx.action_class('edit')
 class EditActions:
-    def zoom_in(): actions.key("ctrl-0")
-    def zoom_out(): actions.key("ctrl-1")
+    def zoom_in(): actions.key("ctrl-0")  # in german version
+    def zoom_out(): actions.key("ctrl-1")  # in german version TODO: differentiate languages
     def zoom_reset(): actions.key("ctrl-2")
 
 
@@ -31,11 +31,10 @@ class UserActions:
         page = actions.edit.selected_text()
         actions.key("tab:2 enter")
         return int(page)
-    def page_next(): actions.key("right")
-    def page_previous(): actions.key("left")
+    def page_next(): actions.key("ctrl-pagedown")
+    def page_previous(): actions.key("ctrl-pageup")
     def page_jump(number: int):
-        if number > 0:
-            actions.key("ctrl-shift-n")
-            actions.insert(str(number))
-            actions.key("enter")
+        actions.key("ctrl-shift-n")
+        actions.insert(str(number))
+        actions.key("enter")
     def page_final(): actions.key("end")

--- a/apps/calibre/calibre.py
+++ b/apps/calibre/calibre.py
@@ -1,0 +1,19 @@
+from talon import Module
+
+# --- App definition ---
+mod = Module()
+mod.apps.calibre = """
+os: windows
+and app.name: calibre.exe
+os: windows
+and app.exe: calibre.exe
+os: windows
+and app.name: calibre-parallel.exe
+os: windows
+and app.exe: calibre-parallel.exe
+"""
+mod.apps.calibre = """
+os: linux
+app.name: calibre
+"""
+# TODO: mac context

--- a/apps/calibre/calibre_viewer.py
+++ b/apps/calibre/calibre_viewer.py
@@ -1,0 +1,30 @@
+from talon import Module, Context, actions
+
+# --- App definition ---
+mod = Module()
+mod.apps.calibre_viewer = """
+app: calibre
+title: /E-book viewer$/
+title: /eBook-Betrachter$/
+"""
+
+# Context matching
+ctx = Context()
+ctx.matches = """
+os: windows
+os: linux
+app: calibre_viewer
+"""
+# TODO: mac implementation
+
+
+# --- Implement actions ---
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_next(): actions.key("pagedown")
+    def page_previous(): actions.key("pageup")
+    def page_final(): actions.key("ctrl-end")
+    # user.chapters
+    def chapter_next(): actions.key("ctrl-pagedown")
+    def chapter_previous(): actions.key("ctrl-pageup")

--- a/apps/calibre/calibre_viewer.talon
+++ b/apps/calibre/calibre_viewer.talon
@@ -1,0 +1,5 @@
+app: calibre_viewer
+-
+# Set tags
+tag(): user.pages
+tag(): user.chapters

--- a/apps/kindle/kindle.py
+++ b/apps/kindle/kindle.py
@@ -1,0 +1,11 @@
+from talon import Module
+
+# --- App definition ---
+mod = Module()
+mod.apps.kindle = """
+os: windows
+and app.name: Kindle
+os: windows
+and app.exe: Kindle.exe
+"""
+# TODO: mac context and implementation

--- a/apps/kindle/kindle.talon
+++ b/apps/kindle/kindle.talon
@@ -1,0 +1,4 @@
+app: kindle
+-
+# Set tags
+tag(): user.pages

--- a/apps/kindle/win.py
+++ b/apps/kindle/win.py
@@ -15,7 +15,6 @@ class UserActions:
     def page_next(): actions.key("down")
     def page_previous(): actions.key("up")
     def page_jump(number: int):
-        if number > 0:
-            actions.key("ctrl-g")
-            actions.insert(str(number))
-            actions.key("enter")
+        actions.key("ctrl-g")
+        actions.insert(str(number))
+        actions.key("enter")

--- a/apps/kindle/win.py
+++ b/apps/kindle/win.py
@@ -1,0 +1,21 @@
+from talon import Context, actions
+
+# Context matching
+ctx = Context()
+ctx.matches = """
+os: windows
+app: kindle
+"""
+
+
+# --- Implement actions ---
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_next(): actions.key("down")
+    def page_previous(): actions.key("up")
+    def page_jump(number: int):
+        if number > 0:
+            actions.key("ctrl-g")
+            actions.insert(str(number))
+            actions.key("enter")

--- a/apps/okular/okular.py
+++ b/apps/okular/okular.py
@@ -1,0 +1,43 @@
+from talon import Module, Context, actions
+
+# --- App definition ---
+mod = Module()
+mod.apps.okular = """
+os: windows
+and app.name: okular.exe
+os: windows
+and app.exe: okular.exe
+"""
+mod.apps.okular = """
+os: linux
+and app.name: okular
+"""
+# TODO: mac context and implementation
+
+# Context matching
+ctx = Context()
+ctx.matches = """
+os: windows
+os: linux
+app: okular
+"""
+
+
+# --- Implement actions ---
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_current():
+        actions.key("ctrl-g")
+        page = actions.edit.selected_text()
+        actions.key("escape")
+        return int(page)
+    def page_next(): actions.key("l")
+    def page_previous(): actions.key("h")
+    def page_jump(number: int):
+        if number > 0:
+            actions.key("ctrl-g")
+            actions.sleep("100ms")
+            actions.insert(str(number))
+            actions.key("enter")
+    def page_final(): actions.key("ctrl-end")

--- a/apps/okular/okular.py
+++ b/apps/okular/okular.py
@@ -35,9 +35,8 @@ class UserActions:
     def page_next(): actions.key("l")
     def page_previous(): actions.key("h")
     def page_jump(number: int):
-        if number > 0:
-            actions.key("ctrl-g")
-            actions.sleep("100ms")
-            actions.insert(str(number))
-            actions.key("enter")
+        actions.key("ctrl-g")
+        actions.sleep("100ms")
+        actions.insert(str(number))
+        actions.key("enter")
     def page_final(): actions.key("ctrl-end")

--- a/apps/okular/okular.talon
+++ b/apps/okular/okular.talon
@@ -1,0 +1,4 @@
+app: okular
+-
+# Set tags
+tag(): user.pages

--- a/apps/platforms/linux/atril/atril.py
+++ b/apps/platforms/linux/atril/atril.py
@@ -26,8 +26,7 @@ class UserActions:
     def page_next(): actions.key("ctrl-pagedown")
     def page_previous(): actions.key("ctrl-pageup")
     def page_jump(number: int):
-        if number > 0:
-            actions.key("ctrl-l")
-            actions.insert(str(number))
-            actions.key("enter")
+        actions.key("ctrl-l")
+        actions.insert(str(number))
+        actions.key("enter")
     def page_final(): actions.key("ctrl-end")

--- a/apps/platforms/linux/atril/atril.py
+++ b/apps/platforms/linux/atril/atril.py
@@ -1,0 +1,33 @@
+from talon import Module, Context, actions
+
+# --- App definition ---
+mod = Module()
+mod.apps.atril = """
+os: linux
+and app.name: Atril
+"""
+
+# Context matching
+ctx = Context()
+ctx.matches = r"""
+app: atril
+"""
+
+
+# --- Implement actions ---
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_current():
+        actions.key("ctrl-l")
+        page = actions.edit.selected_text()
+        actions.key("right escape")
+        return int(page)
+    def page_next(): actions.key("ctrl-pagedown")
+    def page_previous(): actions.key("ctrl-pageup")
+    def page_jump(number: int):
+        if number > 0:
+            actions.key("ctrl-l")
+            actions.insert(str(number))
+            actions.key("enter")
+    def page_final(): actions.key("ctrl-end")

--- a/apps/platforms/linux/atril/atril.talon
+++ b/apps/platforms/linux/atril/atril.talon
@@ -1,0 +1,4 @@
+app: atril
+-
+# Set tags
+tag(): user.pages

--- a/apps/platforms/linux/evince/evince.py
+++ b/apps/platforms/linux/evince/evince.py
@@ -1,0 +1,33 @@
+from talon import Module, Context, actions
+
+# --- App definition ---
+mod = Module()
+mod.apps.evince = """
+os: linux
+and app.name: Evince
+"""
+
+# Context matching
+ctx = Context()
+ctx.matches = r"""
+app: evince
+"""
+
+
+# --- Implement actions ---
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_current():
+        actions.key("ctrl-l")
+        page = actions.edit.selected_text()
+        actions.key("escape")
+        return int(page)
+    def page_next(): actions.key("n")
+    def page_previous(): actions.key("p")
+    def page_jump(number: int):
+        if number > 0:
+            actions.key("ctrl-l")
+            actions.insert(str(number))
+            actions.key("enter")
+    def page_final(): actions.key("ctrl-end")

--- a/apps/platforms/linux/evince/evince.py
+++ b/apps/platforms/linux/evince/evince.py
@@ -26,8 +26,7 @@ class UserActions:
     def page_next(): actions.key("n")
     def page_previous(): actions.key("p")
     def page_jump(number: int):
-        if number > 0:
-            actions.key("ctrl-l")
-            actions.insert(str(number))
-            actions.key("enter")
+        actions.key("ctrl-l")
+        actions.insert(str(number))
+        actions.key("enter")
     def page_final(): actions.key("ctrl-end")

--- a/apps/platforms/linux/evince/evince.talon
+++ b/apps/platforms/linux/evince/evince.talon
@@ -1,0 +1,4 @@
+app: evince
+-
+# Set tags
+tag(): user.pages

--- a/apps/platforms/win/nitro_reader/nitro_reader_5.py
+++ b/apps/platforms/win/nitro_reader/nitro_reader_5.py
@@ -1,0 +1,40 @@
+from talon import Module, Context, actions
+
+# --- App definition ---
+mod = Module()
+mod.apps.nitro_reader_five = """
+os: windows
+and app.name: Nitro Reader 5
+os: windows
+and app.exe: NitroPDFReader.exe
+"""
+
+# Context matching
+ctx = Context()
+ctx.matches = """
+app: nitro_reader_five
+"""
+
+
+# --- Implement actions ---
+@ctx.action_class("app")
+class app_actions:
+    # app.tabs
+    def tab_open(): actions.key("ctrl-shift-o")
+
+
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_next(): actions.key("right")
+    def page_previous(): actions.key("left")
+    def page_jump(number: int):
+        if number > 0:
+            actions.key("ctrl-g")
+            actions.edit.select_line()
+            actions.insert(str(number))
+            actions.key("enter alt:2")
+    def page_final(): actions.key("end")
+    # user.tabs
+    def tab_jump(number: int): pass
+    def tab_final(): pass

--- a/apps/platforms/win/nitro_reader/nitro_reader_5.py
+++ b/apps/platforms/win/nitro_reader/nitro_reader_5.py
@@ -29,12 +29,8 @@ class UserActions:
     def page_next(): actions.key("right")
     def page_previous(): actions.key("left")
     def page_jump(number: int):
-        if number > 0:
-            actions.key("ctrl-g")
-            actions.edit.select_line()
-            actions.insert(str(number))
-            actions.key("enter alt:2")
+        actions.key("ctrl-g")
+        actions.edit.select_line()
+        actions.insert(str(number))
+        actions.key("enter alt:2")
     def page_final(): actions.key("end")
-    # user.tabs
-    def tab_jump(number: int): pass
-    def tab_final(): pass

--- a/apps/platforms/win/nitro_reader/nitro_reader_5.talon
+++ b/apps/platforms/win/nitro_reader/nitro_reader_5.talon
@@ -1,0 +1,5 @@
+app: nitro_reader_five
+-
+# Set tags
+tag(): user.pages
+tag(): user.tabs

--- a/apps/platforms/win/sumatrapdf/sumatrapdf.py
+++ b/apps/platforms/win/sumatrapdf/sumatrapdf.py
@@ -1,0 +1,52 @@
+from talon import Module, Context, actions
+
+# --- App definition ---
+mod = Module()
+mod.apps.sumatrapdf = """
+os: windows
+and app.name: SumatraPDF
+os: windows
+and app.exe: SumatraPDF.exe
+"""
+
+# Context matching
+ctx = Context()
+ctx.matches = """
+app: sumatrapdf
+"""
+
+
+# --- Implement actions ---
+@ctx.action_class("app")
+class app_actions:
+    # app.tabs
+    def tab_open(): actions.key("ctrl-o")
+
+
+@ctx.action_class('edit')
+class EditActions:
+    def zoom_in(): actions.key("+")
+    def zoom_out(): actions.key("-")
+
+
+@ctx.action_class("user")
+class UserActions:
+    # user.pages
+    def page_current():
+        actions.key("ctrl-g")
+        page = actions.edit.selected_text()
+        actions.key("escape")
+        return int(page)
+    def page_next(): actions.key("n")
+    def page_previous(): actions.key("p")
+    def page_jump(number: int):
+        if number > 0:
+            actions.key("ctrl-g")
+            actions.insert(str(number))
+            actions.key("enter")
+    def page_final(): actions.key("end")
+    # user.tabs
+    def tab_jump(number: int):
+        if number < 9:
+            actions.key(f"alt-{number}")
+    def tab_final(): actions.key("alt-9")

--- a/apps/platforms/win/sumatrapdf/sumatrapdf.py
+++ b/apps/platforms/win/sumatrapdf/sumatrapdf.py
@@ -40,10 +40,9 @@ class UserActions:
     def page_next(): actions.key("n")
     def page_previous(): actions.key("p")
     def page_jump(number: int):
-        if number > 0:
-            actions.key("ctrl-g")
-            actions.insert(str(number))
-            actions.key("enter")
+        actions.key("ctrl-g")
+        actions.insert(str(number))
+        actions.key("enter")
     def page_final(): actions.key("end")
     # user.tabs
     def tab_jump(number: int):

--- a/apps/platforms/win/sumatrapdf/sumatrapdf.talon
+++ b/apps/platforms/win/sumatrapdf/sumatrapdf.talon
@@ -1,0 +1,5 @@
+app: sumatrapdf
+-
+# Set tags
+tag(): user.pages
+tag(): user.tabs

--- a/code/chapters.py
+++ b/code/chapters.py
@@ -15,7 +15,7 @@ class Actions:
         actions.user.chapter_jump(actions.user.chapter_current() + 1)
     def chapter_previous():
         """Go to previous chapter"""
-        actions.user.chapter_jump(min(actions.user.chapter_current() - 1, 1))
+        actions.user.chapter_jump(actions.user.chapter_current() - 1)
     def chapter_jump(number: int):
         """Go to chapter number"""
     def chapter_final():

--- a/code/chapters.py
+++ b/code/chapters.py
@@ -1,0 +1,22 @@
+from talon import Module, actions
+
+# --- Tag definition ---
+mod = Module()
+mod.tag("chapters", desc="Reader app with chapter navigation")
+
+
+# --- Define actions ---
+@mod.action_class
+class Actions:
+    def chapter_current() -> int:
+        """Return current chapter number"""
+    def chapter_next():
+        """Go to next chapter"""
+        actions.user.chapter_jump(actions.user.chapter_current() + 1)
+    def chapter_previous():
+        """Go to previous chapter"""
+        actions.user.chapter_jump(min(actions.user.chapter_current() - 1, 1))
+    def chapter_jump(number: int):
+        """Go to chapter number"""
+    def chapter_final():
+        """Go to final chapter"""

--- a/code/pages.py
+++ b/code/pages.py
@@ -1,0 +1,22 @@
+from talon import Module, actions
+
+# --- Tag definition ---
+mod = Module()
+mod.tag("pages", desc="Anything with page navigation")
+
+
+# --- Define actions ---
+@mod.action_class
+class Actions:
+    def page_current() -> int:
+        """Return current page number"""
+    def page_next():
+        """Go to next page"""
+        actions.user.page_jump(actions.user.page_current() + 1)
+    def page_previous():
+        """Go to previous page"""
+        actions.user.page_jump(actions.user.page_current() - 1)
+    def page_jump(number: int):
+        """Go to page number"""
+    def page_final():
+        """Go to final page"""

--- a/misc/chapters.talon
+++ b/misc/chapters.talon
@@ -1,0 +1,6 @@
+tag: user.chapters
+-
+chapter next: user.chapter_next()
+chapter last: user.chapter_previous()
+go chapter <number>: user.chapter_jump(number)
+go chapter final: user.chapter_final()

--- a/misc/pages.talon
+++ b/misc/pages.talon
@@ -1,0 +1,6 @@
+tag: user.pages
+-
+page next: user.page_next()
+page last: user.page_previous()
+go page <number>: user.page_jump(number)
+go page final: user.page_final()


### PR DESCRIPTION
Add tags to navigate pages and chapters.

Implement pages (and chapters/tabs when applicable) for reader apps:
- Adobe Acrobat Reader DC (mac missing)
- Calibre Viewer (mac missing)
- Kindle (mac missing)
- Okular (mac missing)
- Atril
- Evince
- Nitro Reader 5
- Sumatra PDF

Since I don't have a Mac, I could only implement for Windows and Linux.