### PR TITLE
voice commands for reporting bugs

### DIFF
--- a/misc/talon_helpers.talon
+++ b/misc/talon_helpers.talon
@@ -10,7 +10,7 @@ talon copy name:
 talon copy executable:
     executable = app.executable()
     clip.set_text(executable)
-talon copy bundle:
+talon copy bundle:[Talon](talonvoice.com)
     bundle = app.bundle()
     clip.set_text(bundle)
 talon copy title: 
@@ -57,3 +57,7 @@ talon dump context:
 ^talon copy active app$:
     result = user.talon_get_active_application_info()
     clip.set_text(result)
+
+^report talon bug$: 'https://github.com/talonvoice/talon/issues'
+^report knausj bug$:'https://github.com/knausj85/knausj_talon/issues'
+

--- a/misc/talon_helpers.talon
+++ b/misc/talon_helpers.talon
@@ -58,6 +58,4 @@ talon dump context:
     result = user.talon_get_active_application_info()
     clip.set_text(result)
 
-^report talon bug$: 'https://github.com/talonvoice/talon/issues'
-^report knausj bug$:'https://github.com/knausj85/knausj_talon/issues'
-
+talon (bug report|report bug): user.open_url('https://github.com/knausj85/knausj_talon/issues')

--- a/misc/talon_helpers.talon
+++ b/misc/talon_helpers.talon
@@ -10,7 +10,7 @@ talon copy name:
 talon copy executable:
     executable = app.executable()
     clip.set_text(executable)
-talon copy bundle:[Talon](talonvoice.com)
+talon copy bundle:
     bundle = app.bundle()
     clip.set_text(bundle)
 talon copy title: 


### PR DESCRIPTION
Added two commands that print out urls to the Talon and Knausj
issue trackers to encourage bug reporting.  Right now the link to
the Talon issue tracker is hidden as a pinned message on the help
channel of the slack.  Attaching it to the command 'report Talon bug'
may make it easier to find.