### PR TITLE
Add default TypeScript function declaration

### DIFF
--- a/lang/typescript/typescript.py
+++ b/lang/typescript/typescript.py
@@ -25,9 +25,9 @@ class UserActions:
                 text, settings.get("user.code_private_function_formatter")
             )
         )
-        
+
         actions.user.code_insert_function(result, None)
-        
+
     def code_private_function(text: str):
         """Inserts private function declaration"""
         result = "private function {}".format(

--- a/lang/typescript/typescript.py
+++ b/lang/typescript/typescript.py
@@ -18,6 +18,16 @@ ctx.lists["user.code_type"] = {
 
 @ctx.action_class("user")
 class UserActions:
+    def code_default_function(text: str):
+        """Inserts function declaration"""
+        result = "function {}".format(
+            actions.user.formatted_text(
+                text, settings.get("user.code_private_function_formatter")
+            )
+        )
+        
+        actions.user.code_insert_function(result, None)
+        
     def code_private_function(text: str):
         """Inserts private function declaration"""
         result = "private function {}".format(


### PR DESCRIPTION
Currently it's not possible to create a plain old function declaration in TypeScript: "funky" defaults to a protected function, which only makes sense in the context of a class. This also makes the behavior of "funky" match the JS implementation.

---

"funky hello world"

```ts
// before
protected function helloWorld()

// after
function helloWorld()
```