### PR TITLE
Fix duplicate newlines in CSVs on Windows.

### DIFF
--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -20,7 +20,7 @@ def get_list_from_csv(
     assert filename.endswith(".csv")
 
     if not path.is_file():
-        with open(path, "w", encoding="utf-8") as file:
+        with open(path, "w", encoding="utf-8", newline="") as file:
             writer = csv.writer(file)
             writer.writerow(headers)
             for key, value in default.items():


### PR DESCRIPTION
See footnote: https://docs.python.org/3/library/csv.html#id3

I can confirm that I witnessed this bug and this fixes it.