### PR TITLE
WIP: Add ability to configure Talon alphabet with CSV

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -2,6 +2,7 @@ from typing import Set
 
 from talon import Module, Context, actions, app
 import sys
+from .user_settings import get_list_from_csv
 
 default_alphabet = "air bat cap drum each fine gust harp sit jury crunch look made near odd pit quench red sun trap urge vest whale plex yank zip".split(
     " "
@@ -122,8 +123,12 @@ if app.platform  == "mac":
     modifier_keys["command"] = "cmd"
     modifier_keys["option"] = "alt"
 ctx.lists["self.modifier_key"] = modifier_keys
-alphabet = dict(zip(default_alphabet, letters_string))
-ctx.lists["self.letter"] = alphabet
+_default_alphabet = dict(zip(default_alphabet, letters_string))
+ctx.lists["self.letter"] = get_list_from_csv(
+    "alphabet.csv",
+    headers=("Letter", "Talon Word"),
+    default=_default_alphabet,
+)
 
 # `punctuation_words` is for words you want available BOTH in dictation and as key names in command mode.
 # `symbol_key_words` is for key names that should be available in command mode, but NOT during dictation.


### PR DESCRIPTION
It is seems to be fairly common folks want to provide alternative words for the alphabet, I thought I would take a stab at making the alphabet configurable with a CSV like some other lists.

The benefit of this is that editing CSV is a bit easier to understand for non-tech users and makes managing a fork of this repo a bit easier.