### PR TITLE
Add new name variant for VS Code - Insiders

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -31,6 +31,8 @@ and app.name: Visual Studio Code
 os: windows
 and app.name: Visual Studio Code Insiders
 os: windows
+and app.name: Visual Studio Code - Insiders
+os: windows
 and app.exe: Code.exe
 os: windows
 and app.exe: Code-Insiders.exe


### PR DESCRIPTION
A newly downloaded version of VS Code - Insiders has a dash in the name now 🤷 Before I added this line Talon wasn't recognizing the Insiders version at all.