### PR TITLE
numbers.py: disallow leading scale words

### DIFF
--- a/code/numbers.py
+++ b/code/numbers.py
@@ -169,7 +169,7 @@ def digits(m) -> int:
     """Parses a phrase representing a digit sequence, returning it as an integer."""
     return int(m.digit_string)
 
-@mod.capture(rule=f"{number_word_leading} {number_word}* (and {number_word}+)*")
+@mod.capture(rule=f"{number_word_leading} ([and] {number_word})*")
 def number_string(m) -> str:
     """Parses a number phrase, returning that number as a string."""
     return parse_number(list(m))

--- a/code/numbers.py
+++ b/code/numbers.py
@@ -155,6 +155,10 @@ alt_teens = "(" + ("|".join(teens_map.keys())) + ")"
 alt_tens = "(" + ("|".join(tens_map.keys())) + ")"
 alt_scales = "(" + ("|".join(scales_map.keys())) + ")"
 number_word = "(" + "|".join(numbers_map.keys()) + ")"
+# don't allow numbers to start with scale words like "hundred", "thousand", etc
+# or with "oh"/"o"; this disallows bare "oh" from recognizing as 0.
+leading_words = numbers_map.keys() - scales_map.keys() - {'oh', 'o'}
+number_word_leading = f"({'|'.join(leading_words)})"
 
 # TODO: allow things like "double eight" for 88
 @ctx.capture("digit_string", rule=f"({alt_digits} | {alt_teens} | {alt_tens})+")
@@ -165,7 +169,7 @@ def digits(m) -> int:
     """Parses a phrase representing a digit sequence, returning it as an integer."""
     return int(m.digit_string)
 
-@mod.capture(rule=f"{number_word}+ (and {number_word}+)*")
+@mod.capture(rule=f"{number_word_leading} {number_word}* (and {number_word}+)*")
 def number_string(m) -> str:
     """Parses a number phrase, returning that number as a string."""
     return parse_number(list(m))

--- a/code/numbers.py
+++ b/code/numbers.py
@@ -156,8 +156,8 @@ alt_tens = "(" + ("|".join(tens_map.keys())) + ")"
 alt_scales = "(" + ("|".join(scales_map.keys())) + ")"
 number_word = "(" + "|".join(numbers_map.keys()) + ")"
 # don't allow numbers to start with scale words like "hundred", "thousand", etc
-# or with "oh"/"o"; this disallows bare "oh" from recognizing as 0.
-leading_words = numbers_map.keys() - scales_map.keys() - {'oh', 'o'}
+leading_words = numbers_map.keys() - scales_map.keys()
+leading_words -= {'oh', 'o'} # comment out to enable bare/initial "oh"
 number_word_leading = f"({'|'.join(leading_words)})"
 
 # TODO: allow things like "double eight" for 88


### PR DESCRIPTION
fixes #634, so bare "hundred" "thousand" "million" etc will no longer recognize as numbers.

also disallows leading "oh" in number words, in particular preventing bare "oh" from recognizing as 0. I could factor this into a separate PR if desired, but it seems to be a common pain point.

In my testing this seems to perform fine during DFA compilation and command parsing. Would appreciate further testing.