### PR TITLE
Fix watchdogs when getting page address in Safari

### DIFF
--- a/apps/platforms/mac/safari/safari.py
+++ b/apps/platforms/mac/safari/safari.py
@@ -25,15 +25,18 @@ class BrowserActions:
         except IndexError:
             return ''
         try:
-            address_field = window.element.children.find_one(
+            toolbar = window.children.find_one(AXRole='AXToolbar', max_depth=0)
+            address_field = toolbar.children.find_one(
                 AXRole='AXTextField', AXIdentifier='WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD')
             address = address_field.AXValue
         except (ui.UIErr, AttributeError):
             address = applescript.run('''
-            tell application id "com.apple.Safari"
-                if not (exists (window 1)) then return ""
-                return window 1's current tab's URL
-            end tell
+                tell application id "com.apple.Safari"
+                    with timeout of 0.1 seconds
+                        if not (exists (window 1)) then return ""
+                        return window 1's current tab's URL
+                    end timeout
+                end tell
             ''')
         return address
     def bookmark():


### PR DESCRIPTION
This sometimes inadvertently scanned in the web page. Now we only look in the window's toolbar for the address and search field.

Tested in all toolbar configurations in macOS 10.15 and 12.

Also add a short timeout to attempt to prevent hangs while trying to retrieve the frontmost tab's URL via AppleScript (backup method).