### PR TITLE
Add command to open screenshot settings

### DIFF
--- a/code/screenshot.py
+++ b/code/screenshot.py
@@ -42,6 +42,14 @@ class Actions:
         elif app.platform == "linux":
             actions.key("shift-printscr")
 
+    def screenshot_settings():
+        """Opens the settings UI for screenshots.
+        Only applies to Mac for now
+        """
+        if app.platform == "mac":
+            actions.key("cmd-shift-5")
+
+
     def screenshot_clipboard(screen_number: Optional[int] = None):
         """Takes a screenshot of the entire screen and saves it to the clipboard.
         Optional screen number can be given to use screen other than main."""

--- a/code/screenshot.py
+++ b/code/screenshot.py
@@ -48,7 +48,8 @@ class Actions:
         """
         if app.platform == "mac":
             actions.key("cmd-shift-5")
-
+        else:
+            app.notify("Not supported on this operating system")
 
     def screenshot_clipboard(screen_number: Optional[int] = None):
         """Takes a screenshot of the entire screen and saves it to the clipboard.

--- a/misc/screenshot.talon
+++ b/misc/screenshot.talon
@@ -2,7 +2,7 @@
 ^grab screen <number_small>$:        user.screenshot(number_small)
 ^grab window$:                       user.screenshot_window()
 ^grab selection$:                    user.screenshot_selection()
-
+^grab settings$:                     user.screenshot_settings()
 ^grab screen clip$:                  user.screenshot_clipboard()
 ^grab screen <number_small> clip$:   user.screenshot_clipboard(number_small)
 ^grab window clip$:                  user.screenshot_window_clipboard()


### PR DESCRIPTION
This is an important UI on mac for taking screenshots as it's where you decide where to save it, whether it will be a video, if a timer should be used, etc.

I'm open to ideas for the command naming, the naming I went for matches the pattern in the file but could be more intuitive.