### PR TITLE
Updated language context to use tags instead of modes 

### DIFF
--- a/apps/vscode/snippets/csharp_snippets.py
+++ b/apps/vscode/snippets/csharp_snippets.py
@@ -6,9 +6,7 @@ import os
 ctx = Context()
 ctx.matches = r"""
 app: vscode
-mode: user.csharp
-mode: user.auto_lang 
-and code.language: csharp
+tag: user.csharp
 """
 # short name -> ide clip name
 ctx.lists["user.snippets"] = {

--- a/apps/vscode/snippets/python_snippets.py
+++ b/apps/vscode/snippets/python_snippets.py
@@ -6,9 +6,7 @@ import os
 ctx = Context()
 ctx.matches = r"""
 app: vscode
-mode: user.python
-mode: user.auto_lang 
-and code.language: python
+tag: user.python
 """
 # short name -> ide clip name
 ctx.lists["user.snippets"] = {

--- a/code/code.py
+++ b/code/code.py
@@ -1,11 +1,11 @@
-from talon import Context, Module, actions, app
+from talon import Context, Module, actions
 
 ctx = Context()
 mod = Module()
 
-key = actions.key
 extension_lang_map = {
     ".asm": "assembly",
+    ".bashbook": "bash",
     ".bat": "batch",
     ".c": "c",
     ".cmake": "cmake",
@@ -15,10 +15,11 @@ extension_lang_map = {
     ".go": "go",
     ".h": "c",
     ".hpp": "cplusplus",
+    ".html": "html",
     ".java": "java",
     ".js": "javascript",
-    ".jsx": "javascript",
     ".json": "json",
+    ".jsx": "javascriptreact",
     ".lua": "lua",
     ".md": "markdown",
     ".pl": "perl",
@@ -30,13 +31,32 @@ extension_lang_map = {
     ".sh": "bash",
     ".snippets": "snippets",
     ".talon": "talon",
-    ".ts": "typescript",
-    ".tsx": "typescript",
     ".tf": "terraform",
+    ".ts": "typescript",
+    ".tsx": "typescriptreact",
     ".vba": "vba",
     ".vim": "vimscript",
     ".vimrc": "vimscript",
 }
+
+
+# Create a context for each defined language
+for lang in extension_lang_map.values():
+    mod.tag(lang)
+    mod.tag(f"{lang}_forced")
+    c = Context()
+    # Context is active if language is forced or auto language matches
+    c.matches = f"""
+    tag: user.{lang}_forced
+    tag: user.auto_lang
+    and code.language: {lang}
+    """
+    c.tags = [f"user.{lang}"]
+
+# Create a mode for the automated language detection. This is active when no lang is forced.
+mod.tag("auto_lang")
+ctx.tags = ["user.auto_lang"]
+
 
 @ctx.action_class("code")
 class code_actions:
@@ -45,32 +65,15 @@ class code_actions:
         file_extension = actions.win.file_ext()
         if file_extension and file_extension in extension_lang_map:
             result = extension_lang_map[file_extension]
-
-        # print("code.language: " + result)
         return result
 
-# create a mode for each defined language
-for __, lang in extension_lang_map.items():
-    mod.mode(lang)
-
-# Create a mode for the automated language detection. This is active when no lang is forced.
-mod.mode("auto_lang")
-
-# Auto lang is enabled by default
-app.register("ready", lambda: actions.user.code_clear_language_mode())
 
 @mod.action_class
 class Actions:
     def code_set_language_mode(language: str):
         """Sets the active language mode, and disables extension matching"""
-        actions.user.code_clear_language_mode()
-        actions.mode.disable("user.auto_lang")
-        actions.mode.enable("user.{}".format(language))
-        # app.notify("Enabled {} mode".format(language))
+        ctx.tags = [f"user.{language}_forced"]
 
     def code_clear_language_mode():
         """Clears the active language mode, and re-enables code.language: extension matching"""
-        actions.mode.enable("user.auto_lang")
-        for __, lang in extension_lang_map.items():
-            actions.mode.disable("user.{}".format(lang))
-        # app.notify("Cleared language modes")
+        ctx.tags = ["user.auto_lang"]

--- a/lang/batch/batch.py
+++ b/lang/batch/batch.py
@@ -2,9 +2,7 @@ from talon import Context, actions
 
 ctx = Context()
 ctx.matches = r"""
-mode: user.batch
-mode: user.auto_lang
-and code.language: batch
+tag: user.batch
 """
 
 

--- a/lang/batch/batch.talon
+++ b/lang/batch/batch.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.batch
-mode: command
-and mode: user.auto_lang
-and code.language: batch
+tag: user.batch
 -
 tag(): user.code_comment_line
 

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -10,9 +10,7 @@ mod.setting(
 
 ctx = Context()
 ctx.matches = r"""
-mode: user.c
-mode: user.auto_lang
-and code.language: c
+tag: user.c
 """
 
 ctx.lists["self.c_pointers"] = {

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -28,8 +28,8 @@ settings():
 
 
 
-^funky <user.text>$:                   user.code_default_function(text)
-^static funky <user.text>$:            user.code_private_static_function(text)
+^funky <user.text>$: user.code_default_function(text)
+^static funky <user.text>$: user.code_private_static_function(text)
 
 # NOTE: migrated from generic, as they were only used here, though once cpp support is added, perhaps these should be migrated to a tag together with the commands below
 state include:
@@ -50,17 +50,17 @@ state type deaf struct:
 
 
 # XXX - create a preprocessor tag for these, as they will match cpp, etc
-state define:                          "#define "
-state undefine:                        "#undef "
-state if define:                       "#ifdef "
+state define: "#define "
+state undefine: "#undef "
+state if define: "#ifdef "
 
 # XXX - preprocessor instead of pre?
-state pre if:                          "#if "
-state error:                           "#error "
-state pre else if:                     "#elif "
-state pre end:                         "#endif "
-state pragma:                          "#pragma "
-state default:                         "default:\nbreak;"
+state pre if: "#if "
+state error: "#error "
+state pre else if: "#elif "
+state pre end: "#endif "
+state pragma: "#pragma "
+state default: "default:\nbreak;"
 
 #control flow
 #best used with a push like command
@@ -86,18 +86,18 @@ push brackets:
     insert("{c_variable} {letter} ")
 
 # Ex. (int *)
-cast to <user.c_cast>:                 "{c_cast}"
-standard cast to <user.stdint_cast>:   "{stdint_cast}"
-<user.c_types>:                        "{c_types}"
-<user.c_pointers>:                     "{c_pointers}"
-<user.c_keywords>:                     "{c_keywords}"
-<user.c_signed>:                       "{c_signed}"
-standard <user.stdint_types>:          "{stdint_types}"
+cast to <user.c_cast>: "{c_cast}"
+standard cast to <user.stdint_cast>: "{stdint_cast}"
+<user.c_types>: "{c_types}"
+<user.c_pointers>: "{c_pointers}"
+<user.c_keywords>: "{c_keywords}"
+<user.c_signed>: "{c_signed}"
+standard <user.stdint_types>: "{stdint_types}"
 int main:
     insert("int main()")
     edit.left()
 
-toggle includes:                       user.code_toggle_libraries()
+toggle includes: user.code_toggle_libraries()
 include <user.code_libraries>:
     user.code_insert_library(code_libraries, "")
     key(end enter)

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.c
-mode: command
-and mode: user.auto_lang
-and code.language: c
+tag: user.c
 -
 tag(): user.code_imperative
 
@@ -32,8 +28,8 @@ settings():
 
 
 
-^funky <user.text>$: user.code_default_function(text)
-^static funky <user.text>$: user.code_private_static_function(text)
+^funky <user.text>$:                   user.code_default_function(text)
+^static funky <user.text>$:            user.code_private_static_function(text)
 
 # NOTE: migrated from generic, as they were only used here, though once cpp support is added, perhaps these should be migrated to a tag together with the commands below
 state include:
@@ -54,17 +50,17 @@ state type deaf struct:
 
 
 # XXX - create a preprocessor tag for these, as they will match cpp, etc
-state define: "#define "
-state undefine: "#undef "
-state if define: "#ifdef "
+state define:                          "#define "
+state undefine:                        "#undef "
+state if define:                       "#ifdef "
 
 # XXX - preprocessor instead of pre?
-state pre if: "#if "
-state error: "#error "
-state pre else if: "#elif "
-state pre end: "#endif "
-state pragma: "#pragma "
-state default: "default:\nbreak;"
+state pre if:                          "#if "
+state error:                           "#error "
+state pre else if:                     "#elif "
+state pre end:                         "#endif "
+state pragma:                          "#pragma "
+state default:                         "default:\nbreak;"
 
 #control flow
 #best used with a push like command
@@ -90,18 +86,18 @@ push brackets:
     insert("{c_variable} {letter} ")
 
 # Ex. (int *)
-cast to <user.c_cast>: "{c_cast}"
-standard cast to <user.stdint_cast>: "{stdint_cast}"
-<user.c_types>: "{c_types}"
-<user.c_pointers>: "{c_pointers}"
-<user.c_keywords>: "{c_keywords}"
-<user.c_signed>: "{c_signed}"
-standard <user.stdint_types>: "{stdint_types}"
+cast to <user.c_cast>:                 "{c_cast}"
+standard cast to <user.stdint_cast>:   "{stdint_cast}"
+<user.c_types>:                        "{c_types}"
+<user.c_pointers>:                     "{c_pointers}"
+<user.c_keywords>:                     "{c_keywords}"
+<user.c_signed>:                       "{c_signed}"
+standard <user.stdint_types>:          "{stdint_types}"
 int main:
     insert("int main()")
     edit.left()
 
-toggle includes: user.code_toggle_libraries()
+toggle includes:                       user.code_toggle_libraries()
 include <user.code_libraries>:
     user.code_insert_library(code_libraries, "")
     key(end enter)

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -2,9 +2,7 @@ from talon import Context, Module, actions, settings
 
 ctx = Context()
 ctx.matches = r"""
-mode: user.csharp
-mode: user.auto_lang
-and code.language: csharp
+tag: user.csharp
 """
 ctx.lists["user.code_functions"] = {
     "integer": "int.TryParse",

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.csharp
-mode: command
-and mode: user.auto_lang
-and code.language: csharp
+tag: user.csharp
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/go/go.talon
+++ b/lang/go/go.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.go
-mode: command
-and mode: user.auto_lang
-and code.language: go
+tag: user.go
 -
 variadic: "..."
 logical and: " && "

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -3,9 +3,7 @@ from talon import Context, Module, actions, settings
 ctx = Context()
 mod = Module()
 ctx.matches = r"""
-mode: user.java
-mode: user.auto_lang
-and code.language: java
+tag: user.java
 """
 ctx.tags = ["user.code_operators", "user.code_generic", "user.code_functions_gui"]
 

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.java
-mode: command
-and mode: user.auto_lang
-and code.language: java
+tag: user.java
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -3,14 +3,6 @@ from talon import Module, Context, actions, settings
 mod = Module()
 mod.tag("javascript", desc="Enables commands for JavaScript and JS-like languages")
 
-mode_ctx = Context()
-mode_ctx.matches = r"""
-mode: user.javascript
-mode: user.auto_lang
-and code.language: javascript
-"""
-mode_ctx.tags = ["user.javascript"]
-
 ctx = Context()
 ctx.matches = """
 tag: user.javascript

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -1,8 +1,6 @@
 from talon import Module, Context, actions, settings
 
 mod = Module()
-mod.tag("javascript", desc="Enables commands for JavaScript and JS-like languages")
-
 ctx = Context()
 ctx.matches = """
 tag: user.javascript

--- a/lang/javascript/javascriptreact.talon
+++ b/lang/javascript/javascriptreact.talon
@@ -1,0 +1,3 @@
+tag: user.javascriptreact
+-
+tag(): user.javascript

--- a/lang/markdown/markdown.talon
+++ b/lang/markdown/markdown.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.markdown
-mode: command
-and mode: user.auto_lang
-and code.language: markdown
+tag: user.markdown
 -
 level one: "# "
 level two: "## "

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -5,9 +5,7 @@ from talon import Context, Module, actions, settings
 mod = Module()
 ctx = Context()
 ctx.matches = r"""
-mode: user.python
-mode: user.auto_lang
-and code.language: python
+tag: user.python
 """
 ctx.lists["user.code_functions"] = {
     "enumerate": "enumerate",

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.python
-mode: command
-and mode: user.auto_lang
-and code.language: python
+tag: user.python
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -3,9 +3,7 @@ from talon import Context, Module, actions, clip, imgui, settings, ui
 ctx = Context()
 
 ctx.matches = r"""
-mode: user.r
-mode: user.auto_lang
-and code.language: r
+tag: user.r
 """
 
 ctx.lists["user.code_functions"] = {

--- a/lang/r/r.talon
+++ b/lang/r/r.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.r
-mode: command
-and mode: user.auto_lang
-and code.language: r
+tag: user.r
 -
 tag(): user.code_imperative
 

--- a/lang/ruby/ruby.py
+++ b/lang/ruby/ruby.py
@@ -2,9 +2,7 @@ from talon import Context, actions, settings
 
 ctx = Context()
 ctx.matches = r"""
-mode: user.ruby
-mode: user.auto_lang
-and code.language: ruby
+tag: user.ruby
 """
 
 @ctx.action_class('user')

--- a/lang/ruby/ruby.talon
+++ b/lang/ruby/ruby.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.ruby
-mode: command
-and mode: user.auto_lang
-and code.language: ruby
+tag: user.ruby
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/talon/talon.py
+++ b/lang/talon/talon.py
@@ -28,9 +28,7 @@ mod.list("talon_scopes")
 mod.list("talon_modes")
 
 ctx.matches = r"""
-mode: user.talon
-mode: user.auto_lang 
-and code.language: talon
+tag: user.talon
 """
 ctx.lists["user.code_functions"] = {
     "insert": "insert",

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.talon
-mode: command
-and mode: user.auto_lang
-and code.language: talon
+tag: user.talon
 -
 tag(): user.code_operators_math
 tag(): user.code_operators_assignment

--- a/lang/terraform/terraform.py
+++ b/lang/terraform/terraform.py
@@ -3,9 +3,7 @@ from talon import Context, Module, actions, settings
 ctx = Context()
 mod = Module()
 ctx.matches = r"""
-mode: user.terraform
-mode: user.auto_lang
-and code.language: terraform
+tag: user.terraform
 """
 
 types = {

--- a/lang/terraform/terraform.talon
+++ b/lang/terraform/terraform.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.terraform
-mode: command
-and mode: user.auto_lang
-and code.language: terraform
+tag: user.terraform
 -
 tag(): user.code_comment_block_c_like
 tag(): user.code_comment_line

--- a/lang/typescript/typescript.py
+++ b/lang/typescript/typescript.py
@@ -2,9 +2,7 @@ from talon import Module, Context, actions, ui, imgui, settings
 
 ctx = Context()
 ctx.matches = r"""
-mode: user.typescript
-mode: user.auto_lang
-and code.language: typescript
+tag: user.typescript
 """
 # tbd
 # ctx.lists["user.code_functions"] = {

--- a/lang/typescript/typescript.talon
+++ b/lang/typescript/typescript.talon
@@ -1,7 +1,3 @@
-mode: command
-and mode: user.typescript
-mode: command
-and mode: user.auto_lang
-and code.language: typescript
+tag: user.typescript
 -
 tag(): user.javascript

--- a/lang/typescript/typescriptreact.talon
+++ b/lang/typescript/typescriptreact.talon
@@ -1,0 +1,3 @@
+tag: user.typescriptreact
+-
+tag(): user.typescript

--- a/lang/vimscript/vimscript.py
+++ b/lang/vimscript/vimscript.py
@@ -3,9 +3,7 @@ from talon import Context, Module, actions, settings
 mod = Module()
 ctx = Context()
 ctx.matches = r"""
-mode: user.vimscript
-mode: user.auto_lang
-and code.language: vimscript
+tag: user.vimscript
 """
 
 ctx.lists["self.vimscript_functions"] = {

--- a/lang/vimscript/vimscript.talon
+++ b/lang/vimscript/vimscript.talon
@@ -1,8 +1,4 @@
-mode: command
-and mode: user.vimscript
-mode: command
-and mode: user.auto_lang
-and code.language: vimscript
+tag: user.vimscript
 -
 tag(): user.code_imperative
 tag(): user.code_operators_assignment


### PR DESCRIPTION
Instead of the following header
```
mode: command
and mode: user.c
mode: command
and mode: user.auto_lang
and code.language: c
```

We can now just use
```
tag: user.c
```

Also took the liberty to add a few new file endings when I was in there.

@rntz @knausj85 @pokey 
Would probably be nice to get this one merged before the other pr regarding new languages
