### PR TITLE
Improve phrase history mechanism

### DIFF
--- a/code/history.py
+++ b/code/history.py
@@ -16,6 +16,9 @@ history = []
 def on_phrase(j):
     global history
 
+    if not actions.speech.enabled():
+        return
+    
     words = j.get('text')
 
     if text := actions.user.history_transform_phrase_text(words):

--- a/code/history.py
+++ b/code/history.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from talon import imgui, Module, speech_system, actions, app
 
 # We keep command_history_size lines of history, but by default display only
@@ -12,20 +13,13 @@ hist_more = False
 history = []
 
 
-def parse_phrase(word_list):
-    return " ".join(word.split("\\")[0] for word in word_list)
-
-
 def on_phrase(j):
     global history
 
-    try:
-        val = parse_phrase(getattr(j["parsed"], "_unmapped", j["phrase"]))
-    except:
-        val = parse_phrase(j["phrase"])
+    words = j.get('text')
 
-    if val != "":
-        history.append(val)
+    if text := actions.user.history_transform_phrase_text(words):
+        history.append(text)
         history = history[-setting_command_history_size.get() :]
 
 
@@ -85,3 +79,7 @@ class Actions:
         """returns the history entry at the specified index"""
         num = (0 - number) - 1
         return history[num]
+
+    def history_transform_phrase_text(words: list[str]) -> Optional[str]:
+        """Transforms phrase text for presentation in history. Return `None` to omit from history"""
+        return ' '.join(words) if words else None

--- a/code/history.py
+++ b/code/history.py
@@ -18,7 +18,9 @@ def on_phrase(j):
 
     words = j.get('text')
 
-    if text := actions.user.history_transform_phrase_text(words):
+    text = actions.user.history_transform_phrase_text(words)
+
+    if text is not None:
         history.append(text)
         history = history[-setting_command_history_size.get() :]
 

--- a/code/history.py
+++ b/code/history.py
@@ -16,9 +16,6 @@ history = []
 def on_phrase(j):
     global history
 
-    if not actions.speech.enabled():
-        return
-    
     words = j.get('text')
 
     if text := actions.user.history_transform_phrase_text(words):
@@ -85,4 +82,8 @@ class Actions:
 
     def history_transform_phrase_text(words: list[str]) -> Optional[str]:
         """Transforms phrase text for presentation in history. Return `None` to omit from history"""
+
+        if not actions.speech.enabled():
+            return None
+
         return ' '.join(words) if words else None


### PR DESCRIPTION
Fixes #757
Fixes #660

Also adds support for user-defined history phrase transformation by overriding `user.history_transform_phrase_text` action

This PR starts to move us in a direction where users have more flexibility to influence knausj behaviour without needing to have a fork, by adding an action that the user can override

Here's an [example](https://github.com/pokey/pokey_talon/blob/main/custom/code/history.py) of user-defined history processing