### PR TITLE
Enable voice management of consolidated csv settings

### DIFF
--- a/code/abbreviate.py
+++ b/code/abbreviate.py
@@ -1,11 +1,13 @@
 # XXX - would be nice to be able pipe these through formatters
 
+from .user_settings import get_list_from_csv
+
 from talon import Context, Module
 
 mod = Module()
 mod.list("abbreviation", desc="Common abbreviation")
 
-abbreviations = {
+_abbreviation_defaults = {
     "address": "addr",
     "administrator": "admin",
     "administrators": "admins",
@@ -213,6 +215,12 @@ abbreviations = {
     "what the fuck": "wtf",
     "window": "win",
 }
+
+abbreviations = get_list_from_csv(
+    "abbreviate.csv",
+    headers=("Abbreviation", "Word(s)"),
+    default=_abbreviation_defaults
+)
 
 ctx = Context()
 ctx.lists["user.abbreviation"] = abbreviations

--- a/code/exec.py
+++ b/code/exec.py
@@ -1,10 +1,16 @@
 import os
 import subprocess
 
-from talon import Module
+from talon import Module, actions, app, ui, settings
 
 mod = Module()
 
+setting_eof_keys = mod.setting(
+    "eof_keys",
+    type=str,
+    default=None,
+    desc="Shortcut key(s) for moving to end of file in your default editor, e.g. 'ctrl-end'.",
+)
 
 @mod.action_class
 class Actions:
@@ -15,3 +21,73 @@ class Actions:
     def system_command_nb(cmd: str):
         """execute a command on the system without blocking"""
         subprocess.Popen(cmd, shell=True)
+
+    def get_repo_relpath():
+        """Get path of the repo containing this file, relative to the talon user folder"""
+        return os.path.dirname(os.path.dirname(os.path.relpath(__file__, actions.path.talon_user())))
+
+    def edit_additional_words():
+        """execute a command on the system without blocking"""
+        repo_dir = actions.user.get_repo_relpath()
+        path = os.path.join(repo_dir, 'settings', 'additional_words.csv')
+        actions.user.edit_talon_user_csv(path)
+
+    def edit_words_to_replace():
+        """execute a command on the system without blocking"""
+        repo_dir = actions.user.get_repo_relpath()
+        path = os.path.join(repo_dir, 'settings', 'words_to_replace.csv')
+        actions.user.edit_talon_user_csv(path)
+
+    def edit_abbreviations():
+        """execute a command on the system without blocking"""
+        repo_dir = actions.user.get_repo_relpath()
+        path = os.path.join(repo_dir, 'settings', 'abbreviate.csv')
+        actions.user.edit_talon_user_csv(path)
+
+    def edit_homophones():
+        """execute a command on the system without blocking"""
+        repo_dir = actions.user.get_repo_relpath()
+        path = os.path.join(repo_dir, 'settings', 'homophones.csv')
+
+        abs_path = os.path.join(actions.path.talon_user(), path)
+        if not os.path.exists(abs_path):
+            # create an empty file
+            open(abs_path, 'a').close()
+
+        actions.user.edit_talon_user_csv(path)
+
+    def edit_talon_user_csv(talon_user_file_path: str) -> None:
+        """Opens a .csv file under the talon user folder using the default application"""
+
+        if not os.path.relpath(talon_user_file_path):
+            print('edit_talon_user_csv: can only open files under the talon user folder!')
+
+        if not talon_user_file_path.endswith(".csv"):
+            print('edit_talon_user_csv: can only open .csv files!')
+
+        path = os.path.join(actions.path.talon_user(), talon_user_file_path)
+
+        eof_keys = settings.get('user.csv_eof_keys')
+
+        if app.platform == "windows":
+            os.startfile(path, 'open')
+
+            if not eof_keys:
+                eof_keys='ctrl-end'
+        elif app.platform == "mac":
+            ui.launch(path='open', args=[str(path)])
+
+            if not eof_keys:
+                eof_keys='cmd-down'
+        elif app.platform == "linux":
+            ui.launch(path='/usr/bin/xdg-open', args=[str(path)])
+
+            if not eof_keys:
+                eof_keys='ctrl-end'
+        else:
+            raise Exception(f'unknown system: {app.platform}')
+
+        actions.sleep("500ms")
+        actions.key(eof_keys)
+        actions.sleep("500ms")
+        actions.key("enter")

--- a/code/exec.py
+++ b/code/exec.py
@@ -59,13 +59,19 @@ class Actions:
     def edit_talon_user_csv(talon_user_file_path: str) -> None:
         """Opens a .csv file under the talon user folder using the default application"""
 
-        if not os.path.relpath(talon_user_file_path):
-            print('edit_talon_user_csv: can only open files under the talon user folder!')
-
         if not talon_user_file_path.endswith(".csv"):
             print('edit_talon_user_csv: can only open .csv files!')
 
-        path = os.path.join(actions.path.talon_user(), talon_user_file_path)
+        if os.path.isabs(talon_user_file_path):
+            if not talon_user_file_path.startswith(str(actions.path.talon_user())):
+                raise ValueError('edit_talon_user_csv: can only open files under the talon user folder!')
+            else:
+                path = talon_user_file_path
+        else:
+            path = os.path.join(actions.path.talon_user(), talon_user_file_path)
+
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
 
         eof_keys = settings.get('user.csv_eof_keys')
 

--- a/code/homophones.py
+++ b/code/homophones.py
@@ -1,3 +1,5 @@
+from .user_settings import SETTINGS_DIR
+
 from talon import Context, Module, app, clip, cron, imgui, actions, ui, fs
 import os
 
@@ -11,6 +13,7 @@ import os
 # https://github.com/pimentel/homophones
 cwd = os.path.dirname(os.path.realpath(__file__))
 homophones_file = os.path.join(cwd, "homophones.csv")
+user_homophones_file = os.path.join(SETTINGS_DIR, "homophones.csv")
 # if quick_replace, then when a word is selected and only one homophone exists,
 # replace it without bringing up the options
 quick_replace = True
@@ -31,14 +34,15 @@ def update_homophones(name, flags):
 
     phones = {}
     canonical_list = []
-    with open(homophones_file, "r") as f:
-        for line in f:
-            words = line.rstrip().split(",")
-            canonical_list.append(words[0])
-            for word in words:
-                word = word.lower()
-                old_words = phones.get(word, [])
-                phones[word] = sorted(set(old_words + words))
+    for path in [homophones_file, user_homophones_file]:
+        with open(path, "r") as f:
+            for line in f:
+                words = line.rstrip().split(",")
+                canonical_list.append(words[0])
+                for word in words:
+                    word = word.lower()
+                    old_words = phones.get(word, [])
+                    phones[word] = sorted(set(old_words + words))
 
     global all_homophones
     all_homophones = phones
@@ -47,6 +51,8 @@ def update_homophones(name, flags):
 
 update_homophones(homophones_file, None)
 fs.watch(cwd, update_homophones)
+if os.path.exists(user_homophones_file):
+    fs.watch(user_homophones_file, update_homophones)
 active_word_list = None
 is_selection = False
 

--- a/misc/standard.talon
+++ b/misc/standard.talon
@@ -28,3 +28,14 @@ wipe: key(backspace)
 	key(left)
 slap: edit.line_insert_down()
 
+additional word:
+    user.edit_additional_words()
+
+additional replacement:
+    user.edit_words_to_replace()
+
+additional brief:
+    user.edit_abbreviations()
+
+additional phone:
+    user.edit_homophones()


### PR DESCRIPTION
Goal: provide voice commands for supplementing user vocabulary files, e.g. 'additional word' to add a new word.

Inspired by code shared by @pokey some time back.

A secondary goal is to consolidate user vocabulary settings in one place (under the settings folder).

This change makes use of the user's default application mapping to open the .csv files. I tried to avoid security pitfalls common for this sort of use case. It seems to work on windows and (Ubuntu 21.04) linux, have not tested on mac though.

I included code to move to the end of the newly-opened file and start a new line. This code is sensitive to timing variations, however. I'm looking for suggestions on how to do this better...I tried using a 'win_focus' callback, but that fails when the default application already has focus.