### PR TITLE
talon.py: rename update_lists to on_update_decls

### DIFF
--- a/lang/talon/talon.py
+++ b/lang/talon/talon.py
@@ -40,8 +40,7 @@ ctx.lists["user.code_functions"] = {
 }
 
 
-def update_lists(decls):
-    # print("update_lists")
+def on_update_decls(decls):
     # todo modes?
     for thing in [
         "actions",
@@ -66,8 +65,8 @@ def update_lists(decls):
 
 def on_ready():
     # print("on_ready")
-    update_lists(registry.decls)
-    registry.register("update_decls", update_lists)
+    on_update_decls(registry.decls)
+    registry.register("update_decls", on_update_decls)
 
 
 app.register("ready", on_ready)


### PR DESCRIPTION
In talon.py, update_lists has a confusing name, since `'update_lists'` is in fact the name of a different callback we can register for; this PR renames it to be called `on_update_decls`, since that's when it's called.