### PR TITLE
Extend Scala language

### DIFF
--- a/lang/scala/scala.py
+++ b/lang/scala/scala.py
@@ -8,31 +8,80 @@ tag: user.scala
 
 # Scala Common Types
 scala_common_types = {
-    "Byte": "Byte",
-    "Int": "Int",
-    "Double": "Double",
-    "Short": "Short",
-    "Float": "Float",
-    "Long": "Long",
-    "Boolean": "Boolean",
-    "Char": "Char",
-    "String": "String",
-    "None": "None"
+    "boolean": "Boolean",
+    "int": "Int",
+    "float": "Float",
+    "byte": "Byte",
+    "double": "Double",
+    "short": "Short",
+    "long": "Long",
+    "char": "Char",
+    "unit": "Unit",
+    "any": "Any",
+    "any val": "AnyVal",
+    "string": "String",
+    "thread": "Thread",
+    "exception": "Exception",
+    "throwable": "Throwable",
+    "none": "None",
+    "success": "Success",
+    "failure": "Failure",
 }
 
 # Scala Common Generic Types
 scala_common_generic_types = {
-    "seq": "Seq",
-    "set": "Set",
-    "list": "List",
     "array": "Array",
+    "deck": "Deque",
+    "future": "Future",
+    "list": "List",
     "map": "Map",
-    "stack": "Stack"
+    "nil": "Nil",
+    "option": "Option",
+    "queue": "Queue",
+    "seek": "Seq",
+    "set": "Set",
+    "some": "Some",
+    "stack": "Stack",
+    "try": "Try",
 }
 
 scala_types = scala_common_types.copy()
 scala_types.update(scala_common_generic_types)
 ctx.lists["user.code_type"] = scala_types
+
+# Scala Modifies
+scala_modifiers = {
+    "public": "public",
+    "private": "private",
+    "protected": "protected",
+}
+
+mod.list("scala_modifier", desc="Scala Modifiers")
+ctx.lists["user.scala_modifier"] = scala_modifiers
+
+scala_keywords = {
+    "abstract": "abstract",
+    "case class": "case class",
+    "def": "def",
+    "extends": "extends",
+    "implicit": "implicit",
+    "lazy val": "lazy val",
+    "new": "new",
+    "object": "object",
+    "override": "override",
+    "package": "package",
+    "sealed": "sealed",
+    "throw": "throw",
+    "trait": "trait",
+    "type": "type",
+    "val": "val",
+    "var": "var",
+    "with": "with",
+    "yield": "yield",
+}
+
+mod.list("scala_keyword", desc="Scala Keywords")
+ctx.lists["user.scala_keyword"] = scala_keywords
 
 @ctx.action_class("user")
 class UserActions:
@@ -42,110 +91,110 @@ class UserActions:
         actions.key('enter')
 
     def code_operator_lambda():
-        actions.auto_insert(" => ")
+        actions.insert(" => ")
 
     def code_operator_subscript():
         actions.insert("()")
         actions.edit.left()
 
     def code_operator_assignment():
-        actions.auto_insert(" = ")
+        actions.insert(" = ")
 
     def code_operator_subtraction():
         actions.insert(" - ")
 
     def code_operator_subtraction_assignment():
-        actions.auto_insert(" -= ")
+        actions.insert(" -= ")
 
     def code_operator_addition():
-        actions.auto_insert(" + ")
+        actions.insert(" + ")
 
     def code_operator_addition_assignment():
-        actions.auto_insert(" += ")
+        actions.insert(" += ")
 
     def code_operator_multiplication():
-        actions.auto_insert(" * ")
+        actions.insert(" * ")
 
     def code_operator_multiplication_assignment():
-        actions.auto_insert(" *= ")
+        actions.insert(" *= ")
 
     def code_operator_exponent():
-        actions.auto_insert(" ^ ")
+        actions.insert(" ^ ")
 
     def code_operator_division():
-        actions.auto_insert(" / ")
+        actions.insert(" / ")
 
     def code_operator_division_assignment():
-        actions.auto_insert(" /= ")
+        actions.insert(" /= ")
 
     def code_operator_modulo():
-        actions.auto_insert(" % ")
+        actions.insert(" % ")
 
     def code_operator_modulo_assignment():
-        actions.auto_insert(" %= ")
+        actions.insert(" %= ")
 
     def code_operator_equal():
-        actions.auto_insert(" == ")
+        actions.insert(" == ")
 
     def code_operator_not_equal():
-        actions.auto_insert(" != ")
+        actions.insert(" != ")
 
     def code_operator_greater_than():
-        actions.auto_insert(" > ")
+        actions.insert(" > ")
 
     def code_operator_greater_than_or_equal_to():
-        actions.auto_insert(" >= ")
+        actions.insert(" >= ")
 
     def code_operator_less_than():
-        actions.auto_insert(" < ")
+        actions.insert(" < ")
 
     def code_operator_less_than_or_equal_to():
-        actions.auto_insert(" <= ")
+        actions.insert(" <= ")
 
     def code_operator_and():
-        actions.auto_insert(" && ")
+        actions.insert(" && ")
 
     def code_operator_or():
-        actions.auto_insert(" || ")
+        actions.insert(" || ")
 
     def code_operator_bitwise_and():
-        actions.auto_insert(" & ")
+        actions.insert(" & ")
 
     def code_operator_bitwise_and_assignment():
-        actions.auto_insert(' &= ')
+        actions.insert(' &= ')
 
     def code_operator_increment():
-        actions.auto_insert('++')
+        actions.insert('++')
 
     def code_operator_bitwise_or():
-        actions.auto_insert(" | ")
+        actions.insert(" | ")
 
     def code_operator_bitwise_exclusive_or():
-        actions.auto_insert(" ^ ")
+        actions.insert(" ^ ")
 
     def code_operator_bitwise_left_shift():
-        actions.auto_insert(" << ")
+        actions.insert(" << ")
 
     def code_operator_bitwise_left_shift_assignment():
-        actions.auto_insert(" <<= ")
+        actions.insert(" <<= ")
 
     def code_operator_bitwise_right_shift():
-        actions.auto_insert(" >> ")
+        actions.insert(" >> ")
 
     def code_operator_bitwise_right_shift_assignment():
-        actions.auto_insert(" >>= ")
+        actions.insert(" >>= ")
 
     def code_self():
-        actions.auto_insert("this")
+        actions.insert("this")
 
     def code_insert_null():
-        actions.auto_insert("null")
+        actions.insert("null")
 
     def code_insert_is_null():
-        actions.auto_insert(" == null")
+        actions.insert(" == null")
 
     def code_insert_is_not_null():
-        actions.auto_insert(" != null")
+        actions.insert(" != null")
 
     def code_state_if():
         actions.insert("if () ")
@@ -159,7 +208,6 @@ class UserActions:
 
     def code_state_else():
         actions.insert("else ")
-        actions.key("enter")
 
     def code_state_switch():
         actions.insert("match {\n")
@@ -182,28 +230,28 @@ class UserActions:
         actions.edit.left()
 
     def code_break():
-        actions.auto_insert('break')
+        actions.insert('break')
 
     def code_next():
-        actions.auto_insert('continue')
+        actions.insert('continue')
 
     def code_insert_true():
-        actions.auto_insert('true')
+        actions.insert('true')
 
     def code_insert_false():
-        actions.auto_insert('false')
+        actions.insert('false')
 
     def code_define_class():
-        actions.auto_insert("class ")
+        actions.insert("class ")
 
     def code_import():
-        actions.auto_insert("import ")
+        actions.insert("import ")
 
     def code_state_return():
         actions.insert("return ")
 
     def code_comment_line_prefix():
-        actions.auto_insert('// ')
+        actions.insert('// ')
 
     def code_comment_block():
         actions.insert('/*')
@@ -213,10 +261,10 @@ class UserActions:
         actions.edit.up()
 
     def code_comment_block_prefix():
-        actions.auto_insert('/*')
+        actions.insert('/*')
 
     def code_comment_block_suffix():
-        actions.auto_insert('*/')
+        actions.insert('*/')
 
     def code_insert_type_annotation(type: str):
         actions.insert(f": {type}")

--- a/lang/scala/scala.talon
+++ b/lang/scala/scala.talon
@@ -24,15 +24,18 @@ settings():
     user.code_protected_variable_formatter = "PRIVATE_CAMEL_CASE"
     user.code_public_variable_formatter = "PRIVATE_CAMEL_CASE"
 
-state package: "package "
+state {user.scala_modifier}:
+    insert("{user.scala_modifier} ")
 
-state val: "val "
-state var: "var "
+state {user.scala_keyword}:
+    insert("{scala_keyword} ")
+
+op right arrow: " -> "
+op left arrow: " <- "
+op plus plus: " ++ "
+op subtype: " <: "
 
 state match: user.code_state_switch()
-
-state case class: "case class "
-state object: "object "
 
 block string:
   insert('""""""')


### PR DESCRIPTION
This pull request intends to extend the scala language definitions introduced in #735. If applied, it will

- add further types
- add modifiers
- add keywords
- remove added `enter` after `else` keyword to enable `if(foo) bar else baz` syntax