### PR TITLE
Enable window next/last on windows platform.

### DIFF
--- a/code/platforms/win/app.py
+++ b/code/platforms/win/app.py
@@ -1,14 +1,22 @@
 # defines the default app actions for windows
 
-import win32gui
-from talon import Context, actions, ui
+
+from talon import Context, actions, ui, app
+
+# we expect this import to succeed on windows (only)
+if app.platform == 'windows':
+    import win32gui
+
 ctx = Context()
 ctx.matches = r"""
 os: windows
 """
 
 # adapted this from code posted by @PeterLinder
-# return list of top level windows
+# this is a wrapper around the win32 EnumWindows() function, which is documented
+# here - https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumwindows.
+# you might think that 'top level windows' are non-hidden, non-background windows that are
+# not child windows...but you'd be wrong.
 def get_top_level_windows():
     def enumHandler(hwnd, resultList):
         resultList.append(hwnd)
@@ -18,9 +26,11 @@ def get_top_level_windows():
     win32gui.EnumWindows(enumHandler, top_level_windows)
     return top_level_windows
 
-# focuses the n-th next or n-th previous instance of the current
-# app, depending on the magnitude and sign of the 'direction' arg
 def _focus_neighbor_window(direction: int) -> ui.Window:
+    """
+    focuses the n-th next or n-th previous instance of the current
+    app, depending on the magnitude and sign of the 'direction' arg.
+    """
     active_window = ui.active_window()
     active_app = active_window.app
 

--- a/code/platforms/win/app.py
+++ b/code/platforms/win/app.py
@@ -1,6 +1,6 @@
 # defines the default app actions for windows
 
-
+import os
 from talon import Context, actions, ui, app
 
 # we expect this import to succeed on windows (only)
@@ -39,6 +39,14 @@ def _focus_neighbor_window(direction: int) -> ui.Window:
     # don't use .hidden for now, as the cached value may be stale (https://github.com/talonvoice/talon/issues/494#issuecomment-1059517184)
     # app_windows = [w for w in ui.windows() if w.app.name == active_app.name and not w.hidden and w.id in top_level_windows]
     app_windows = [w for w in ui.windows() if w.app.name == active_app.name and win32gui.IsWindowVisible(w.id) and w.id in top_level_windows]
+
+    # Windows Explorer is a special case
+    if active_app.name == 'Windows Explorer':
+        app_windows = [w for w in app_windows if len(w.title) > 0 and os.path.exists(w.title)]
+        # for w in app_windows:
+        #     if len(w.title) > 0:
+        #         pass
+        
     app_windows.sort(key=lambda w: w.id)
     window_count = len(app_windows)
     # print(f'_focus_neighbor_window: app_windows: {len(app_windows)=}, {[w.id for w in app_windows]}')

--- a/code/platforms/win/app.py
+++ b/code/platforms/win/app.py
@@ -42,10 +42,38 @@ def _focus_neighbor_window(direction: int) -> ui.Window:
 
     # Windows Explorer is a special case
     if active_app.name == 'Windows Explorer':
-        app_windows = [w for w in app_windows if len(w.title) > 0 and os.path.exists(w.title)]
-        # for w in app_windows:
-        #     if len(w.title) > 0:
-        #         pass
+        libraries_path = os.path.join(actions.path.user_home(), 'AppData\\Roaming\\Microsoft\\Windows\\Libraries')
+        user_libraries = [os.path.splitext(i)[0] for i in os.listdir(libraries_path)]
+        # print(f'_focus_neighbor_window: {user_libraries=}')
+        user_libraries_long = ['Libraries\\' + i for i in user_libraries]
+
+        user_home_folders = []
+        for f in os.listdir(actions.path.user_home()):
+            full_path = os.path.join(actions.path.user_home(), f)
+            if os.path.isdir(full_path):
+                user_home_folders.append(f)
+        
+        # filter list of explore windows down to those that are filesystem browser windows
+        temp = []
+        for w in app_windows:
+            if len(w.title) > 0:
+                mangled_title = w.title.replace(' ', '')
+                title_home_path = os.path.join(actions.path.user_home(), w.title)
+                if (
+                    w.title == 'Libraries' or
+                    mangled_title in user_libraries or
+                    mangled_title in user_libraries_long or
+                    w.title in user_home_folders or
+                    os.path.exists(w.title) or
+                    os.path.exists(title_home_path)
+                ):
+                    # print(f'_focus_neighbor_window: including explorer window {w.title}')
+                    temp.append(w)
+            #     else:
+            #         print(f'_focus_neighbor_window: excluding explorer window {w.title}')
+            # else:
+            #     print(f'_focus_neighbor_window: excluding explorer window {w.title}')
+        app_windows = temp
         
     app_windows.sort(key=lambda w: w.id)
     window_count = len(app_windows)


### PR DESCRIPTION
Use win32 calls to enable 'window next'/'window last' commands on the windows platform, without requiring third party software.