### PR TITLE
Add support for terraform

### DIFF
--- a/apps/terraform/terraform.py
+++ b/apps/terraform/terraform.py
@@ -1,0 +1,4 @@
+from talon import Module, Context
+
+mod = Module()
+mod.tag("terraform", desc="tag for enabling terraform commands in your terminal")

--- a/apps/terraform/terraform.talon
+++ b/apps/terraform/terraform.talon
@@ -1,0 +1,15 @@
+tag: terminal
+and tag: user.terraform
+-
+terraform: "terraform "
+
+terraform apply: "terraform apply "
+terraform destroy: "terraform destroy "
+terraform format recursive: "terraform fmt -recursive\n"
+terraform format: "terraform fmt\n"
+terraform help: "terraform -help"
+terraform init upgrade: "terraform init -upgrade\n"
+terraform init: "terraform init\n"
+terraform plan: "terraform plan\n"
+terraform state move: "terraform state mv "
+terraform validate: "terraform validate\n"

--- a/code/code.py
+++ b/code/code.py
@@ -32,6 +32,7 @@ extension_lang_map = {
     ".talon": "talon",
     ".ts": "typescript",
     ".tsx": "typescript",
+    ".tf": "terraform",
     ".vba": "vba",
     ".vim": "vimscript",
     ".vimrc": "vimscript",

--- a/lang/terraform/terraform.py
+++ b/lang/terraform/terraform.py
@@ -1,0 +1,156 @@
+from talon import Context, Module, actions, settings
+
+ctx = Context()
+mod = Module()
+ctx.matches = r"""
+mode: user.terraform
+mode: user.auto_lang
+and code.language: terraform
+"""
+
+types = {
+    "string": "string",
+    "number": "number",
+    "bool": "bool",
+    "list": "list",
+    "map": "map",
+    "null": "null"
+}
+
+ctx.lists["user.code_type"] = types
+
+common_properties = {
+    "name": "name",
+    "type": "type",
+    "description": "description",
+    "default": "default",
+    "for each": "for_each",
+    "count": "count",
+    "prevent destroy": "prevent_destroy",
+    "nullable": "nullable",
+    "sensitive": "sensitive",
+    "depends on": "depends_on",
+    "provider": "provider",
+    "source": "source",
+}
+
+mod.list("terraform_common_property", desc="Terraform Modifier")
+ctx.lists["self.terraform_common_property"] = common_properties
+
+module_blocks = {
+    "variable": "variable",
+    "output": "output",
+    "provider": "provider",
+    "module": "module",
+}
+
+mod.list("terraform_module_block", desc="Simple Terraform Block")
+ctx.lists["self.terraform_module_block"] = module_blocks
+
+
+@mod.action_class
+class Actions:
+
+    def code_terraform_module_block(text: str):
+        """Inserts a new module-related block of a given type (e.g. variable, output, provider...)"""
+
+    def code_terraform_resource(text: str):
+        """Inserts a new resource block with given name"""
+
+    def code_terraform_data_source(text: str):
+        """Inserts a new data block with given name"""
+
+
+@ctx.action_class("user")
+class UserActions:
+
+    def code_terraform_module_block(text: str):
+        actions.insert(text + ' ""')
+        actions.key("left")
+
+    def code_terraform_resource(text: str):
+        result = 'resource "{}" ""'.format(
+            actions.user.formatted_text(
+                text, "SNAKE_CASE"
+            )
+        )
+
+        actions.insert(result)
+        actions.key("left")
+
+    def code_terraform_data_source(text: str):
+        result = 'data "{}" ""'.format(
+            actions.user.formatted_text(
+                text, "SNAKE_CASE"
+            )
+        )
+
+        actions.insert(result)
+        actions.key("left")
+
+    def code_operator_assignment():
+        actions.insert(" = ")
+
+    def code_operator_subtraction():
+        actions.insert(" - ")
+
+    def code_operator_addition():
+        actions.insert(" + ")
+
+    def code_operator_multiplication():
+        actions.insert(" * ")
+
+    def code_operator_division():
+        actions.insert(" / ")
+
+    def code_operator_modulo():
+        actions.insert(" % ")
+
+    def code_operator_equal():
+        actions.insert(" == ")
+
+    def code_operator_not_equal():
+        actions.insert(" != ")
+
+    def code_operator_greater_than():
+        actions.insert(" > ")
+
+    def code_operator_greater_than_or_equal_to():
+        actions.insert(" >= ")
+
+    def code_operator_less_than():
+        actions.insert(" < ")
+
+    def code_operator_less_than_or_equal_to():
+        actions.insert(" <= ")
+
+    def code_operator_and():
+        actions.insert(" && ")
+
+    def code_operator_or():
+        actions.insert(" || ")
+
+    def code_insert_true():
+        actions.insert("true")
+
+    def code_insert_false():
+        actions.insert("false")
+
+    def code_operator_lambda():
+        actions.insert(" => ")
+
+    def code_insert_null():
+        actions.insert("null")
+
+    def code_insert_is_null():
+        actions.insert(" == null")
+
+    def code_insert_is_not_null():
+        actions.insert(" != null")
+
+    def code_comment_line_prefix():
+        actions.insert("# ")
+
+    def code_state_for():
+        actions.insert("for  in")
+        actions.key("left left left")

--- a/lang/terraform/terraform.talon
+++ b/lang/terraform/terraform.talon
@@ -1,0 +1,29 @@
+mode: command
+and mode: user.terraform
+mode: command
+and mode: user.auto_lang
+and code.language: terraform
+-
+tag(): user.code_comment_block_c_like
+tag(): user.code_comment_line
+tag(): user.code_data_bool
+tag(): user.code_data_null
+tag(): user.code_imperative
+tag(): user.code_operators_assignment
+tag(): user.code_operators_lambda
+tag(): user.code_operators_math
+
+state {user.terraform_module_block}:
+    user.code_terraform_module_block(user.terraform_module_block)
+
+resource <user.text>:
+    user.code_terraform_resource(text)
+
+data [source] <user.text>:
+    user.code_terraform_data_source(text)
+
+[state] prop {user.terraform_common_property}:
+    insert(user.terraform_common_property)
+    user.code_operator_assignment()
+
+type {user.code_type}: insert("{code_type}")

--- a/modes/language_modes.talon
+++ b/modes/language_modes.talon
@@ -6,6 +6,7 @@
 ^force type script$: user.code_set_language_mode("typescript")
 ^force markdown$: user.code_set_language_mode("markdown")
 ^force python$: user.code_set_language_mode("python")
+^force terraform$: user.code_set_language_mode("terraform")
 ^force are language$: user.code_set_language_mode("r")
 ^force talon [language]$: user.code_set_language_mode("talon")
 ^clear language modes$: user.code_clear_language_mode()


### PR DESCRIPTION
This merge request intends to add support for [terraform](https://www.terraform.io/). Since terraform is both an application and a language, I included basic bindings for both.
Terraform uses a declarative language, so I could not implement most of the mutating definitions in tag `user.code_operators_assignment`. I included this tag only for the assignment operator. I'm not sure of this is the right way to go.