### PR TITLE
Added commands for adding vocabulary words/phrases

### DIFF
--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -1,7 +1,7 @@
 import csv
 import os
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 from talon import resource
 
 # NOTE: This method requires this module to be one folder below the top-level
@@ -13,13 +13,13 @@ if not SETTINGS_DIR.is_dir():
 
 
 def get_list_from_csv(
-    filename: str, headers: Tuple[str, str], default: Dict[str, str] = {}
+    filename: str, headers: Tuple[str, str], default: Dict[str, str] = {}, write_default=True
 ):
     """Retrieves list from CSV"""
     path = SETTINGS_DIR / filename
     assert filename.endswith(".csv")
 
-    if not path.is_file():
+    if write_default and not path.is_file():
         with open(path, "w", encoding="utf-8", newline="") as file:
             writer = csv.writer(file)
             writer.writerow(headers)
@@ -58,3 +58,19 @@ def get_list_from_csv(
             mapping[spoken_form] = output
 
     return mapping
+
+def append_to_csv(filename: str, rows: Dict[str, str]):
+    path = SETTINGS_DIR / filename
+    assert filename.endswith(".csv")
+
+    with open(str(path), "r") as file:
+        line = None
+        for line in file:
+            pass
+        needs_newline = line is not None and not line.endswith("\n")
+    with open(path, "a", encoding="utf-8", newline="") as file:
+        if needs_newline:
+            file.write("\n")
+        writer = csv.writer(file)
+        for key, value in rows.items():
+            writer.writerow([key] if key == value else [value, key])

--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -69,8 +69,8 @@ def append_to_csv(filename: str, rows: Dict[str, str]):
             pass
         needs_newline = line is not None and not line.endswith("\n")
     with open(path, "a", encoding="utf-8", newline="") as file:
-        if needs_newline:
-            file.write("\n")
         writer = csv.writer(file)
+        if needs_newline:
+            writer.writerow([])
         for key, value in rows.items():
             writer.writerow([key] if key == value else [value, key])

--- a/code/user_settings.py
+++ b/code/user_settings.py
@@ -13,13 +13,13 @@ if not SETTINGS_DIR.is_dir():
 
 
 def get_list_from_csv(
-    filename: str, headers: Tuple[str, str], default: Dict[str, str] = {}, write_default=True
+    filename: str, headers: Tuple[str, str], default: Dict[str, str] = {}
 ):
     """Retrieves list from CSV"""
     path = SETTINGS_DIR / filename
     assert filename.endswith(".csv")
 
-    if write_default and not path.is_file():
+    if not path.is_file():
         with open(path, "w", encoding="utf-8", newline="") as file:
             writer = csv.writer(file)
             writer.writerow(headers)

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -170,8 +170,14 @@ def _create_vocabulary_entries(spoken_form, written_form, type):
     """
     entries = {spoken_form: written_form}
     if type == "name":
+        # Note that we use the spoken form without apostrophe because this seems to generally lead
+        # to better recognition on Conformer b108.
         entries[f"{spoken_form}s"] = f"{written_form}'s"
     elif type == "noun":
+        # Note that we simply append an "s", but we could use something more sophisticated like
+        # https://github.com/jpvanhal/inflection. The downside is that this is less predictable,
+        # and this feature is likely to be used in ways that are unlike common English prose, which
+        # is already included in the lexicon. For example, made up identifiers used in programming.
         entries[f"{spoken_form}s"] = f"{written_form}s"
     return entries
 
@@ -203,7 +209,7 @@ def _add_selection_to_csv(
             added_some_phrases = True
     append_to_csv(csv, new_entries)
     if added_some_phrases:
-        actions.app.notify(f'Added to {csv}')
+        actions.app.notify(f'Added to {csv}: {new_entries}')
 
 @mod.action_class
 class Actions:

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -182,6 +182,7 @@ def _add_selection_to_csv(
     type: str,
     csv: str,
     csv_contents: dict[str, str],
+    skip_identical_replacement: bool,
 ):
     written_form = actions.edit.selected_text().strip()
     if phrase:
@@ -191,15 +192,17 @@ def _add_selection_to_csv(
         spoken_form = " ".join(written_form) if is_acronym else written_form
     entries = _create_vocabulary_entries(spoken_form, written_form, type)
     new_entries = {}
-    added_all_phrases = True
+    added_some_phrases = False
     for spoken_form, written_form in entries.items():
-        if spoken_form in csv_contents:
+        if skip_identical_replacement and spoken_form == written_form:
+            actions.app.notify(f'Skipping identical replacement: "{spoken_form}"')
+        elif spoken_form in csv_contents:
             actions.app.notify(f'Spoken form "{spoken_form}" is already in {csv}')
-            added_all_phrases = False
         else:
             new_entries[spoken_form] = written_form
+            added_some_phrases = True
     append_to_csv(csv, new_entries)
-    if added_all_phrases:
+    if added_some_phrases:
         actions.app.notify(f'Added to {csv}')
 
 @mod.action_class
@@ -213,6 +216,7 @@ class Actions:
             type,
             "additional_words.csv",
             vocabulary,
+            False,
         )
 
     def add_selection_to_words_to_replace(phrase: Phrase, type: str = ""):
@@ -224,4 +228,5 @@ class Actions:
             type,
             "words_to_replace.csv",
             phrases_to_replace,
+            True,
         )

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -188,12 +188,16 @@ def _add_selection_to_csv(
     phrases = get_list_from_csv(csv, headers=headers, write_default=False)
     entries = _create_vocabulary_entries(spoken_form, written_form, type)
     new_entries = {}
+    added_all_phrases = True
     for spoken_form, written_form in entries.items():
         if spoken_form in phrases:
-            logging.info(f'Spoken form "{spoken_form}" is already in {csv}')
+            actions.app.notify(f'Spoken form "{spoken_form}" is already in {csv}')
+            added_all_phrases = False
         else:
             new_entries[spoken_form] = written_form
     append_to_csv(csv, new_entries)
+    if added_all_phrases:
+        actions.app.notify(f'Added to {csv}')
 
 @mod.action_class
 class Actions:

--- a/misc/vocabulary.talon
+++ b/misc/vocabulary.talon
@@ -1,0 +1,9 @@
+mode: command
+mode: dictation
+-
+copy to vocab [as <phrase>]$: user.add_selection_to_vocabulary(phrase or "")
+copy name to vocab [as <phrase>]$: user.add_selection_to_vocabulary(phrase or "", "name")
+copy noun to vocab [as <phrase>]$: user.add_selection_to_vocabulary(phrase or "", "noun")
+copy to replacements as <phrase>$: user.add_selection_to_words_to_replace(phrase)
+copy name to replacements as <phrase>$: user.add_selection_to_words_to_replace(phrase, "name")
+copy noun to replacements as <phrase>$: user.add_selection_to_words_to_replace(phrase, "noun")

--- a/misc/vocabulary.talon
+++ b/misc/vocabulary.talon
@@ -2,8 +2,12 @@ mode: command
 mode: dictation
 -
 copy to vocab [as <phrase>]$: user.add_selection_to_vocabulary(phrase or "")
+# Automatically adds possessive form by appending "'s".
 copy name to vocab [as <phrase>]$: user.add_selection_to_vocabulary(phrase or "", "name")
+# Automatically adds plural form by simply appending "s".
 copy noun to vocab [as <phrase>]$: user.add_selection_to_vocabulary(phrase or "", "noun")
 copy to replacements as <phrase>$: user.add_selection_to_words_to_replace(phrase)
+# Automatically adds possessive form by appending "'s".
 copy name to replacements as <phrase>$: user.add_selection_to_words_to_replace(phrase, "name")
+# Automatically adds plural form by simply appending "s".
 copy noun to replacements as <phrase>$: user.add_selection_to_words_to_replace(phrase, "noun")


### PR DESCRIPTION
Implements Option 1 in #792.

See also https://github.com/wolfmanstout/talon-vocabulary-editor/blob/main/vocabulary.py for a fancier version of this that depends on unstable APIs (for parse_phrase.py). That is intended to override this simpler implementation. There is some duplication of code, unfortunately, but I think that would be hard to avoid without exposing a bunch of functions as actions that don't need to be otherwise (i.e. the CSV functions). Open to feedback, though!