### PR TITLE
Add c keywords

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -30,7 +30,7 @@ ctx.lists["self.c_signed"] = {
     "unsigned": "unsigned ",
 }
 
-common_types = {
+ctx.lists["self.c_keywords"] = {
     "static": "static",
     "volatile": "volatile",
     "register": "register",
@@ -135,6 +135,7 @@ ctx.lists["user.code_functions"] = {
 
 mod.list("c_pointers", desc="Common C pointers")
 mod.list("c_signed", desc="Common C datatype signed modifiers")
+mod.list("c_keywords", desc="C keywords")
 mod.list("c_types", desc="Common C types")
 mod.list("stdint_types", desc="Common stdint C types")
 mod.list("stdint_signed", desc="Common stdint C datatype signed modifiers")
@@ -151,6 +152,10 @@ def c_signed(m) -> str:
     "Returns a string"
     return m.c_signed
 
+@mod.capture(rule="{self.c_keywords}")
+def c_keywords(m) -> str:
+    "Returns a string"
+    return m.c_keywords
 
 @mod.capture(rule="{self.c_types}")
 def c_types(m) -> str:

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -94,6 +94,7 @@ cast to <user.c_cast>: "{c_cast}"
 standard cast to <user.stdint_cast>: "{stdint_cast}"
 <user.c_types>: "{c_types}"
 <user.c_pointers>: "{c_pointers}"
+<user.c_keywords>: "{c_keywords}"
 <user.c_signed>: "{c_signed}"
 standard <user.stdint_types>: "{stdint_types}"
 int main:


### PR DESCRIPTION
This common types dictionary was created but unused before. I've renamed it to c_keywords as that more accurately describes what was inside the dictionary (though it is not a complete list of the c keywords at the moment) .  I've then tried to plug it into the .talon file the same way the c_types dictionary is.