### PR TITLE
Remove redundant `ctrl` press from Mac screenshots

### DIFF
--- a/code/screenshot.py
+++ b/code/screenshot.py
@@ -38,7 +38,7 @@ class Actions:
         if app.platform == "windows":
             actions.key("super-shift-s")
         elif app.platform == "mac":
-            actions.key("ctrl-shift-cmd-4")
+            actions.key("cmd-shift-4")
         elif app.platform == "linux":
             actions.key("shift-printscr")
 


### PR DESCRIPTION
Remove redundant `ctrl` press from Mac screenshots