### PR TITLE
Add tag for C-style block comments

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -265,14 +265,7 @@ class UserActions:
     def code_insert_true():            actions.auto_insert('true')
     def code_insert_false():           actions.auto_insert('false')
     def code_comment_line_prefix(): actions.auto_insert('//')
-    def code_block_comment():
-        actions.insert('/*')
-        actions.key('enter')
-        actions.key('enter')
-        actions.insert('*/')
-        actions.edit.up()
-    def code_block_comment_prefix(): actions.auto_insert('/*')
-    def code_block_comment_suffix(): actions.auto_insert('*/')
+
     def code_insert_function(text: str, selection: str):
         if selection:
             text = text + "({})".format(selection)

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -7,7 +7,7 @@ and code.language: c
 tag(): user.code_imperative
 
 tag(): user.code_comment_line
-tag(): user.code_comment_block
+tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -8,6 +8,7 @@ tag(): user.code_imperative
 tag(): user.code_object_oriented
 
 tag(): user.code_comment_line
+tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -269,19 +269,6 @@ class UserActions:
     def code_comment_line_prefix():
         actions.auto_insert('// ')
 
-    def code_block_comment():
-        actions.insert('/*')
-        actions.key('enter')
-        actions.key('enter')
-        actions.insert('*/')
-        actions.edit.up()
-
-    def code_block_comment_prefix():
-        actions.auto_insert('/*')
-
-    def code_block_comment_suffix():
-        actions.auto_insert('*/')
-
     def code_insert_function(text: str, selection: str):
         if selection:
             text = text + "({})".format(selection)

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -6,7 +6,7 @@ tag(): user.code_imperative
 tag(): user.code_object_oriented
 
 tag(): user.code_comment_line
-tag(): user.code_comment_block
+tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -8,6 +8,7 @@ tag(): user.code_imperative
 tag(): user.code_object_oriented
 
 tag(): user.code_comment_line
+tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions

--- a/lang/tags/comment_block.py
+++ b/lang/tags/comment_block.py
@@ -1,13 +1,19 @@
-from talon import Context, Module
+from talon import Context, Module, actions
 
 ctx = Context()
 mod = Module()
 
 mod.tag("code_comment_block", desc="Tag for enabling generic block comment commands")
+mod.tag("code_comment_block_c_like", desc="Denotes usage of C-style block comments")
+
+ctx.matches = """
+tag: user.code_comment_block_c_like
+"""
+ctx.tags = ["user.code_comment_block"]
+
 
 @mod.action_class
 class Actions:
-
     def code_comment_block():
         """Block comment"""
 
@@ -16,3 +22,16 @@ class Actions:
 
     def code_comment_block_suffix():
         """Block comment end syntax"""
+
+
+@ctx.action_class("user")
+class CActions:
+    def code_comment_block():
+        actions.insert("/*\n\n*/")
+        actions.edit.up()
+
+    def code_comment_block_prefix():
+        actions.auto_insert("/*")
+
+    def code_comment_block_suffix():
+        actions.auto_insert("*/")

--- a/lang/tags/comment_block.py
+++ b/lang/tags/comment_block.py
@@ -1,15 +1,15 @@
 from talon import Context, Module, actions
 
-ctx = Context()
+c_like_ctx = Context()
 mod = Module()
 
 mod.tag("code_comment_block", desc="Tag for enabling generic block comment commands")
 mod.tag("code_comment_block_c_like", desc="Denotes usage of C-style block comments")
 
-ctx.matches = """
+c_like_ctx.matches = """
 tag: user.code_comment_block_c_like
 """
-ctx.tags = ["user.code_comment_block"]
+c_like_ctx.tags = ["user.code_comment_block"]
 
 
 @mod.action_class
@@ -24,7 +24,7 @@ class Actions:
         """Block comment end syntax"""
 
 
-@ctx.action_class("user")
+@c_like_ctx.action_class("user")
 class CActions:
     def code_comment_block():
         actions.insert("/*\n\n*/")


### PR DESCRIPTION
In #656 the block comment actions were renamed for consistency, however their implementations were not renamed. The only implementations of these were for C and Java.

This adds a common implementation for C-style block comments behind a tag, and adds the tag to C# and JavaScript.

Using a tag makes it easier for users to override `code_comment_block` for their editor (targeting the relevant languages) if needed (for example, if their editor auto-closes block comments).

This assumes that #716 will be merged, and hence does not add the tag to typescript.talon.