### PR TITLE
Add browser action implementations for Chrome on Linux

### DIFF
--- a/apps/chrome/chrome.py
+++ b/apps/chrome/chrome.py
@@ -47,6 +47,7 @@ class user_actions:
         Long-term we want a better shortcut from browsers.
         """
         actions.browser.focus_address()
+        actions.sleep("180ms")
         actions.key("alt-enter")
 
 

--- a/apps/chrome/chrome.py
+++ b/apps/chrome/chrome.py
@@ -14,6 +14,11 @@ mod.apps.chrome = """
 os: mac
 and app.bundle: com.google.Chrome
 """
+mod.apps.chrome = """
+os: linux
+app.exe: chrome
+app.exe: chromium-browser
+"""
 ctx.matches = r"""
 app: chrome
 """

--- a/apps/chrome/linux.py
+++ b/apps/chrome/linux.py
@@ -1,0 +1,43 @@
+from talon import Context, actions
+
+ctx = Context()
+ctx.matches = """
+os: linux
+app: chrome
+"""
+ctx.tags = ['browser', 'user.tabs']
+
+@ctx.action_class('browser')
+class BrowserActions:
+    def bookmark():
+        actions.key('ctrl-d')
+    def bookmarks():
+        actions.key('ctrl-shift-o')
+    def bookmarks_bar():
+        actions.key('ctrl-shift-b')
+    def focus_address():
+        actions.key('ctrl-l')
+    def focus_search():
+        actions.browser.focus_address()
+    def go_blank():
+        actions.key('ctrl-n')
+    def go_back():
+        actions.key('alt-left')
+    def go_forward():
+        actions.key('alt-right')
+    def go_home():
+        actions.key('alt-home')
+    def open_private_window():
+        actions.key('ctrl-shift-n')
+    def reload():
+        actions.key('ctrl-r')
+    def reload_hard():
+        actions.key('ctrl-shift-r')
+    def show_downloads():
+        actions.key('ctrl-j')
+    def show_history():
+        actions.key('ctrl-h')
+    def submit_form():
+        actions.key('enter')
+    def toggle_dev_tools():
+        actions.key('ctrl-shift-i')


### PR DESCRIPTION
This lets Chrome/Chromium on Linux benefit from the generic browser commands. This PR also improves the reliability of the recently merged tab duplicate command (cc @xavier630).