### PR TITLE
selected_text(): use capture().text() not .get()

### DIFF
--- a/code/edit.py
+++ b/code/edit.py
@@ -11,7 +11,7 @@ class EditActions:
         with clip.capture() as s:
             actions.edit.copy()
         try:
-            return s.get()
+            return s.text()
         except clip.NoChange:
             return ""
     def line_insert_down():


### PR DESCRIPTION
Squashes some warnings from talon. My only concern here is that this API may not yet be in public talon. Can someone check?