### PR TITLE
Adds Smooth Scroll Behavior to mouse.py

### DIFF
--- a/code/mouse.py
+++ b/code/mouse.py
@@ -214,7 +214,7 @@ class Actions:
         mouse_scroll(-amount * setting_mouse_wheel_down_amount.get())()
 
     def mouse_scroll_up_smooth(amount: float = 1):
-        """Scrolls down smoothly"""
+        """Scrolls up smoothly"""
         global continuous_scoll_mode
         continuous_scoll_mode = "scroll up smooth"
         mouse_scroll(-1 * setting_mouse_wheel_down_amount.get())()


### PR DESCRIPTION
This adds smooth scrolling as the default, however, it may be desirable for this to be controlled via settings to toggle between smooth/jump scrolling?

Related to #801 

<hr>

This provides consistent smooth scrolling behavior,  that when multiplied with `third`, `second`...etc has an effective scroll speed increase based on the multiplier. Ie. scrolling 4th scrolls 4x as far, but in the same amount of time as a single scroll.

## Testing:

In `mouse.talon` replace the `scroll up` & `scroll down` commands:

```
scroll down: user.mouse_scroll_down_smooth(5)
scroll up: user.mouse_scroll_up_smooth(5)
```