### PR TITLE
replace insert_cursor with insert_between

### DIFF
--- a/apps/gdb/gdb.py
+++ b/apps/gdb/gdb.py
@@ -30,8 +30,7 @@ class UserActions:
     def debugger_show_registers(): actions.auto_insert('info registers\n')
     def debugger_get_register(): actions.auto_insert('r ')
     def debugger_set_register():
-        actions.insert('set $=')
-        actions.edit.left()
+        actions.user.insert_between('set $', '=')
         # Breakpoints
     def debugger_show_breakpoints(): actions.auto_insert('info breakpoints\n')
     def debugger_add_sw_breakpoint(): actions.auto_insert('break ')

--- a/apps/kubectl/kubectl.talon
+++ b/apps/kubectl/kubectl.talon
@@ -64,5 +64,4 @@ cube detach:
     key("ctrl-p")
     key("ctrl-q")
 cube shell:
-    insert("kubectl exec -it  -- /bin/bash")
-    key("left:13")
+    user.insert_between("kubectl exec -it ", " -- /bin/bash")

--- a/apps/windbg/windbg.py
+++ b/apps/windbg/windbg.py
@@ -54,8 +54,7 @@ class UserActions:
     def debugger_get_register():
         actions.insert('r @')
     def debugger_set_register():
-        actions.insert('set $@=')
-        actions.edit.left()
+        actions.user.insert_between('set $@', '=')
         # Breakpoints
     def debugger_show_breakpoints():
         actions.insert('bl\n')

--- a/apps/windbg/windbg.talon
+++ b/apps/windbg/windbg.talon
@@ -28,8 +28,7 @@ display pointers:
     
 # XXX - should be generic
 dereference pointer:
-    insert("poi()")
-    edit.left()
+    user.insert_between("poi(", ")")
     
 show version: key(ctrl-alt-w)
 

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -329,10 +329,7 @@ class Actions:
         # so that future dictation is properly formatted.
         text = text.replace("“", "\"").replace("”", "\"")
         actions.user.add_phrase_to_history(text)
-        # we insert the text all at once in case we have an implementation of
-        # insert that is more efficient for long strings, eg. paste-to-insert
-        actions.insert(text + (" " if add_space_after else ""))
-        if add_space_after: actions.edit.left()
+        actions.user.insert_between(text, " " if add_space_after else "")
 
     def dictation_peek_left(clobber: bool = False) -> Optional[str]:
         """

--- a/code/insert_between.py
+++ b/code/insert_between.py
@@ -5,7 +5,7 @@ mod = Module()
 @mod.action_class
 class module_actions:
     def insert_between(before: str, after: str):
-        """Insert `before + after`, leaving cursor between `before` and `after`."""
+        """Insert `before + after`, leaving cursor between `before` and `after`. Not entirely reliable if `after` contains newlines."""
         actions.insert(before + after)
         for _ in after: actions.edit.left()
 

--- a/code/insert_between.py
+++ b/code/insert_between.py
@@ -1,4 +1,4 @@
-from talon import Module, actions
+from talon import Module, actions, app
 
 mod = Module()
 
@@ -9,10 +9,11 @@ class module_actions:
         actions.insert(before + after)
         for _ in after: actions.edit.left()
 
-    # # This is deprecated, please use insert_between instead.
-    # def insert_cursor(text: str):
-    #     """Insert a string. Leave the cursor wherever [|] is in the text"""
-    #     if "[|]" in text:
-    #         actions.user.insert_between(*text.split("[|]", 1))
-    #     else:
-    #         actions.insert(text)
+    # This is deprecated, please use insert_between instead.
+    def insert_cursor(text: str):
+        """Insert a string. Leave the cursor wherever [|] is in the text"""
+        if "[|]" in text:
+            actions.user.insert_between(*text.split("[|]", 1))
+        else:
+            actions.insert(text)
+        app.notify("insert_cursor is deprecated, please update your code to use insert_between")

--- a/code/insert_between.py
+++ b/code/insert_between.py
@@ -1,0 +1,18 @@
+from talon import Module, actions
+
+mod = Module()
+
+@mod.action_class
+class module_actions:
+    def insert_between(before: str, after: str):
+        """Insert `before + after`, leaving cursor between `before` and `after`."""
+        actions.insert(before + after)
+        for _ in after: actions.edit.left()
+
+    # # This is deprecated, please use insert_between instead.
+    # def insert_cursor(text: str):
+    #     """Insert a string. Leave the cursor wherever [|] is in the text"""
+    #     if "[|]" in text:
+    #         actions.user.insert_between(*text.split("[|]", 1))
+    #     else:
+    #         actions.insert(text)

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -39,11 +39,9 @@ settings():
 state include:
     insert('#include ')
 state include system:
-    insert('#include <>')
-    edit.left()
+    user.insert_between("#include <", ">")
 state include local:
-    insert('#include ""')
-    edit.left()
+    user.insert_between('#include "', '"')
 state type deaf:
     insert('typedef ')
 state type deaf struct:
@@ -98,8 +96,7 @@ standard cast to <user.stdint_cast>: "{stdint_cast}"
 <user.c_signed>: "{c_signed}"
 standard <user.stdint_types>: "{stdint_types}"
 int main:
-    insert("int main()")
-    edit.left()
+    user.insert_between("int main(", ")")
 
 toggle includes: user.code_toggle_libraries()
 include <user.code_libraries>:

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -20,8 +20,7 @@ class UserActions:
     def code_operator_structure_dereference(): actions.auto_insert('->')
     def code_operator_lambda():                actions.auto_insert('=>')
     def code_operator_subscript():
-        actions.insert('[]')
-        actions.key('left')
+        actions.user.insert_between('[', ']')
     def code_operator_assignment():                      actions.auto_insert(' = ')
     def code_operator_subtraction():                     actions.auto_insert(' - ')
     def code_operator_subtraction_assignment():          actions.auto_insert(' -= ')
@@ -66,17 +65,14 @@ class UserActions:
     def code_insert_is_null():     actions.auto_insert(' == null ')
     def code_insert_is_not_null(): actions.auto_insert(' != null')
     def code_state_if():
-        actions.insert('if()')
-        actions.key('left')
+        actions.user.insert_between('if(', ')')
     def code_state_else_if():
-        actions.insert('else if()')
-        actions.key('left')
+        actions.user.insert_between('else if(', ')')
     def code_state_else():
         actions.insert('else\n{\n}\n')
         actions.key('up')
     def code_state_switch():
-        actions.insert('switch()')
-        actions.edit.left()
+        actions.user.insert_between('switch(', ')')
     def code_state_case():
         actions.insert('case \nbreak;')
         actions.edit.up()
@@ -89,8 +85,7 @@ class UserActions:
         actions.edit.left()
     def code_state_go_to(): actions.auto_insert('go to ')
     def code_state_while():
-        actions.insert('while()')
-        actions.edit.left()
+        actions.user.insert_between('while(', ')')
     def code_state_return():   actions.auto_insert('return ')
     def code_break():          actions.auto_insert('break;')
     def code_next():           actions.auto_insert('continue;')

--- a/lang/go/go.talon
+++ b/lang/go/go.talon
@@ -138,11 +138,9 @@ slice of: "[]"
 [state] (no | nil): "nil"
 state (int | integer | ant) 64: " int64 "
 state tag:
-  insert(" ``")
-  key("left")
+  user.insert_between(" `", "`")
 field tag <user.text> [over]:
-    insert(" ``")
-    key("left")
+    user.insert_between(" `", "`")
     sleep(100ms)
     insert(user.formatted_text(text, "snake"))
     insert(" ")

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -98,8 +98,7 @@ class UserActions:
         actions.insert(" -> ")
 
     def code_operator_subscript():
-        actions.insert("[]")
-        actions.key("left")
+        actions.user.insert_between("[", "]")
 
     def code_operator_assignment():
         actions.insert(" = ")
@@ -204,37 +203,27 @@ class UserActions:
         actions.insert(" != null")
 
     def code_state_if():
-        actions.insert("if () ")
-        actions.key("left")
-        actions.key("left")
+        actions.user.insert_between("if (", ") ")
 
     def code_state_else_if():
-        actions.insert("else if () ")
-        actions.key("left")
-        actions.key("left")
+        actions.user.insert_between("else if (", ") ")
 
     def code_state_else():
         actions.insert("else ")
         actions.key("enter")
 
     def code_state_switch():
-        actions.insert("switch () ")
-        actions.key("left")
-        actions.edit.left()
+        actions.user.insert_between("switch (", ") ")
 
     def code_state_case():
         actions.insert("case \nbreak;")
         actions.edit.up()
 
     def code_state_for():
-        actions.insert("for () ")
-        actions.key("left")
-        actions.key("left")
+        actions.user.insert_between("for (", ") ")
 
     def code_state_while():
-        actions.insert("while () ")
-        actions.edit.left()
-        actions.edit.left()
+        actions.user.insert_between("while (", ") ")
 
     def code_break():
         actions.insert('break;')

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -34,9 +34,7 @@ boxed [type] {user.java_boxed_type}:
     key("space")
 
 generic [type] {user.java_generic_data_structure}:
-    insert(java_generic_data_structure)
-    insert("<>")
-    key("left")
+    user.insert_between(java_generic_data_structure + "<", ">")
 
 # Arrays
 type {user.code_type} array:

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -32,24 +32,21 @@ class UserActions:
         actions.auto_insert(" === null")
 
     def code_type_dictionary():
-        actions.insert("{}")
-        actions.key("left")
+        actions.user.insert_between("{", "}")
 
     def code_state_if():
-        actions.insert("if ()")
-        actions.key("left")
+        actions.user.insert_between("if (", ")")
 
     def code_state_else_if():
-        actions.insert(" else if ()")
-        actions.key("left")
+        actions.user.insert_between(" else if (", ")")
 
     def code_state_else():
-        actions.insert(" else {}")
-        actions.key("left enter")
+        actions.user.insert_between(" else {", "}")
+        actions.key("enter")
 
     def code_block():
-        actions.insert("{}")
-        actions.key("left enter")
+        actions.user.insert_between("{", "}")
+        actions.key("enter")
 
     def code_self():
         actions.auto_insert("this")
@@ -58,8 +55,7 @@ class UserActions:
         actions.auto_insert('.')
 
     def code_state_while():
-        actions.insert("while ()")
-        actions.key("left")
+        actions.user.insert_between("while (", ")")
 
     def code_state_do():
         actions.auto_insert("do ")
@@ -68,12 +64,10 @@ class UserActions:
         actions.insert("return ")
 
     def code_state_for():
-        actions.insert("for ()")
-        actions.key("left")
+        actions.user.insert_between("for (", ")")
 
     def code_state_switch():
-        actions.insert("switch ()")
-        actions.key("left")
+        actions.user.insert_between("switch (", ")")
 
     def code_state_case():
         actions.auto_insert("case :")
@@ -88,8 +82,7 @@ class UserActions:
         actions.auto_insert("class ")
 
     def code_state_for_each():
-        actions.insert(".forEach()")
-        actions.key("left")
+        actions.user.insert_between(".forEach(", ")")
 
     def code_break():
         actions.auto_insert("break;")
@@ -110,8 +103,7 @@ class UserActions:
         actions.auto_insert(" => ")
 
     def code_operator_subscript():
-        actions.insert("[]")
-        actions.key("left")
+        actions.user.insert_between("[", "]")
 
     def code_operator_assignment():
         actions.auto_insert(" = ")

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -40,19 +40,15 @@ state async: "async "
 state await: "await "
 
 state map:
-    insert(".map()")
-    key(left)
+    user.insert_between(".map(", ")")
 
 state filter:
-    insert(".filter()")
-    key(left)
+    user.insert_between(".filter(", ")")
 
 state reduce:
-    insert(".reduce()")
-    key(left)
+    user.insert_between(".reduce(", ")")
 
 state spread: "..."
 
 from import:
-    insert(' from  ""')
-    key("left")
+    user.insert_between(' from  "', '"')

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -206,7 +206,7 @@ class UserActions:
         actions.insert('return ')
     def code_insert_true():            actions.auto_insert('True')
     def code_insert_false():           actions.auto_insert('False')
-    def code_comment_documentation(): actions.user.insert_cursor('"""[|]"""')
+    def code_comment_documentation(): actions.user.insert_between('"""', '"""')
     def code_insert_function(text: str, selection: str):
         if selection:
             text = text + "({})".format(selection)
@@ -245,17 +245,3 @@ class UserActions:
 
     def code_insert_return_type(type: str):
         actions.insert(f" -> {type}")
-
-
-@mod.action_class
-class module_actions:
-    # TODO this could go somewhere else
-    def insert_cursor(text: str):
-        """Insert a string. Leave the cursor wherever [|] is in the text"""
-        if "[|]" in text:
-            end_pos = text.find("[|]")
-            s = text.replace("[|]", "")
-            actions.insert(s)
-            actions.key(f"left:{len(s) - end_pos}")
-        else:
-            actions.insert(text)

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -137,8 +137,7 @@ ctx.lists["user.python_exception"] = {
 @ctx.action_class("user")
 class UserActions:
     def code_operator_subscript():
-        actions.insert('[]')
-        actions.key('left')
+        actions.user.insert_between('[', ']')
     def code_operator_assignment():                      actions.auto_insert(' = ')
     def code_operator_subtraction():                     actions.auto_insert(' - ')
     def code_operator_subtraction_assignment():          actions.auto_insert(' -= ')
@@ -175,30 +174,21 @@ class UserActions:
     def code_insert_is_null():                                  actions.auto_insert(' is None')
     def code_insert_is_not_null():                              actions.auto_insert(' is not None')
     def code_state_if():
-        actions.insert('if :')
-        actions.key('left')
+        actions.user.insert_between('if ', ':')
     def code_state_else_if():
-        actions.insert('elif :')
-        actions.key('left')
+        actions.user.insert_between('elif ', ':')
     def code_state_else():
         actions.insert('else:')
         actions.key('enter')
     def code_state_switch():
-        actions.insert('match :')
-        actions.edit.left()
+        actions.user.insert_between('match ', ':')
     def code_state_case():
-        actions.insert('case :')
-        actions.edit.left()
+        actions.user.insert_between('case ', ':')
     def code_state_for(): actions.auto_insert('for ')
     def code_state_for_each():
-        actions.insert('for in ')
-        actions.key('left')
-        actions.edit.word_left()
-        actions.key('space')
-        actions.edit.left()
+        actions.user.insert_between('for ', ' in ')
     def code_state_while():
-        actions.insert('while :')
-        actions.edit.left()
+        actions.user.insert_between('while ', ':')
     def code_define_class(): actions.auto_insert('class ')
     def code_import():     actions.auto_insert('import ')
     def code_comment_line_prefix(): actions.auto_insert('# ')

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -56,4 +56,4 @@ import <user.code_libraries>:
     user.code_insert_library(code_libraries, "")
     key(end enter)
 
-from import: user.insert_between("from ", " import")
+from import: user.insert_between("from ", " import ")

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -38,7 +38,7 @@ self taught: "self."
 pie test: "pytest"
 state past: "pass"
 
-raise {user.python_exception}: user.insert_cursor("raise {python_exception}([|])")
+raise {user.python_exception}: user.insert_between("raise {python_exception}(", ")")
 except {user.python_exception}: "except {python_exception}:"
 
 dock string:
@@ -47,18 +47,13 @@ dock {user.python_docstring_fields}:
     insert("{python_docstring_fields}")
     edit.left()
 dock type {user.code_type}:
-    user.insert_cursor(":type [|]: {code_type}")
+    user.insert_between(":type ", ": {code_type}")
 dock returns type {user.code_type}:
-    user.insert_cursor(":rtype [|]: {code_type}")
+    user.insert_between(":rtype ", ": {code_type}")
 
 toggle imports: user.code_toggle_libraries()
 import <user.code_libraries>:
     user.code_insert_library(code_libraries, "")
     key(end enter)
 
-from import:
-    insert('from import ')
-    key('left')
-    edit.word_left()
-    key('space')
-    edit.left()
+from import: user.insert_between("from ", " import")

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -277,12 +277,10 @@ class UserActions:
         actions.insert('while () {}')
         actions.key('left enter up end left:3')
     def code_import():
-        actions.insert('library()')
-        actions.key('left')
+        actions.user.insert_between('library(', ')')
     def code_comment_line_prefix(): actions.auto_insert('#')
     def code_state_return():
-        actions.insert('return()')
-        actions.key('left')
+        actions.user.insert_between('return(', ')')
     def code_break(): actions.auto_insert('break')
     def code_next():  actions.auto_insert('next')
     def code_insert_true():  actions.auto_insert('TRUE')
@@ -311,10 +309,8 @@ class UserActions:
         actions.edit.left()
 
     def code_insert_library(text: str, selection: str):
-        actions.insert("library()")
-        actions.edit.left()
-        actions.clip.set_text(text + "{}".format(selection))
-        actions.edit.paste()
+        actions.user.insert_between("library(", ")")
+        actions.user.paste(text + selection)
 
     def code_insert_named_argument(parameter_name: str):
         actions.insert(f"{parameter_name} = ")

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -17,9 +17,7 @@ tag(): user.code_functions_gui
 dot talon: insert(".talon")
 #defintion blocks for the context
 action block:
-    insert("action():")
-    edit.left()
-    edit.left()
+    user.insert_between("action(", "):")
 setting block:
     insert("settings():\n\t")
 setting {user.talon_settings}:

--- a/lang/terraform/terraform.py
+++ b/lang/terraform/terraform.py
@@ -65,8 +65,7 @@ class Actions:
 class UserActions:
 
     def code_terraform_module_block(text: str):
-        actions.insert(text + ' ""')
-        actions.key("left")
+        actions.user.insert_between(text + ' "', '"')
 
     def code_terraform_resource(text: str):
         result = 'resource "{}" ""'.format(
@@ -152,5 +151,4 @@ class UserActions:
         actions.insert("# ")
 
     def code_state_for():
-        actions.insert("for  in")
-        actions.key("left left left")
+        actions.user.insert_between("for ", " in")


### PR DESCRIPTION
Fixes a few things:

1. insert_cursor was in `lang/python/python.py`, which is a weird place. This moves it to `code/insert_between.py`.

2. insert_cursor looks for a magic symbol, `[|]`, to determine where to put the cursor. This is fine for inserting constant strings but means we can't use it more widely. I've replaced it with `insert_between(before, after)`, which takes two strings and doesn't look for magic symbols.

3. Updated lots of code to use insert_between instead of manually calling edit.left() after inserting stuff.

One of the nice things about `insert_between` is that it might eventually be possible to implement it more efficiently (eg via accessibility APIs), avoiding the repeated edit.left()s.