### PR TITLE
Fix VSCode draft window on Mac

### DIFF
--- a/draft_editor/draft_editor.talon
+++ b/draft_editor/draft_editor.talon
@@ -1,5 +1,5 @@
 user.draft_editor_running: True
-not app: draft_editor
+not tag: user.draft_editor_app_focused
 -
 
 draft this:

--- a/draft_editor/draft_editor_open.talon
+++ b/draft_editor/draft_editor_open.talon
@@ -1,5 +1,5 @@
-mode: user.draft_editor
-app: draft_editor
+tag: user.draft_editor_active
+and tag: user.draft_editor_app_focused
 -
 
 draft submit:    user.draft_editor_submit()


### PR DESCRIPTION
Switches to using tags for everything and then setting them by listening for app focus switch rather than trying to use `matches`.  Should be more robust, and also means it should reflect settings changes in real time

Also fixed timing issue on submit

- [x] Test Windows
- [x] Test Linux