### PR TITLE
adding missing camel_left/right to the line_commands.talon

### DIFF
--- a/text/line_commands.talon
+++ b/text/line_commands.talon
@@ -66,3 +66,8 @@ drag down <number> until <number>:
     user.select_range(number_1, number_2)
     edit.line_swap_down()
 clone (line|that): edit.line_clone()
+
+select camel left: user.extend_camel_left()
+select camel right: user.extend_camel_right()
+go camel left: user.camel_left()
+go camel right: user.camel_right()


### PR DESCRIPTION
camel_left/right functions were only in the line_commands.py python file. adding it also to the talon file