### PR TITLE
Handle capitalization of e.g. and i.e. within prose.

### DIFF
--- a/code/dictation.py
+++ b/code/dictation.py
@@ -161,7 +161,8 @@ no_cap_after = re.compile(r"""(
 
 def auto_capitalize(text, state = None):
     """
-    Auto-capitalizes text. `state` argument means:
+    Auto-capitalizes text. Text must contain complete words, abbreviations, and
+    formatted expressions. `state` argument means:
 
     - None: Don't capitalize initial word.
     - "sentence start": Capitalize initial word.

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -178,7 +178,7 @@ def auto_capitalize(text, state = None):
     sentence_end = False
     for c in text:
         # Sentence endings followed by space & double newlines create a charge.
-        if (sentence_end and c == " ") or (newline and c == "\n"):
+        if (sentence_end and c in " \n\t") or (newline and c == "\n"):
             charge = True
         # Alphanumeric characters and commas/colons absorb charge & try to
         # capitalize (for numbers & punctuation this does nothing, which is what

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -154,6 +154,11 @@ def needs_space_between(before: str, after: str) -> bool:
 # assert not needs_space_between("hello'", ".")
 # assert not needs_space_between("hello.", "'")
 
+no_cap_after = re.compile(r"""(
+    e\.g\.
+    | i\.e\.
+    )$""", re.VERBOSE)
+
 def auto_capitalize(text, state = None):
     """
     Auto-capitalizes text. `state` argument means:
@@ -170,9 +175,10 @@ def auto_capitalize(text, state = None):
     # string left-to-right.
     charge = state == "sentence start"
     newline = state == "after newline"
+    sentence_end = False
     for c in text:
-        # Sentence endings & double newlines create a charge.
-        if c in ".!?" or (newline and c == "\n"):
+        # Sentence endings followed by space & double newlines create a charge.
+        if (sentence_end and c == " ") or (newline and c == "\n"):
             charge = True
         # Alphanumeric characters and commas/colons absorb charge & try to
         # capitalize (for numbers & punctuation this does nothing, which is what
@@ -183,7 +189,8 @@ def auto_capitalize(text, state = None):
         # Otherwise the charge just passes through.
         output += c
         newline = c == "\n"
-    return output, ("sentence start" if charge else
+        sentence_end = c in ".!?" and not no_cap_after.search(output)
+    return output, ("sentence start" if charge or sentence_end else
                     "after newline" if newline else None)
 
 

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -29,6 +29,14 @@ if hasattr(talon, "test_mode"):
         assert result == " Third("
         result = format.format("fourth")
         assert result == "fourth"
+        result = format.format("e.g.")
+        assert result == " e.g."
+        result = format.format("fifth")
+        assert result == " fifth"
+        result = format.format("i.e.")
+        assert result == " i.e."
+        result = format.format("sixth")
+        assert result == " sixth"
 
     def test_force_spacing_and_capitalization():
         format = dictation.DictationFormat()

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -37,6 +37,10 @@ if hasattr(talon, "test_mode"):
         assert result == " i.e."
         result = format.format("sixth")
         assert result == " sixth"
+        result = format.format("with.\nspace")
+        assert result == " with.\nSpace"
+        result = format.format("new.\nline")
+        assert result == " new.\nLine"
 
     def test_force_spacing_and_capitalization():
         format = dictation.DictationFormat()


### PR DESCRIPTION
This works out of the box in Dragon. To test in Conformer you'll need to add something like this to additional_words.csv:
```
i.e.,I E
e.g.,E G
```