### PR TITLE
fix select_line default impls to go to the given line

### DIFF
--- a/code/platforms/linux/edit.py
+++ b/code/platforms/linux/edit.py
@@ -116,6 +116,7 @@ class EditActions:
     def select_all():
         actions.key('ctrl-a')
     def select_line(n: int=None):
+        if n is not None: actions.edit.jump_line(n)
         actions.key('end shift-home')
         #action(edit.select_lines(a: int, b: int)):
     def select_none():

--- a/code/platforms/mac/edit.py
+++ b/code/platforms/mac/edit.py
@@ -116,6 +116,7 @@ class EditActions:
     def select_all():
         actions.key('cmd-a')
     def select_line(n: int=None):
+        if n is not None: actions.edit.jump_line(n)
         actions.key('cmd-right cmd-shift-left')
         #action(edit.select_lines(a: int, b: int)):
     def select_none():

--- a/code/platforms/win/edit.py
+++ b/code/platforms/win/edit.py
@@ -116,6 +116,7 @@ class EditActions:
     def select_all():
         actions.key('ctrl-a')
     def select_line(n: int=None):
+        if n is not None: actions.edit.jump_line(n)
         actions.key('end shift-home')
         #action(edit.select_lines(a: int, b: int)):
     def select_none():


### PR DESCRIPTION
edit.select_line(n) takes an argument saying what line to select, or `None` for current line. Currently the default implementations unconditionally select the current line. This fixes that.