### PR TITLE
Expose CAPITALIZE_FIRST_WORD as 'sentence' formatter

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -151,6 +151,7 @@ formatters_words = {
     "kebab": formatters_dict["DASH_SEPARATED"],
     "packed": formatters_dict["DOUBLE_COLON_SEPARATED"],
     "padded": formatters_dict["SPACE_SURROUNDED_STRING"],
+    "sentence": formatters_dict["CAPITALIZE_FIRST_WORD"],
     "slasher": formatters_dict["SLASH_SEPARATED"],
     "smash": formatters_dict["NO_SPACES"],
     "snake": formatters_dict["SNAKE_CASE"],


### PR DESCRIPTION
 Hey there! Just a tiny pull request for a functionality I personally found lacking so far. This exposes the `CAPITALIZE_FIRST_WORD` formatter for usage via speech. I found this useful e.g. for writing comments or log statements without changing modes to do so. Feel free to deny this PR if you don't think it fits into your vision for this repository, or if it causes some kind of collision I am not aware of.