### PR TITLE
jetbrains: Ignore project module names

### DIFF
--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -263,15 +263,15 @@ class EditActions:
 
 @ctx.action_class("win")
 class WinActions:
-    def filename():
-        title = actions.win.title()
-        result = title.split(" ")
+    def filename() -> str:
+        title: str = actions.win.title()
+        result = title.split()
 
         # iterate over reversed result
         # to support titles such as
-        # Class.Library2 – a.js
+        # Class.Library2 – a.js [.workspace]
         for word in reversed(result):
-            if "." in word:
+            if not word.startswith("[") and "." in word:
                 return word
 
         return ""


### PR DESCRIPTION
IntelliJ allows for having projects with multiple modules, in a similar manner to multiple folders in a VSCode workspace.

This ignores the module name in the title, shown in square brackets after the filename.

I believe this fixes the issue described by @Michaelt293 in #408.