### PR TITLE
Command client pre-phrase signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.sw?
 # Locally generated
 /settings
+.vscode/settings.json

--- a/apps/vscode/command_client/command_client.py
+++ b/apps/vscode/command_client/command_client.py
@@ -20,6 +20,10 @@ VSCODE_COMMAND_TIMEOUT_SECONDS = 3.0
 # long to sleep the first time
 MINIMUM_SLEEP_TIME_SECONDS = 0.0005
 
+# Indicates whether a pre-phrase signal was emitted during the course of the
+# current phrase 
+did_emit_pre_phrase_signal = False
+
 mod = Module()
 
 global_ctx = Context()
@@ -382,6 +386,9 @@ class LinuxUserActions:
 @global_ctx.action_class("user")
 class GlobalUserActions:
     def emit_pre_phrase_signal():
+        # NB: We explicitly define a noop version of this action in the global
+        # scope so that it doesn't do anything before phrases if you're not in
+        # vscode.
         pass
 
 
@@ -416,10 +423,7 @@ def get_signal_path(name: str) -> Path:
     return signal_dir / name
 
 
-did_emit_pre_phrase_signal = False
-
-
-def pre_phrase(_: any):
+def pre_phrase(_: Any):
     try:
         global did_emit_pre_phrase_signal
 
@@ -430,7 +434,7 @@ def pre_phrase(_: any):
         pass
 
 
-def post_phrase(_: any):
+def post_phrase(_: Any):
     global did_emit_pre_phrase_signal
     did_emit_pre_phrase_signal = False
 

--- a/apps/vscode/command_client/command_client.py
+++ b/apps/vscode/command_client/command_client.py
@@ -352,6 +352,21 @@ class Actions:
             return_command_output=True,
         )
 
+    def communication_dir_named_subdir(name: str) -> Path:
+        """
+        Get a named communication dir subdirectory.
+
+        Args:
+            name (str): The name of the subdir
+
+        Returns:
+            Path: The communication subdir
+        """
+        path = get_communication_dir_path() / "namedSubdirs" / name
+        path.mkdir(parents=True, exist_ok=True)
+
+        return path
+
     def trigger_command_server_command_execution():
         """Issue keystroke to trigger command server to execute command that
         was written to the file.  For internal use only"""

--- a/apps/vscode/command_client/command_client.py
+++ b/apps/vscode/command_client/command_client.py
@@ -387,7 +387,7 @@ class LinuxUserActions:
 class GlobalUserActions:
     def emit_pre_phrase_signal():
         # NB: We explicitly define a noop version of this action in the global
-        # scope here so that it doesn't do anything before phrases if you're not
+        # context here so that it doesn't do anything before phrases if you're not
         # in vscode.
         pass
 

--- a/apps/vscode/command_client/command_client.py
+++ b/apps/vscode/command_client/command_client.py
@@ -7,7 +7,7 @@ from tempfile import gettempdir
 from typing import Any, List
 from uuid import uuid4
 
-from talon import Context, Module, actions
+from talon import Context, Module, actions, speech_system
 
 # How old a request file needs to be before we declare it stale and are willing
 # to remove it
@@ -352,21 +352,6 @@ class Actions:
             return_command_output=True,
         )
 
-    def communication_dir_named_subdir(name: str) -> Path:
-        """
-        Get a named communication dir subdirectory.
-
-        Args:
-            name (str): The name of the subdir
-
-        Returns:
-            Path: The communication subdir
-        """
-        path = get_communication_dir_path() / "namedSubdirs" / name
-        path.mkdir(parents=True, exist_ok=True)
-
-        return path
-
     def trigger_command_server_command_execution():
         """Issue keystroke to trigger command server to execute command that
         was written to the file.  For internal use only"""
@@ -383,3 +368,26 @@ class MacUserActions:
 class LinuxUserActions:
     def trigger_command_server_command_execution():
         actions.key("ctrl-shift-alt-p")
+
+
+def get_signal_path(name: str) -> Path:
+    """
+    Get the path to a signal in the signal subdirectory.
+
+    Args:
+        name (str): The name of the subdir
+
+    Returns:
+        Path: The signal path
+    """
+    signal_dir = get_communication_dir_path() / "signals"
+    signal_dir.mkdir(parents=True, exist_ok=True)
+
+    return signal_dir / name
+
+
+def pre_phrase(_: any):
+    get_signal_path("prePhrase").touch()
+
+
+speech_system.register("pre:phrase", pre_phrase)

--- a/apps/vscode/command_client/command_client.py
+++ b/apps/vscode/command_client/command_client.py
@@ -387,8 +387,8 @@ class LinuxUserActions:
 class GlobalUserActions:
     def emit_pre_phrase_signal():
         # NB: We explicitly define a noop version of this action in the global
-        # scope so that it doesn't do anything before phrases if you're not in
-        # vscode.
+        # scope here so that it doesn't do anything before phrases if you're not
+        # in vscode.
         pass
 
 

--- a/apps/vscode/command_client/command_client.py
+++ b/apps/vscode/command_client/command_client.py
@@ -388,12 +388,7 @@ class GlobalUserActions:
 @ctx.action_class("user")
 class UserActions:
     def emit_pre_phrase_signal():
-        try:
-            global did_emit_pre_phrase_signal
-            get_signal_path("prePhrase").touch()
-            did_emit_pre_phrase_signal = True
-        except MissingCommunicationDir:
-            pass
+        get_signal_path("prePhrase").touch()
 
 
 class MissingCommunicationDir(Exception):
@@ -425,7 +420,14 @@ did_emit_pre_phrase_signal = False
 
 
 def pre_phrase(_: any):
-    actions.user.emit_pre_phrase_signal()
+    try:
+        global did_emit_pre_phrase_signal
+
+        actions.user.emit_pre_phrase_signal()
+
+        did_emit_pre_phrase_signal = True
+    except MissingCommunicationDir:
+        pass
 
 
 def post_phrase(_: any):


### PR DESCRIPTION
Touches a file known to the VSCode command server before executing any phrase, to allow VSCode extensions to detect start of phrase and maintain consistency over the course of a phrase.

Inaugural use case is allowing cursorless to freeze a snapshot of the hats so that they don't shift over the course of a single command phrase (https://github.com/pokey/cursorless-vscode/pull/318)