### PR TITLE
Tara Added talon resource websites as defaults to websites.csv

### DIFF
--- a/code/websites_and_search_engines.py
+++ b/code/websites_and_search_engines.py
@@ -11,6 +11,11 @@ mod.list(
 )
 
 website_defaults = {
+    "talon home page":"http://talonvoice.com",
+    "talon slack":"http://talonvoice.slack.com/messages/help",
+    "talon wiki":"https://talon.wiki/",
+    "talon practice":"https://chaosparrot.github.io/talon_practice/",
+    "talon repository search": "https://search.talonvoice.com/search/",
     "amazon": "https://www.amazon.com/",
     "dropbox": "https://dropbox.com/",
     "google": "https://www.google.com/",


### PR DESCRIPTION
To lower the activation energy for people to be able to get to the websites where you can find help, I added 

    "talon website":"http://talonvoice.com",
    "talon slack":"http://talonvoice.slack.com/messages/help",
    "talon wiki":"https://talon.wiki/",
    "talon practice":"https://chaosparrot.github.io/talon_practice/",
    "talon repository search": "https://search.talonvoice.com/search/",
    
As defaults to website.csv, so that the command 
    
*open talon website*  launches the talon website
*open talon slack* launches the talon slack  and puts you in the help channel by default
*open talon wiki* launches the talon wiki
*open talon practice* goes to chaosparrot's talon practice website.  