### PR TITLE
dictation.py refactoring

### DIFF
--- a/code/dictation.py
+++ b/code/dictation.py
@@ -12,21 +12,16 @@ setting_context_sensitive_dictation = mod.setting(
     desc="Look at surrounding text to improve auto-capitalization/spacing in dictation mode. By default, this works by selecting that text & copying it to the clipboard, so it may be slow or fail in some applications.",
 )
 
-# prose_modifiers gives actions that can be triggered within prose to alter
-# formatting of subsequent text. It maps spoken forms to DictationFormat method
-# names (see DictationFormat, below).
-prose_modifiers = {
+mod.list("prose_modifiers", desc="Modifiers that can be used within prose")
+mod.list("prose_snippets", desc="Snippets that can be used within prose")
+ctx = Context()
+# Maps spoken forms to DictationFormat method names (see DictationFormat below).
+ctx.lists["user.prose_modifiers"] = {
     "cap": "cap",
     "no cap": "no_cap",
     "no caps": "no_cap", # "no caps" variant for Dragon
     "no space": "no_space",
 }
-
-mod.list("prose_modifiers", desc="Modifiers that can be used within prose")
-mod.list("prose_snippets", desc="Snippets that can be used within prose")
-ctx = Context()
-# we use the keys in case any method name is a legitimate speakable phrase.
-ctx.lists["user.prose_modifiers"] = prose_modifiers.keys()
 ctx.lists["user.prose_snippets"] = {
     "spacebar": " ",
     "new line": "\n",
@@ -41,7 +36,7 @@ ctx.lists["user.prose_snippets"] = {
 
 @mod.capture(rule="{user.prose_modifiers}")
 def prose_modifier(m) -> Callable:
-    return getattr(DictationFormat, prose_modifiers[m.prose_modifiers])
+    return getattr(DictationFormat, m.prose_modifiers)
 
 @mod.capture(rule="({user.vocabulary} | <word>)")
 def word(m) -> str:

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -87,6 +87,7 @@ def apply_formatting(m):
     formatter.state = None
     result = ""
     for item in m:
+        # prose modifiers (cap/no cap/no space) produce formatter callbacks.
         if isinstance(item, Callable):
             item(formatter)
         else:


### PR DESCRIPTION
Goals of this PR:

1. Make it easier to change what "modifiers" are available in prose/dictation. Currently the meanings of "caps", "no caps", "no space" are hardcoded into `apply_formatting`, which must be kept in sync with both the `prose_modifiers` list and `dictation_mode.talon` commands.

2. Reduce duplication between prose_modifiers and dictation_mode.talon.

3. Allow curly quotes to be used without being auto-straightened, while still getting spacing right for open/close quote commands.

Progress:

- Made a global dictionary, `prose_modifiers`, that maps modifier names to DictationFormat methods; used to generate `{user.prose_modifiers}` and in `apply_formatting`. So instead of editing three places (dictation_mode.talon, the prose_modifiers list, and apply_formatters) you only need to edit two (dictation_mode.talon and the prose_modifiers dictionary).

- Replaced uses of `{user.prose_modifiers}` with a capture `<user.prose_modifier>` which produces a Callable. This avoids confusion between prose modifiers and user vocabulary that produces the same words (fixing #718).

It should be possible to re-use the prose_modifiers list to define commands in dictation_mode.talon. This will make the help for dictation_mode more confusing, unfortunately.