### PR TITLE
Link Mac Chromium to Chrome config

### DIFF
--- a/apps/chrome/chrome.py
+++ b/apps/chrome/chrome.py
@@ -13,6 +13,10 @@ os: mac
 and app.bundle: com.google.Chrome
 """
 mod.apps.chrome = """
+os: mac
+and app.bundle: org.chromium.Chromium
+"""
+mod.apps.chrome = """
 os: linux
 app.exe: chrome
 app.exe: chromium-browser


### PR DESCRIPTION
Windows already works (the downloads I've found use chrome.exe) and Linux already has a custom matcher for Chromium