### PR TITLE
Add Brave as a new browser applicatoin

### DIFF
--- a/apps/brave/brave.py
+++ b/apps/brave/brave.py
@@ -1,0 +1,50 @@
+from talon import ctrl, ui, Module, Context, actions, clip, app
+
+ctx = Context()
+mod = Module()
+
+mod.apps.brave = "app.name: Brave Browser"
+# TODO: Add other OS application identifiers
+mod.apps.brave = """
+os: mac
+and app.bundle: com.brave.Browser
+"""
+ctx.matches = r"""
+app: brave
+"""
+
+@ctx.action_class("user")
+class user_actions:
+    def tab_jump(number: int):
+        if number < 9:
+            if app.platform == "mac":
+                actions.key("cmd-{}".format(number))
+            else:
+                actions.key("ctrl-{}".format(number))
+
+    def tab_final():
+        if app.platform == "mac":
+            actions.key("cmd-9")
+        else:
+            actions.key("ctrl-9")
+
+    def tab_close_wrapper():
+        actions.sleep("180ms")
+        actions.app.tab_close()
+
+    def tab_duplicate():
+        """Limitation: this will not work if the text in your address bar has been manually edited.
+        Long-term we want a better shortcut from browsers.
+        """
+        actions.browser.focus_address()
+        actions.sleep("180ms")
+        actions.key("alt-enter")
+
+
+@ctx.action_class("browser")
+class browser_actions:
+    def go(url: str):
+        actions.browser.focus_address()
+        actions.sleep("50ms")
+        actions.insert(url)
+        actions.key("enter")

--- a/apps/brave/mac.py
+++ b/apps/brave/mac.py
@@ -1,0 +1,71 @@
+from talon import Context, actions, ui
+from talon.mac import applescript
+
+ctx = Context()
+ctx.matches = r"""
+os: mac
+app: brave
+"""
+ctx.tags = ['browser', 'user.tabs']
+
+def brave_app():
+    return ui.apps(bundle="com.brave.Browser")[0]
+
+@ctx.action_class('browser')
+class BrowserActions:
+    def address() -> str:
+        try:
+            window = brave_app().windows()[0]
+        except IndexError:
+            return ''
+        try:
+            web_area = window.element.children.find_one(AXRole='AXWebArea')
+            address = web_area.AXURL
+        except (ui.UIErr, AttributeError):
+            address = applescript.run('''
+                tell application id "com.brave.Browser"
+                    if not (exists (window 1)) then return ""
+                    return window 1's active tab's URL
+                end tell
+            ''')
+        return address
+    def bookmark():
+        actions.key('cmd-d')
+    def bookmark_tabs():
+        actions.key('cmd-shift-d')
+    def bookmarks():
+        actions.key('cmd-alt-b')
+    def bookmarks_bar():
+        actions.key('cmd-shift-b')
+    def focus_address():
+        actions.key('cmd-l')
+        #action(browser.focus_page):
+    def focus_search():
+        actions.browser.focus_address()
+    def go_blank():
+        actions.key('cmd-n')
+    def go_back():
+        actions.key('cmd-[')
+    def go_forward():
+        actions.key('cmd-]')
+    def go_home():
+        actions.key('cmd-shift-h')
+    def open_private_window():
+        actions.key('cmd-shift-n')
+    def reload():
+        actions.key('cmd-r')
+    def reload_hard():
+        actions.key('cmd-shift-r')
+        #action(browser.reload_hardest):
+    def show_clear_cache():
+        actions.key('cmd-shift-delete')
+    def show_downloads():
+        actions.key('cmd-shift-j')
+        #action(browser.show_extensions)
+    def show_history():
+        actions.key('cmd-y')
+    def submit_form():
+        actions.key('enter')
+        #action(browser.title)
+    def toggle_dev_tools():
+        actions.key('cmd-alt-i')

--- a/apps/web/window_titles.md
+++ b/apps/web/window_titles.md
@@ -1,4 +1,4 @@
-Some of the files (e.g. github.talon) use a browser.host matcher. These talon files should work out of the box for Safari and Chrome on Mac, but require additional configuration on other browsers/operating systems. `knasuj_talon` is set up so that if a URL is found in the titlebar of an application matching the 'browser' tag it will be used to populate the browser.host matcher (see `code/browser.py`). This probably means that you will need an extension to make the browser.host based scripts work.
+Some of the files (e.g. github.talon) use a browser.host matcher. These talon files should work out of the box for Safari, Chrome, Brave, on Mac, but require additional configuration on other browsers/operating systems. `knasuj_talon` is set up so that if a URL is found in the titlebar of an application matching the 'browser' tag it will be used to populate the browser.host matcher (see `code/browser.py`). This probably means that you will need an extension to make the browser.host based scripts work.
 
 Browser extensions that can add the protocol and hostname or even the entire URL to the window title:
 


### PR DESCRIPTION
EDIT: This adds Brave as a new browser application. See below for the original issue description.
----

Brave is a web browser built on Chromium and so I thought it was fitting to add it as a variant of Chrome.

This is my first contribution and I'm still getting used to what the configuration parameters are used for if I haven't got it right please correct me. I see this in the contributing section in the README

>For Mac OS X, the bundle id should be used for defining app contexts, rather than the name

And I'm not sure if I've done more than I should have there.

Also I don't have access to a Windows machine (only mac) to test but some googling suggested what the .exe name would be.