### PR TITLE
Align java with other languages

### DIFF
--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -35,8 +35,8 @@ java_boxed_types = {
     "Void": "Void",
 }
 
-mod.list("java_boxed_types", desc="Java Boxed Types")
-ctx.lists["self.java_boxed_types"] = java_boxed_types
+mod.list("java_boxed_type", desc="Java Boxed Types")
+ctx.lists["self.java_boxed_type"] = java_boxed_types
 
 # Common Classes
 java_common_classes = {
@@ -46,8 +46,8 @@ java_common_classes = {
     "exception": "Exception",
 }
 
-mod.list("java_common_classes", desc="Java Common Classes")
-ctx.lists["self.java_common_classes"] = java_common_classes
+mod.list("java_common_class", desc="Java Common Classes")
+ctx.lists["self.java_common_class"] = java_common_classes
 
 
 
@@ -72,8 +72,8 @@ unboxed_types.update(java_generic_data_structures)
 
 ctx.lists["user.code_type"] = unboxed_types
 
-mod.list("java_generic_data_structures", desc="Java Generic Data Structures")
-ctx.lists["self.java_generic_data_structures"] = java_generic_data_structures
+mod.list("java_generic_data_structure", desc="Java Generic Data Structures")
+ctx.lists["self.java_generic_data_structure"] = java_generic_data_structures
 
 # Java Modifies
 java_modifiers = {
@@ -89,119 +89,119 @@ java_modifiers = {
     "final": "final",
 }
 
-mod.list("java_modifiers", desc="Java Modifiers")
-ctx.lists["self.java_modifiers"] = java_modifiers
+mod.list("java_modifier", desc="Java Modifiers")
+ctx.lists["self.java_modifier"] = java_modifiers
 
 @ctx.action_class("user")
 class UserActions:
     def code_operator_lambda():
-        actions.auto_insert(" -> ")
+        actions.insert(" -> ")
 
     def code_operator_subscript():
         actions.insert("[]")
         actions.key("left")
 
     def code_operator_assignment():
-        actions.auto_insert(" = ")
+        actions.insert(" = ")
 
     def code_operator_subtraction():
-        actions.auto_insert(" - ")
+        actions.insert(" - ")
 
     def code_operator_subtraction_assignment():
-        actions.auto_insert(" -= ")
+        actions.insert(" -= ")
 
     def code_operator_addition():
-        actions.auto_insert(" + ")
+        actions.insert(" + ")
 
     def code_operator_addition_assignment():
-        actions.auto_insert(" += ")
+        actions.insert(" += ")
 
     def code_operator_multiplication():
-        actions.auto_insert(" * ")
+        actions.insert(" * ")
 
     def code_operator_multiplication_assignment():
-        actions.auto_insert(" *= ")
+        actions.insert(" *= ")
 
     def code_operator_exponent():
-        actions.auto_insert(" ^ ")
+        actions.insert(" ^ ")
 
     def code_operator_division():
-        actions.auto_insert(" / ")
+        actions.insert(" / ")
 
     def code_operator_division_assignment():
-        actions.auto_insert(" /= ")
+        actions.insert(" /= ")
 
     def code_operator_modulo():
-        actions.auto_insert(" % ")
+        actions.insert(" % ")
 
     def code_operator_modulo_assignment():
-        actions.auto_insert(" %= ")
+        actions.insert(" %= ")
 
     def code_operator_equal():
-        actions.auto_insert(" == ")
+        actions.insert(" == ")
 
     def code_operator_not_equal():
-        actions.auto_insert(" != ")
+        actions.insert(" != ")
 
     def code_operator_greater_than():
-        actions.auto_insert(" > ")
+        actions.insert(" > ")
 
     def code_operator_greater_than_or_equal_to():
-        actions.auto_insert(" >= ")
+        actions.insert(" >= ")
 
     def code_operator_less_than():
-        actions.auto_insert(" < ")
+        actions.insert(" < ")
 
     def code_operator_less_than_or_equal_to():
-        actions.auto_insert(" <= ")
+        actions.insert(" <= ")
 
     def code_operator_and():
-        actions.auto_insert(" && ")
+        actions.insert(" && ")
 
     def code_operator_or():
-        actions.auto_insert(" || ")
+        actions.insert(" || ")
 
     def code_operator_bitwise_and():
-        actions.auto_insert(" & ")
+        actions.insert(" & ")
 
     def code_operator_bitwise_and_assignment():
-        actions.auto_insert(' &= ')
+        actions.insert(' &= ')
 
     def code_operator_increment():
-        actions.auto_insert('++')
+        actions.insert('++')
 
     def code_operator_bitwise_or():
-        actions.auto_insert(" | ")
+        actions.insert(" | ")
 
     def code_operator_bitwise_exclusive_or():
-        actions.auto_insert(" ^ ")
+        actions.insert(" ^ ")
 
     def code_operator_bitwise_left_shift():
-        actions.auto_insert(" << ")
+        actions.insert(" << ")
 
     def code_operator_bitwise_left_shift_assignment():
-        actions.auto_insert(" <<= ")
+        actions.insert(" <<= ")
 
     def code_operator_bitwise_right_shift():
-        actions.auto_insert(" >> ")
+        actions.insert(" >> ")
 
     def code_operator_bitwise_right_shift_assignment():
-        actions.auto_insert(" >>= ")
+        actions.insert(" >>= ")
 
     def code_self():
-        actions.auto_insert("this")
+        actions.insert("this")
 
     def code_operator_object_accessor():
-        actions.auto_insert(".")
+        actions.insert(".")
 
     def code_insert_null():
-        actions.auto_insert("null")
+        actions.insert("null")
 
     def code_insert_is_null():
-        actions.auto_insert(" == null")
+        actions.insert(" == null")
 
     def code_insert_is_not_null():
-        actions.auto_insert(" != null")
+        actions.insert(" != null")
 
     def code_state_if():
         actions.insert("if () ")
@@ -237,22 +237,22 @@ class UserActions:
         actions.edit.left()
 
     def code_break():
-        actions.auto_insert('break;')
+        actions.insert('break;')
 
     def code_next():
-        actions.auto_insert('continue;')
+        actions.insert('continue;')
 
     def code_insert_true():
-        actions.auto_insert('true')
+        actions.insert('true')
 
     def code_insert_false():
-        actions.auto_insert('false')
+        actions.insert('false')
 
     def code_define_class():
-        actions.auto_insert("class ")
+        actions.insert("class ")
 
     def code_import():
-        actions.auto_insert("import ")
+        actions.insert("import ")
 
     def code_private_function(text: str):
         actions.insert("private")
@@ -267,7 +267,7 @@ class UserActions:
         actions.insert("return ")
 
     def code_comment_line_prefix():
-        actions.auto_insert('// ')
+        actions.insert('// ')
 
     def code_insert_function(text: str, selection: str):
         if selection:

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -1,5 +1,7 @@
-mode: user.java
-mode: user.auto_lang
+mode: command
+and mode: user.java
+mode: command
+and mode: user.auto_lang
 and code.language: java
 -
 tag(): user.code_imperative
@@ -27,12 +29,12 @@ settings():
     user.code_public_variable_formatter = "PRIVATE_CAMEL_CASE"
 
 # Types Commands
-boxed [type] {user.java_boxed_types}:
-    insert(user.java_boxed_types)
+boxed [type] {user.java_boxed_type}:
+    insert(user.java_boxed_type)
     key("space")
 
-generic [type] {user.java_generic_data_structures}:
-    insert(java_generic_data_structures)
+generic [type] {user.java_generic_data_structure}:
+    insert(java_generic_data_structure)
     insert("<>")
     key("left")
 
@@ -41,12 +43,8 @@ type {user.code_type} array:
     insert(user.code_type)
     user.code_operator_subscript()
 
-[state] {user.java_access_modifiers}:
-    insert(user.java_access_modifiers)
-    key("space")
-
-[state] {user.java_modifiers}:
-    insert(user.java_modifiers)
+[state] {user.java_modifier}:
+    insert(user.java_modifier)
     key("space")
 
 op array:


### PR DESCRIPTION
While submitting a pull request for terraform (#752), I got some valuable feedback on how to write language files. It turns out I made some mistakes because I copied a lot from the java definition files. This pull request aims to fix the following deviations:

- use singular for lists
- use `insert` instead of `auto_insert`
- restrict to command mode

Also, I removed an apparently unused function (`user.java_access_modifiers` appears to be undefined).