### PR TITLE
Refactor functions_gui to functions_common

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Python, C#, Talon and javascript language support is currently broken up into se
 • `lang/tags/data_null.{talon,py}`             - null & null checks (e.g., Python's `None`)
 • `lang/tags/data_bool.{talon,py}`             - booleans (e.g., Haskell's `True`)
 • `lang/tags/functions.{talon,py}`             - functions and definitions
-• `lang/tags/functions_gui.{talon,py}`         - graphical helper for common functions
+• `lang/tags/functions_common.{talon,py}`      - common functions (also includes a GUI for picking functions)
 • `lang/tags/imperative.{talon,py}`            - statements (e.g., `if`, `while`, `switch`)
 • `lang/tags/libraries.{talon,py}`             - libraries and imports
 • `lang/tags/libraries_gui.{talon,py}`         - graphical helper for common libraries

--- a/apps/generic_snippets/generic_snippets.py
+++ b/apps/generic_snippets/generic_snippets.py
@@ -17,7 +17,7 @@ def gui(gui: imgui.GUI):
         function_list = sorted(registry.lists["user.snippets"][0].keys())
         # print(str(registry.lists["user.snippets"]))
 
-        # print(str(registry.lists["user.code_functions"]))
+        # print(str(registry.lists["user.code_common_function"]))
         if function_list:
             for i, entry in enumerate(function_list):
                 gui.text("{}".format(entry, function_list))

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -87,7 +87,7 @@ ctx.lists["user.code_libraries"] = {
     "standard int": "stdint.h",
 }
 
-ctx.lists["user.code_functions"] = {
+ctx.lists["user.code_common_function"] = {
     "mem copy": "memcpy",
     "mem set": "memset",
     "string cat": "strcat",

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -7,7 +7,7 @@ tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
-tag(): user.code_functions_gui
+tag(): user.code_functions_common
 tag(): user.code_libraries
 tag(): user.code_libraries_gui
 tag(): user.code_operators_array

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -4,7 +4,7 @@ ctx = Context()
 ctx.matches = r"""
 tag: user.csharp
 """
-ctx.lists["user.code_functions"] = {
+ctx.lists["user.code_common_function"] = {
     "integer": "int.TryParse",
     "print": "Console.WriteLine",
     "string": ".ToString",

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -8,7 +8,7 @@ tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
-tag(): user.code_functions_gui
+tag(): user.code_functions_common
 tag(): user.code_libraries
 tag(): user.code_operators_array
 tag(): user.code_operators_assignment

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -5,7 +5,7 @@ mod = Module()
 ctx.matches = r"""
 tag: user.java
 """
-ctx.tags = ["user.code_operators", "user.code_generic", "user.code_functions_gui"]
+ctx.tags = ["user.code_operators", "user.code_generic"]
 
 # Primitive Types
 java_primitive_types = {

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -8,7 +8,6 @@ tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
-tag(): user.code_functions_gui
 tag(): user.code_libraries
 tag(): user.code_operators_array
 tag(): user.code_operators_assignment

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -5,12 +5,6 @@ ctx = Context()
 ctx.matches = """
 tag: user.javascript
 """
-# tbd
-# ctx.lists["user.code_functions"] = {
-#     "integer": "int.TryParse",
-#     "print": "Console.WriteLine",
-#     "string": ".ToString",
-# }
 
 
 @ctx.action_class("user")

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -8,7 +8,6 @@ tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
-tag(): user.code_functions_gui
 tag(): user.code_libraries
 tag(): user.code_operators_array
 tag(): user.code_operators_assignment

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -7,7 +7,7 @@ ctx = Context()
 ctx.matches = r"""
 tag: user.python
 """
-ctx.lists["user.code_functions"] = {
+ctx.lists["user.code_common_function"] = {
     "enumerate": "enumerate",
     "integer": "int",
     "length": "len",

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -8,7 +8,7 @@ tag(): user.code_comment_documentation
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
-tag(): user.code_functions_gui
+tag(): user.code_functions_common
 tag(): user.code_libraries
 tag(): user.code_libraries_gui
 tag(): user.code_operators_array

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -6,7 +6,7 @@ ctx.matches = r"""
 tag: user.r
 """
 
-ctx.lists["user.code_functions"] = {
+ctx.lists["user.code_common_function"] = {
     # base R
     "as character": "as.character",
     "as data frame": "as.data.frame",

--- a/lang/r/r.talon
+++ b/lang/r/r.talon
@@ -6,7 +6,7 @@ tag(): user.code_comment_line
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
-tag(): user.code_functions_gui
+tag(): user.code_functions_common
 tag(): user.code_libraries
 tag(): user.code_libraries_gui
 tag(): user.code_operators_assignment

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -202,8 +202,8 @@ ctx.lists['user.code_libraries'] = {
     'collections': 'std::collections',
 }
 
-# tag: functions_gui
-ctx.lists['user.code_functions'] = {
+# tag: functions_common
+ctx.lists['user.code_common_function'] = {
     'drop': 'drop',
     'catch unwind': 'catch_unwind',
     'iterator': 'iter',

--- a/lang/rust/rust.talon
+++ b/lang/rust/rust.talon
@@ -11,8 +11,7 @@ tag(): user.code_data_bool
 tag(): user.code_data_null
 
 tag(): user.code_functions
-tag(): user.code_functions_gui
-
+tag(): user.code_functions_common
 tag(): user.code_libraries
 tag(): user.code_libraries_gui
 

--- a/lang/tags/functions_common.py
+++ b/lang/tags/functions_common.py
@@ -3,18 +3,18 @@ from talon import Context, Module, actions, imgui, registry, settings
 ctx = Context()
 mod = Module()
 
-mod.list("code_functions", desc="List of functions for active language")
+mod.list("code_common_function", desc="List of common functions for active language")
 
 # global
 function_list = []
 
-@mod.capture(rule="{user.code_functions}")
+@mod.capture(rule="{user.code_common_function}")
 def code_functions(m) -> str:
     """Returns a function name"""
-    return m.code_functions
+    return m.code_common_function
 
-mod.tag("code_functions_gui", desc="Tag for enabling GUI support for common functions")
-mod.tag("code_functions_gui_showing", desc="Active when the function picker GUI is showing")
+mod.tag("code_functions_common", desc="Tag for enabling support for common functions")
+mod.tag("code_functions_common_gui_active", desc="Active when the function picker GUI is showing")
 
 @mod.action_class
 class Actions:
@@ -25,7 +25,7 @@ class Actions:
         if gui_functions.showing:
             function_list = []
             gui_functions.hide()
-            ctx.tags.discard("user.code_functions_gui_showing")
+            ctx.tags.discard("user.code_functions_common_gui_active")
         else:
             update_function_list_and_freeze()
 
@@ -33,7 +33,7 @@ class Actions:
         """Inserts the selected function when the imgui is open"""
         if gui_functions.showing and number < len(function_list):
             actions.user.code_insert_function(
-                registry.lists["user.code_functions"][0][function_list[number]],
+                registry.lists["user.code_common_function"][0][function_list[number]],
                 selection,
             )
 
@@ -46,13 +46,13 @@ class Actions:
 
 def update_function_list_and_freeze():
     global function_list
-    if "user.code_functions" in registry.lists:
-        function_list = sorted(registry.lists["user.code_functions"][0].keys())
+    if "user.code_common_function" in registry.lists:
+        function_list = sorted(registry.lists["user.code_common_function"][0].keys())
     else:
         function_list = []
 
     gui_functions.show()
-    ctx.tags.add("user.code_functions_gui_showing")
+    ctx.tags.add("user.code_functions_common_gui_active")
 
 
 @imgui.open()
@@ -62,10 +62,10 @@ def gui_functions(gui: imgui.GUI):
 
     # print(str(registry.lists["user.code_functions"]))
     for i, entry in enumerate(function_list, 1):
-        if entry in registry.lists["user.code_functions"][0]:
+        if entry in registry.lists["user.code_common_function"][0]:
             gui.text(
                 "{}. {}: {}".format(
-                    i, entry, registry.lists["user.code_functions"][0][entry]
+                    i, entry, registry.lists["user.code_common_function"][0][entry]
                 )
             )
 

--- a/lang/tags/functions_common.py
+++ b/lang/tags/functions_common.py
@@ -9,7 +9,7 @@ mod.list("code_common_function", desc="List of common functions for active langu
 function_list = []
 
 @mod.capture(rule="{user.code_common_function}")
-def code_functions(m) -> str:
+def code_common_function(m) -> str:
     """Returns a function name"""
     return m.code_common_function
 

--- a/lang/tags/functions_common.talon
+++ b/lang/tags/functions_common.talon
@@ -1,11 +1,11 @@
 tag: user.code_functions_common
 -
 toggle funk: user.code_toggle_functions()
-funk <user.code_functions>:
-    user.code_insert_function(code_functions, "")
+funk <user.code_common_function>:
+    user.code_insert_function(code_common_function, "")
 funk cell <number>:
     user.code_select_function(number - 1, "")
-funk wrap <user.code_functions>:
-    user.code_insert_function(code_functions, edit.selected_text())
+funk wrap <user.code_common_function>:
+    user.code_insert_function(code_common_function, edit.selected_text())
 funk wrap <number>:
     user.code_select_function(number - 1, edit.selected_text())

--- a/lang/tags/functions_common.talon
+++ b/lang/tags/functions_common.talon
@@ -1,4 +1,4 @@
-tag: user.code_functions_gui
+tag: user.code_functions_common
 -
 toggle funk: user.code_toggle_functions()
 funk <user.code_functions>:

--- a/lang/tags/functions_common_gui_active.talon
+++ b/lang/tags/functions_common_gui_active.talon
@@ -1,4 +1,4 @@
-tag: user.code_functions_gui_showing
+tag: user.code_functions_common_gui_active
 -
 # Toggle prefix to be mentally similar to the 'toggle funk' show command
 toggle funk: user.code_toggle_functions()

--- a/lang/talon/talon.py
+++ b/lang/talon/talon.py
@@ -30,7 +30,7 @@ mod.list("talon_modes")
 ctx.matches = r"""
 tag: user.talon
 """
-ctx.lists["user.code_functions"] = {
+ctx.lists["user.code_common_function"] = {
     "insert": "insert",
     "key": "key",
     "print": "print",

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -3,7 +3,7 @@ tag: user.talon
 tag(): user.code_operators_math
 tag(): user.code_operators_assignment
 tag(): user.code_comment_line
-tag(): user.code_functions_gui
+tag(): user.code_functions_common
 # uncomment user.talon_populate_lists tag to activate talon-specific lists of actions, scopes, modes etcetera.
 # Do not enable this tag with dragon, as it will be unusable.
 # with conformer, the latency increase may also be unacceptable depending on your cpu
@@ -47,10 +47,6 @@ capture {user.talon_captures}: "<{talon_captures}>"
 #commands for dictating key combos
 key <user.keys> over: "{keys}"
 key <user.modifiers> over: "{modifiers}"
-
-# basic list of actions (e.g., insert, key)
-funk <user.code_functions>:
-    user.code_insert_function(code_functions, "")
 
 # all actions (requires uncommenting user.talon_populate_lists tag above)
 funk {user.talon_actions}: user.code_insert_function(talon_actions, edit.selected_text())

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -52,7 +52,7 @@ key <user.modifiers> over: "{modifiers}"
 funk {user.talon_actions}: user.code_insert_function(talon_actions, edit.selected_text())
 funk cell <number>:
     user.code_select_function(number - 1, "")
-funk wrap <user.code_functions>:
-    user.code_insert_function(code_functions, edit.selected_text())
+funk wrap <user.code_common_function>:
+    user.code_insert_function(code_common_function, edit.selected_text())
 funk wrap <number>:
     user.code_select_function(number - 1, edit.selected_text())

--- a/lang/typescript/typescript.py
+++ b/lang/typescript/typescript.py
@@ -4,12 +4,6 @@ ctx = Context()
 ctx.matches = r"""
 tag: user.typescript
 """
-# tbd
-# ctx.lists["user.code_functions"] = {
-#     "integer": "int.TryParse",
-#     "print": "Console.WriteLine",
-#     "string": ".ToString",
-# }
 
 ctx.lists["user.code_type"] = {
     "boolean": "boolean",


### PR DESCRIPTION
Fixes #732

This commit refactors the misleadingly named functions_gui tag and the associated list, tags, and files, as @pokey suggested in #732. 
It also removes dead configuration for some languages.

As suggested in the issue, I changed the name of the function list to singular to increase readability and align with the code standard. I deviated from pokey's suggestions in that I used the tag `code_functions_common` instead of `code_common_functions` (same with the file names). I did so to conform with the pattern established by other tags e.g. `code_operators_array` or `code_data_bool`.

I was as careful as possible, but considering the large number of files I had to touch, this pull request has the potential of breaking functionality. Therefore, I would welcome a thorough review. I manually verified that the `funk` command still works for the languages I touched.

I realize that there is a similar functionality for common libraries. If this pull request is welcomed, I would volunteer to refactor that functionality as well.