### PR TITLE
Add a question formatter to Talon

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -14,6 +14,8 @@ words_to_keep_lowercase = "a,an,the,at,by,for,in,is,of,on,to,up,and,as,but,or,no
 
 DEFAULT_SEPARATOR = ' '
 SMASH_SEPARATOR = ''
+SEP = False
+NOSEP = True
 
 # The last phrase spoken, without & with formatting. Used for reformatting.
 last_phrase = ""
@@ -67,10 +69,6 @@ def format_phrase_no_history(word_list, formatters: str):
     return separator.join(words)
 
 
-NOSEP = True
-SEP = False
-
-
 def words_with_joiner(joiner):
     """Pass through words unchanged, but add a separator between them."""
 
@@ -94,6 +92,24 @@ def first_vs_rest(first_func, rest_func=lambda w: w):
 
     def formatter_function(i, word, _):
         return first_func(word) if i == 0 else rest_func(word)
+
+    return formatter_function
+
+
+def last_vs_rest(last_func, rest_func=lambda w: w):
+    """Supply one or two transformer functions for the last and rest of
+    words respectively.
+
+    Leave second argument out if you want all but the last word to be passed
+    through unchanged.
+    Set first argument to None if you want the last word to be passed
+    through unchanged.
+    """
+    if last_func is None:
+        last_func = lambda w: w
+
+    def formatter_function(_, word, is_last_word):
+        return last_func(word) if is_last_word else rest_func(word)
 
     return formatter_function
 
@@ -136,6 +152,7 @@ formatters_dict = {
     "DOT_SNAKE": (NOSEP, lambda i, word, _: "." + word if i == 0 else "_" + word),
     "SLASH_SEPARATED": (NOSEP, every_word(lambda w: "/" + w)),
     "CAPITALIZE_FIRST_WORD": (SEP, first_vs_rest(lambda w: w.capitalize())),
+    "QUESTION": (SEP, last_vs_rest(lambda w: w + '?')),
     "CAPITALIZE_ALL_WORDS": (
         SEP,
         lambda i, word, _: word.capitalize()
@@ -151,6 +168,7 @@ formatters_dict = {
 formatters_words = {
     "allcaps": formatters_dict["ALL_CAPS"],
     "alldown": formatters_dict["ALL_LOWERCASE"],
+    "ask": formatters_dict["QUESTION"],
     "camel": formatters_dict["PRIVATE_CAMEL_CASE"],
     "dotted": formatters_dict["DOT_SEPARATED"],
     "dubstring": formatters_dict["DOUBLE_QUOTED_STRING"],
@@ -305,4 +323,3 @@ ctx.lists["self.prose_formatter"] = {
     "speak": "NOOP",
     "sentence": "CAPITALIZE_FIRST_WORD",
 }
-

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -12,6 +12,9 @@ words_to_keep_lowercase = "a,an,the,at,by,for,in,is,of,on,to,up,and,as,but,or,no
     ","
 )
 
+DEFAULT_SEPARATOR = ' '
+SMASH_SEPARATOR = ''
+
 # The last phrase spoken, without & with formatting. Used for reformatting.
 last_phrase = ""
 last_phrase_formatted = ""
@@ -28,7 +31,7 @@ def surround(by):
     return func
 
 
-def format_phrase(m: Union[str, Phrase], fmtrs: str):
+def format_phrase(m: Union[str, Phrase], formatters: str):
     global last_phrase, last_phrase_formatted
     last_phrase = m
     words = []
@@ -42,7 +45,7 @@ def format_phrase(m: Union[str, Phrase], fmtrs: str):
         words = actions.dictate.parse_words(m)
         words = actions.dictate.replace_words(words)
 
-    result = last_phrase_formatted = format_phrase_no_history(words, fmtrs)
+    result = last_phrase_formatted = format_phrase_no_history(words, formatters)
     actions.user.add_phrase_to_history(result)
     # Arguably, we shouldn't be dealing with history here, but somewhere later
     # down the line. But we have a bunch of code that relies on doing it this
@@ -50,18 +53,18 @@ def format_phrase(m: Union[str, Phrase], fmtrs: str):
     return result
 
 
-def format_phrase_no_history(word_list, fmtrs: str):
-    fmtr_list = fmtrs.split(",")
+def format_phrase_no_history(word_list, formatters: str):
+    formatter_list = formatters.split(",")
     words = []
     spaces = True
     for i, w in enumerate(word_list):
-        for name in reversed(fmtr_list):
+        for name in reversed(formatter_list):
             smash, func = all_formatters[name]
             w = func(i, w, i == len(word_list) - 1)
             spaces = spaces and not smash
         words.append(w)
-    sep = " " if spaces else ""
-    return sep.join(words)
+    separator = DEFAULT_SEPARATOR if spaces else SMASH_SEPARATOR
+    return separator.join(words)
 
 
 NOSEP = True
@@ -84,7 +87,8 @@ def first_vs_rest(first_func, rest_func=lambda w: w):
     Leave second argument out if you want all but the first word to be passed
     through unchanged.
     Set first argument to None if you want the first word to be passed
-    through unchanged."""
+    through unchanged.
+    """
     if first_func is None:
         first_func = lambda w: w
 


### PR DESCRIPTION
Adds a question formatter `ask` to Talon.

Example:
`"Ask where do I go"` -> `"where do I go?"`

In the future, I'd like to make an `ask` formatter which auto-capitalises the first word. For now I'm keeping it quite simple and assumption-free.


