### PR TITLE
lowercase first word in camel-case formatters

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -104,11 +104,8 @@ def every_word(word_func):
 formatters_dict = {
     "NOOP": (SEP, lambda i, word, _: word),
     "DOUBLE_UNDERSCORE": (NOSEP, first_vs_rest(lambda w: "__%s__" % w)),
-    "PRIVATE_CAMEL_CASE": (NOSEP, first_vs_rest(lambda w: w, lambda w: w.capitalize())),
-    "PROTECTED_CAMEL_CASE": (
-        NOSEP,
-        first_vs_rest(lambda w: w, lambda w: w.capitalize()),
-    ),
+    "PRIVATE_CAMEL_CASE": (NOSEP, first_vs_rest(lambda w: w.lower(), lambda w: w.capitalize())),
+    "PROTECTED_CAMEL_CASE": (NOSEP, first_vs_rest(lambda w: w.lower(), lambda w: w.capitalize())),
     "PUBLIC_CAMEL_CASE": (NOSEP, every_word(lambda w: w.capitalize())),
     "SNAKE_CASE": (
         NOSEP,


### PR DESCRIPTION
currently if the user has a word that is capitalized in the lexicon, eg. "Baltics", then it'll be capitalized by "camel": "camel baltics hello" -> "BalticsHello". This is probably undesirable; this PR fixes it.