### PR TITLE
Quickly add new vocabulary to additional_words.csv via voice command.

### DIFF
--- a/code/add_vocabulary.py
+++ b/code/add_vocabulary.py
@@ -24,4 +24,4 @@ def add_word_to_additional_words(word: str):
 class Actions:
     def add_custom_vocabulary(word: str):
         """ Adds a word to additional_words.csv"""
-        add_word_to_additional_words(word) 
+        add_word_to_additional_words(word)

--- a/code/add_vocabulary.py
+++ b/code/add_vocabulary.py
@@ -1,0 +1,27 @@
+import csv
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+from talon import resource
+
+from talon import Context, Module, actions
+
+mod = Module()
+
+ctx = Context()
+
+# NOTE: This method requires this module to be one folder below the top-level
+#   knausj folder.
+SETTINGS_DIR = Path(__file__).parents[1] / "settings"
+
+def add_word_to_additional_words(word: str):
+    path = SETTINGS_DIR / "additional_words.csv"
+
+    with resource.open(str(path), "a") as f:
+        f.write(word + "\n") #there is a csv writer in user.settings py, should i be using that instead?
+
+@mod.action_class
+class Actions:
+    def add_custom_vocabulary(word: str):
+        """ Adds a word to additional_words.csv"""
+        add_word_to_additional_words(word) 

--- a/misc/add_vocabulary.talon
+++ b/misc/add_vocabulary.talon
@@ -2,6 +2,6 @@ mode: dictation
 
 -
 
-add that: 
+add that:
     word = edit.selected_text()
     user.add_custom_vocabulary(word)

--- a/misc/add_vocabulary.talon
+++ b/misc/add_vocabulary.talon
@@ -1,0 +1,7 @@
+mode: dictation
+
+-
+
+add that: 
+    word = edit.selected_text()
+    user.add_custom_vocabulary(word)


### PR DESCRIPTION
This is a voice command to quickly add highlighted words to additional_words.csv from dictation mode.  

I don't think this is necessarily the best way to implement this, because 

- I don't check to see if the word is already present in additional_words.csv
- I'm using f.write and string-concatinating a newline in order to add the file.  I saw in user_settings.py there was a csv writer, but I don't know how to use it.   