### PR TITLE
Terminator for Linux

### DIFF
--- a/apps/platforms/linux/terminator/terminator-linux.py
+++ b/apps/platforms/linux/terminator/terminator-linux.py
@@ -28,7 +28,7 @@ ctx.tags = [
 # --- Implement actions ---
 @ctx.action_class("user")
 class user_actions:
-    # tag: user.splits
+    # user.splits
     def split_window_right(): actions.key("alt-right")
     def split_window_left(): actions.key("alt-left")
     def split_window_down(): actions.key("alt-down")

--- a/apps/platforms/linux/terminator/terminator-linux.py
+++ b/apps/platforms/linux/terminator/terminator-linux.py
@@ -16,7 +16,6 @@ app: terminator
 """
 ctx.tags = [
     'terminal',
-    'user.terminal',
     'user.tabs',
     'user.splits',
     'user.generic_unix_shell',

--- a/apps/platforms/linux/terminator/terminator-linux.py
+++ b/apps/platforms/linux/terminator/terminator-linux.py
@@ -70,4 +70,4 @@ class EditActions:
 
     def delete_line():
         actions.edit.line_start()
-        actions.key('ctrl-a ctrl-k')
+        actions.key('ctrl-u')

--- a/apps/platforms/linux/terminator/terminator-linux.py
+++ b/apps/platforms/linux/terminator/terminator-linux.py
@@ -72,11 +72,3 @@ class EditActions:
     def delete_line():
         actions.edit.line_start()
         actions.key('ctrl-a ctrl-k')
-
-    # afaik not possible in gnome-terminal
-    def extend_left(): pass
-    def extend_right(): pass
-    def extend_up(): pass
-    def extend_down(): pass
-    def extend_word_left(): pass
-    def extend_word_right(): pass

--- a/apps/platforms/linux/terminator/terminator-linux.py
+++ b/apps/platforms/linux/terminator/terminator-linux.py
@@ -15,42 +15,42 @@ ctx.matches = r"""
 app: terminator
 """
 ctx.tags = [
-    "terminal",
-    "user.terminal",
-    "user.tabs",
-    "user.splits",
-    "user.generic_unix_shell",
-    "user.git",
-    "user.kubectl",
+    'terminal',
+    'user.terminal',
+    'user.tabs',
+    'user.splits',
+    'user.generic_unix_shell',
+    'user.git',
+    'user.kubectl',
 ]
 
 
 # --- Implement actions ---
-@ctx.action_class("user")
+@ctx.action_class('user')
 class user_actions:
     # user.splits
-    def split_window_right(): actions.key("alt-right")
-    def split_window_left(): actions.key("alt-left")
-    def split_window_down(): actions.key("alt-down")
-    def split_window_up(): actions.key("alt-up")
-    def split_window_vertically(): actions.key("shift-ctrl-e")
-    def split_window_horizontally(): actions.key("shift-ctrl-o")
-    def split_flip(): actions.key("super-r")
-    def split_window(): actions.key("shift-ctrl-o")
-    def split_clear(): actions.key("shift-ctrl-r")
-    def split_clear_all(): actions.key("shift-ctrl-g")
-    def split_next(): actions.key("shift-ctrl-n")
-    def split_last(): actions.key("shift-ctrl-p")
+    def split_window_right(): actions.key('alt-right')
+    def split_window_left(): actions.key('alt-left')
+    def split_window_down(): actions.key('alt-down')
+    def split_window_up(): actions.key('alt-up')
+    def split_window_vertically(): actions.key('shift-ctrl-e')
+    def split_window_horizontally(): actions.key('shift-ctrl-o')
+    def split_flip(): actions.key('super-r')
+    def split_window(): actions.key('shift-ctrl-o')
+    def split_clear(): actions.key('shift-ctrl-r')
+    def split_clear_all(): actions.key('shift-ctrl-g')
+    def split_next(): actions.key('shift-ctrl-n')
+    def split_last(): actions.key('shift-ctrl-p')
 
 
-@ctx.action_class("app")
+@ctx.action_class('app')
 class AppActions:
 
     # app.tabs
-    def tab_open(): actions.key("ctrl-shift-t")
-    def tab_previous(): actions.key("ctrl-pageup")
-    def tab_next(): actions.key("ctrl-pagedown")
-    def tab_close(): actions.key("ctrl-shift-w")
+    def tab_open(): actions.key('ctrl-shift-t')
+    def tab_previous(): actions.key('ctrl-pageup')
+    def tab_next(): actions.key('ctrl-pagedown')
+    def tab_close(): actions.key('ctrl-shift-w')
     # global (overwrite linux/app.py)
     def window_open(): actions.key('ctrl-shift-i')
     def window_close(): actions.key('ctrl-shift-q')

--- a/apps/platforms/linux/terminator/terminator-linux.py
+++ b/apps/platforms/linux/terminator/terminator-linux.py
@@ -70,4 +70,4 @@ class EditActions:
 
     def delete_line():
         actions.edit.line_start()
-        actions.key('ctrl-u')
+        actions.key('ctrl-k')

--- a/apps/platforms/linux/terminator/terminator-linux.py
+++ b/apps/platforms/linux/terminator/terminator-linux.py
@@ -1,0 +1,82 @@
+from talon import Context, actions, Module
+
+# App definition
+mod = Module()
+mod.apps.terminator = """
+os: linux
+and app.exe: terminator
+os: linux
+and app.name: Terminator
+"""
+
+# Context matching
+ctx = Context()
+ctx.matches = r"""
+app: terminator
+"""
+ctx.tags = [
+    "terminal",
+    "user.terminal",
+    "user.tabs",
+    "user.splits",
+    "user.generic_unix_shell",
+    "user.git",
+    "user.kubectl",
+]
+
+
+# --- Implement actions ---
+@ctx.action_class("user")
+class user_actions:
+    # tag: user.splits
+    def split_window_right(): actions.key("alt-right")
+    def split_window_left(): actions.key("alt-left")
+    def split_window_down(): actions.key("alt-down")
+    def split_window_up(): actions.key("alt-up")
+    def split_window_vertically(): actions.key("shift-ctrl-e")
+    def split_window_horizontally(): actions.key("shift-ctrl-o")
+    def split_flip(): actions.key("super-r")
+    def split_window(): actions.key("shift-ctrl-o")
+    def split_clear(): actions.key("shift-ctrl-r")
+    def split_clear_all(): actions.key("shift-ctrl-g")
+    def split_next(): actions.key("shift-ctrl-n")
+    def split_last(): actions.key("shift-ctrl-p")
+
+
+@ctx.action_class("app")
+class AppActions:
+
+    # app.tabs
+    def tab_open(): actions.key("ctrl-shift-t")
+    def tab_previous(): actions.key("ctrl-pageup")
+    def tab_next(): actions.key("ctrl-pagedown")
+    def tab_close(): actions.key("ctrl-shift-w")
+    # global (overwrite linux/app.py)
+    def window_open(): actions.key('ctrl-shift-i')
+    def window_close(): actions.key('ctrl-shift-q')
+
+
+# global (overwrite linux/edit.py)
+@ctx.action_class('edit')
+class EditActions:
+    def page_down(): actions.key('shift-pagedown')
+    def page_up(): actions.key('shift-pageup')
+    def paste(): actions.key('ctrl-shift-v')
+    def copy(): actions.key('ctrl-shift-c')
+
+    def find(text: str = None):
+        actions.key('ctrl-shift-f')
+        if text:
+            actions.insert(text)
+
+    def delete_line():
+        actions.edit.line_start()
+        actions.key('ctrl-a ctrl-k')
+
+    # afaik not possible in gnome-terminal
+    def extend_left(): pass
+    def extend_right(): pass
+    def extend_up(): pass
+    def extend_down(): pass
+    def extend_word_left(): pass
+    def extend_word_right(): pass


### PR DESCRIPTION
Added terminator for Linux, based on the gnome terminal.

Shortcuts appropriately updated, and split window functionality implemented based on the splits tag.