### PR TITLE
dictation_mode: clarify comment

### DIFF
--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -2,7 +2,8 @@ mode: dictation
 -
 ^press <user.keys>$: key("{keys}")
 
-# Everything here should call auto_insert to preserve the state to correctly auto-capitalize/auto-space.
+# Everything here should call `auto_insert()` (instead of `insert()`), to preserve the state to correctly auto-capitalize/auto-space.
+# (Talonscript string literals implicitly call `auto_insert`, so there's no need to wrap those)
 <user.prose>: auto_insert(prose)
 new line: "\n"
 new paragraph: "\n\n"


### PR DESCRIPTION
I was a bit confused by this initially, because I thought it was saying that every insertion (including string literals) should be wrapped with `auto_insert()`.

But it's really just saying that you should call `auto_insert()` over `insert()` to ensure the text goes through the dictation inserter override defined here:

```python
@dictation_ctx.action_class("main")
class main_action:
    def auto_insert(text): actions.user.dictation_insert(text)
```