### PR TITLE
Fix terraform client tagging

### DIFF
--- a/apps/terraform/terraform.py
+++ b/apps/terraform/terraform.py
@@ -1,4 +1,4 @@
 from talon import Module, Context
 
 mod = Module()
-mod.tag("terraform", desc="tag for enabling terraform commands in your terminal")
+mod.tag("terraform_client", desc="tag for enabling terraform commands in your terminal")

--- a/apps/terraform/terraform.talon
+++ b/apps/terraform/terraform.talon
@@ -1,5 +1,5 @@
 tag: terminal
-and tag: user.terraform
+and tag: user.terraform_client
 -
 terraform: "terraform "
 


### PR DESCRIPTION
#776 introduced a bug if the user explicitly set the tag `user.terraform`, which already existed due to #752. Terraform is both an application and a language, which is why this collision occurred. The bug manifested in lang/terraform/terraform.py
always being evaluated if a user explicitly set the client tag. This PR renames the client tag to fix this.