### PR TITLE
vscode: Fix go tab conflict with Mac desktop keys

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -243,13 +243,13 @@ class UserActions:
     def tab_jump(number: int):
         if number < 10:
             if is_mac:
-                actions.key("ctrl-{}".format(number))
+                actions.user.vscode(f"workbench.action.openEditorAtIndex{number}")
             else:
                 actions.key("alt-{}".format(number))
 
     def tab_final():
         if is_mac:
-            actions.key("ctrl-0")
+            actions.user.vscode("workbench.action.lastEditorInGroup")
         else:
             actions.key("alt-0")
 

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -243,7 +243,7 @@ class UserActions:
     def tab_jump(number: int):
         if number < 10:
             if is_mac:
-                actions.user.vscode(f"workbench.action.openEditorAtIndex{number}")
+                actions.user.vscode_with_plugin(f"workbench.action.openEditorAtIndex{number}")
             else:
                 actions.key("alt-{}".format(number))
 


### PR DESCRIPTION
VSCode's default keybindings for "switch to tab N" conflict with the default-ish macOS "switch to desktop N" keyboard shortcuts. This uses the command client to execute the desired commands instead.

I wasn't able to use the `openEditorAtIndex` via the command palette, so I'm being conservative and only doing this for macOS.