### PR TITLE
make "go <arrows>" use edit.left, allow "press <keys>" for arrow keys instead

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -249,3 +249,12 @@ ctx.lists["self.function_key"] = {
 }
 
 
+@mod.action_class
+class Actions:
+    def move_cursor(s: str):
+        """Given a sequence of directions, eg. 'left left up', moves the cursor accordingly using edit.{left,right,up,down}."""
+        for d in s.split():
+            if d in ('left','right','up','down'):
+                getattr(actions.edit, d)()
+            else:
+                raise RuntimeError(f'invalid arrow key: {d}')

--- a/misc/keys.talon
+++ b/misc/keys.talon
@@ -1,4 +1,4 @@
-go <user.arrow_keys>: key(arrow_keys)
+go <user.arrow_keys>: user.move_cursor(arrow_keys)
 <user.letter>: key(letter)
 (ship | uppercase) <user.letters> [(lowercase | sunk)]: 
     user.insert_formatted(letters, "ALL_CAPS")
@@ -6,4 +6,7 @@ go <user.arrow_keys>: key(arrow_keys)
 <user.function_key>: key(function_key)
 <user.special_key>: key(special_key)
 <user.modifiers> <user.unmodified_key>: key("{modifiers}-{unmodified_key}")
+# for key combos consisting only of modifiers, eg. `press super`.
 press <user.modifiers>: key(modifiers)
+# for consistency with dictation mode and explicit arrow keys if you need them.
+press <user.keys>: key(keys)

--- a/modes/dictation_mode.talon
+++ b/modes/dictation_mode.talon
@@ -1,6 +1,7 @@
 mode: dictation
 -
-^press <user.keys>$: key("{keys}")
+^press <user.modifiers>$: key(modifiers)
+^press <user.keys>$: key(keys)
 
 # Everything here should call `auto_insert()` (instead of `insert()`), to preserve the state to correctly auto-capitalize/auto-space.
 # (Talonscript string literals implicitly call `auto_insert`, so there's no need to wrap those)


### PR DESCRIPTION
Fix #713 and #741:

- `go <user.arrow_keys>` now invokes `edit.left/right/up/down`.
- `press` now has two forms, `press <user.keys>` to press a sequence of keys (eg. `press left left up`) or `press <user.modifiers>` to press a modifier key-combo (eg. `press control super`). These are present in command mode and (anchored) in dictation mode.