### PR TITLE
add user.open_file action and list/commands for editing settings csvs

### DIFF
--- a/code/abbreviate.py
+++ b/code/abbreviate.py
@@ -5,6 +5,8 @@ from talon import Context, Module
 mod = Module()
 mod.list("abbreviation", desc="Common abbreviation")
 
+# TODO: Make this a csv file. Not necessarily a settings/ csv file, it might be
+# better to be like homophones.csv.
 abbreviations = {
     "address": "addr",
     "administrator": "admin",

--- a/code/edit_text_file.py
+++ b/code/edit_text_file.py
@@ -1,4 +1,3 @@
-# Actions for opening files in appropriate applications.
 import os
 import subprocess
 

--- a/code/open_file.py
+++ b/code/open_file.py
@@ -1,5 +1,6 @@
 # Actions for opening files in appropriate applications.
 import os
+import subprocess
 
 from talon import Context, Module, actions, app, ui
 
@@ -28,8 +29,8 @@ ctx.lists["self.talon_settings_csv"] = _csvs
 
 @mod.action_class
 class ModuleActions:
-    def open_file(path: str, directory: str = None):
-        """Opens a file in the appropriate application for its type. If the path is relative, opens in the given directory (defaults to user's home directory)."""
+    def edit_text_file(path: str, directory: str = None):
+        """Tries to open a file in the user's preferred text editor. If the path is relative, opens in the given directory (defaults to user's home directory)."""
         # if the path is relative, directory is relevant.
         if not os.path.isabs(path):
             directory = directory or actions.path.user_home()
@@ -37,15 +38,54 @@ class ModuleActions:
         if not os.path.exists(path):
             app.notify(f"No file found at {path}")
             raise FileNotFoundError(path)
-        # TODO:
-        # 1. error handling if ui.launch/whatever fails?
-        # 2. should we use ui.launch or subprocess? since open/xdg-open is short-lived.
+
+        # tries to open file using a subprocess
+        def subproc(args):
+            try: return subprocess.run(args, timeout=0.5, check=True)
+            except subprocess.TimeoutExpired:
+                app.notify(f"Timeout trying to open file for editing: {path}")
+                raise
+            except subprocess.CalledProcessError:
+                app.notify(f"Could not open file for editing: {path}")
+                raise
+
         if app.platform == "windows":
-            os.startfile(path, "open")
+            # If there's no applications registered that can open the given type
+            # of file, 'edit' will fail, but 'open' always gives the user a
+            # choice between applications.
+            try: os.startfile(path, "edit")
+            except OSError:
+                os.startfile(path, "open")
         elif app.platform == "mac":
-            ui.launch(path="/usr/bin/open", args=[path])
+            # -t means try to open in a text editor.
+            subproc(["/usr/bin/open", "-t", path])
         elif app.platform == "linux":
-            ui.launch(path="/usr/bin/xdg-open", args=[path])
+            # we use xdg-open for this even though it might not open a text
+            # editor. we could use $EDITOR, but that might be something that
+            # requires a terminal (eg nano, vi).
+            subproc(["/usr/bin/xdg-open", path])
         else:
             raise Exception(f"unknown platform: {app.platform}")
         actions.sleep("500ms")
+
+    # def open_file(path: str, directory: str = None):
+    #     """Opens a file in the appropriate application for its type. If the path is relative, opens in the given directory (defaults to user's home directory)."""
+    #     # if the path is relative, directory is relevant.
+    #     if not os.path.isabs(path):
+    #         directory = directory or actions.path.user_home()
+    #         path = os.path.join(directory, path)
+    #     if not os.path.exists(path):
+    #         app.notify(f"No file found at {path}")
+    #         raise FileNotFoundError(path)
+    #     # TODO:
+    #     # 1. error handling if ui.launch/whatever fails?
+    #     # 2. should we use ui.launch or subprocess? since open/xdg-open is short-lived.
+    #     if app.platform == "windows":
+    #         os.startfile(path, "open")
+    #     elif app.platform == "mac":
+    #         ui.launch(path="/usr/bin/open", args=[path])
+    #     elif app.platform == "linux":
+    #         ui.launch(path="/usr/bin/xdg-open", args=[path])
+    #     else:
+    #         raise Exception(f"unknown platform: {app.platform}")
+    #     actions.sleep("500ms")

--- a/code/open_file.py
+++ b/code/open_file.py
@@ -1,29 +1,35 @@
 # Actions for opening files in appropriate applications.
-from talon import Module, Context, actions, ui, app
 import os
+
+from talon import Context, Module, actions, app, ui
+
 
 # path to knausj root directory
 REPO_DIR = os.path.dirname(os.path.dirname(__file__))
-SETTINGS_DIR = os.path.join(REPO_DIR, 'settings')
+SETTINGS_DIR = os.path.join(REPO_DIR, "settings")
 
 mod = Module()
 ctx = Context()
 
-mod.list('talon_settings_csv', desc="Absolute paths to talon user settings csv files.")
+mod.list("talon_settings_csv", desc="Absolute paths to talon user settings csv files.")
 _csvs = {
     name: os.path.join(SETTINGS_DIR, file_name)
-    for name, file_name in
-    { "file extensions": "file_extensions.csv",
-      "search engines": "search_engines.csv",
-      "system paths": "system_paths.csv",
-      "websites": "websites.csv",
-      "words to replace": "words_to_replace.csv",
-      "additional words": "additional_words.csv" }.items()
+    for name, file_name in {
+        "file extensions": "file_extensions.csv",
+        "search engines": "search_engines.csv",
+        "system paths": "system_paths.csv",
+        "websites": "websites.csv",
+        "words to replace": "words_to_replace.csv",
+        "additional words": "additional_words.csv",
+    }.items()
 }
-_csvs.update({
-    "homophones": os.path.join(REPO_DIR, 'code', 'homophones.csv'),
-})
-ctx.lists['self.talon_settings_csv'] = _csvs
+_csvs.update(
+    {
+        "homophones": os.path.join(REPO_DIR, "code", "homophones.csv"),
+    }
+)
+ctx.lists["self.talon_settings_csv"] = _csvs
+
 
 @mod.action_class
 class ModuleActions:
@@ -40,11 +46,11 @@ class ModuleActions:
         # 1. error handling if ui.launch/whatever fails?
         # 2. should we use ui.launch or subprocess? since open/xdg-open is short-lived.
         if app.platform == "windows":
-            os.startfile(path, 'open')
+            os.startfile(path, "open")
         elif app.platform == "mac":
             ui.launch(path="/usr/bin/open", args=[path])
         elif app.platform == "linux":
-            ui.launch(path='/usr/bin/xdg-open', args=[path])
+            ui.launch(path="/usr/bin/xdg-open", args=[path])
         else:
-            raise Exception(f'unknown platform: {app.platform}')
-        actions.sleep('500ms')
+            raise Exception(f"unknown platform: {app.platform}")
+        actions.sleep("500ms")

--- a/code/open_file.py
+++ b/code/open_file.py
@@ -2,7 +2,7 @@
 import os
 import subprocess
 
-from talon import Context, Module, actions, app, ui
+from talon import Context, Module, app
 
 # path to knausj root directory
 REPO_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -32,10 +32,12 @@ class ModuleActions:
     def edit_text_file(path: str):
         """Tries to open a file in the user's preferred text editor."""
 
+
 winctx, linuxctx, macctx = Context(), Context(), Context()
 winctx.matches = "os: windows"
 linuxctx.matches = "os: linux"
 macctx.matches = "os: mac"
+
 
 @winctx.action_class("self")
 class WinActions:
@@ -43,15 +45,18 @@ class WinActions:
         # If there's no applications registered that can open the given type
         # of file, 'edit' will fail, but 'open' always gives the user a
         # choice between applications.
-        try: os.startfile(path, "edit")
+        try:
+            os.startfile(path, "edit")
         except OSError:
             os.startfile(path, "open")
+
 
 @macctx.action_class("self")
 class MacActions:
     def edit_text_file(path):
         # -t means try to open in a text editor.
         open_with_subprocess(path, ["/usr/bin/open", "-t", path])
+
 
 @linuxctx.action_class("self")
 class LinuxActions:
@@ -61,10 +66,12 @@ class LinuxActions:
         # requires a terminal (eg nano, vi).
         open_with_subprocess(path, ["/usr/bin/xdg-open", path])
 
+
 # Helper for linux and mac.
 def open_with_subprocess(path, args):
     """Tries to open a file using the given subprocess arguments."""
-    try: return subprocess.run(args, timeout=0.5, check=True)
+    try:
+        return subprocess.run(args, timeout=0.5, check=True)
     except subprocess.TimeoutExpired:
         app.notify(f"Timeout trying to open file for editing: {path}")
         raise

--- a/code/open_file.py
+++ b/code/open_file.py
@@ -39,8 +39,7 @@ class ModuleActions:
             app.notify(f"No file found at {path}")
             raise FileNotFoundError(path)
 
-        # tries to open file using a subprocess
-        def subproc(args):
+        def open_with_subprocess(args):
             try: return subprocess.run(args, timeout=0.5, check=True)
             except subprocess.TimeoutExpired:
                 app.notify(f"Timeout trying to open file for editing: {path}")
@@ -58,14 +57,16 @@ class ModuleActions:
                 os.startfile(path, "open")
         elif app.platform == "mac":
             # -t means try to open in a text editor.
-            subproc(["/usr/bin/open", "-t", path])
+            open_with_subprocess(["/usr/bin/open", "-t", path])
         elif app.platform == "linux":
             # we use xdg-open for this even though it might not open a text
             # editor. we could use $EDITOR, but that might be something that
             # requires a terminal (eg nano, vi).
-            subproc(["/usr/bin/xdg-open", path])
+            open_with_subprocess(["/usr/bin/xdg-open", path])
         else:
             raise Exception(f"unknown platform: {app.platform}")
+
+        # Wait for app to open so later actions go to that app.
         actions.sleep("500ms")
 
     # def open_file(path: str, directory: str = None):

--- a/code/open_file.py
+++ b/code/open_file.py
@@ -11,9 +11,14 @@ ctx = Context()
 
 mod.list('talon_settings_csv', desc="Absolute paths to talon user settings csv files.")
 _csvs = {
-    x: os.path.join(SETTINGS_DIR, '_'.join(x.split()) + ".csv")
-    for x in ["file extensions", "search engines", "system paths",
-              "websites", "words to replace", "additional words"]
+    name: os.path.join(SETTINGS_DIR, file_name)
+    for name, file_name in
+    { "file extensions": "file_extensions.csv",
+      "search engines": "search_engines.csv",
+      "system paths": "system_paths.csv",
+      "websites": "websites.csv",
+      "words to replace": "words_to_replace.csv",
+      "additional words": "additional_words.csv" }.items()
 }
 _csvs.update({
     "homophones": os.path.join(REPO_DIR, 'code', 'homophones.csv'),
@@ -31,10 +36,13 @@ class ModuleActions:
         if not os.path.exists(path):
             app.notify(f"No file found at {path}")
             raise FileNotFoundError(path)
+        # TODO:
+        # 1. error handling if ui.launch/whatever fails?
+        # 2. should we use ui.launch or subprocess? since open/xdg-open is short-lived.
         if app.platform == "windows":
             os.startfile(path, 'open')
         elif app.platform == "mac":
-            ui.launch(path="open", args=[path])
+            ui.launch(path="/usr/bin/open", args=[path])
         elif app.platform == "linux":
             ui.launch(path='/usr/bin/xdg-open', args=[path])
         else:

--- a/code/open_file.py
+++ b/code/open_file.py
@@ -3,7 +3,6 @@ import os
 
 from talon import Context, Module, actions, app, ui
 
-
 # path to knausj root directory
 REPO_DIR = os.path.dirname(os.path.dirname(__file__))
 SETTINGS_DIR = os.path.join(REPO_DIR, "settings")
@@ -23,11 +22,7 @@ _csvs = {
         "additional words": "additional_words.csv",
     }.items()
 }
-_csvs.update(
-    {
-        "homophones": os.path.join(REPO_DIR, "code", "homophones.csv"),
-    }
-)
+_csvs["homophones"] = os.path.join(REPO_DIR, "code", "homophones.csv")
 ctx.lists["self.talon_settings_csv"] = _csvs
 
 

--- a/code/open_file.py
+++ b/code/open_file.py
@@ -1,0 +1,42 @@
+# Actions for opening files in appropriate applications.
+from talon import Module, Context, actions, ui, app
+import os
+
+# path to knausj root directory
+REPO_DIR = os.path.dirname(os.path.dirname(__file__))
+SETTINGS_DIR = os.path.join(REPO_DIR, 'settings')
+
+mod = Module()
+ctx = Context()
+
+mod.list('talon_settings_csv', desc="Absolute paths to talon user settings csv files.")
+_csvs = {
+    x: os.path.join(SETTINGS_DIR, '_'.join(x.split()) + ".csv")
+    for x in ["file extensions", "search engines", "system paths",
+              "websites", "words to replace", "additional words"]
+}
+_csvs.update({
+    "homophones": os.path.join(REPO_DIR, 'code', 'homophones.csv'),
+})
+ctx.lists['self.talon_settings_csv'] = _csvs
+
+@mod.action_class
+class ModuleActions:
+    def open_file(path: str, directory: str = None):
+        """Opens a file in the appropriate application for its type. If the path is relative, opens in the given directory (defaults to user's home directory)."""
+        # if the path is relative, directory is relevant.
+        if not os.path.isabs(path):
+            directory = directory or actions.path.user_home()
+            path = os.path.join(directory, path)
+        if not os.path.exists(path):
+            app.notify(f"No file found at {path}")
+            raise FileNotFoundError(path)
+        if app.platform == "windows":
+            os.startfile(path, 'open')
+        elif app.platform == "mac":
+            ui.launch(path="open", args=[path])
+        elif app.platform == "linux":
+            ui.launch(path='/usr/bin/xdg-open', args=[path])
+        else:
+            raise Exception(f'unknown platform: {app.platform}')
+        actions.sleep('500ms')

--- a/misc/edit_settings.talon
+++ b/misc/edit_settings.talon
@@ -1,3 +1,3 @@
-edit {user.talon_settings_csv}:
+customize {user.talon_settings_csv}:
   user.open_file(talon_settings_csv)
   edit.file_end()

--- a/misc/edit_settings.talon
+++ b/misc/edit_settings.talon
@@ -1,3 +1,3 @@
 customize {user.talon_settings_csv}:
-  user.open_file(talon_settings_csv)
+  user.edit_text_file(talon_settings_csv)
   edit.file_end()

--- a/misc/edit_settings.talon
+++ b/misc/edit_settings.talon
@@ -1,0 +1,3 @@
+edit {user.talon_settings_csv}:
+  user.open_file(talon_settings_csv)
+  edit.file_end()

--- a/misc/edit_settings.talon
+++ b/misc/edit_settings.talon
@@ -1,3 +1,4 @@
 customize {user.talon_settings_csv}:
   user.edit_text_file(talon_settings_csv)
+  sleep(500ms)
   edit.file_end()


### PR DESCRIPTION
Changes:

1. Adds a new `user.open_file` action which opens a file in whatever the appropriate application is.

2. Adds a list `user.talon_settings_csv` for paths to talon user settings csv files, e.g. additional_words.csv, search_engines.csv, etc.

3. Adds a command `customize {user.talon_settings_csv)` that opens the corresponding csv and jumps to end of file.

This is heavily based on #810.

Feedback requested:

1. Is `customize` the command prefix we want here? At present this will bind the ccommands:

    ```
    customize search engines
    customize websites
    customize file extensions
    customize system paths
    customize words to replace
    customize additional words
    ```

    Alternatives might be `edit` or `open` (a bit short), `add new`, `edit talon`, `edit {talon_settings_csv} csv`.

2. Is there a better place to put this command than in a new file? Maybe standard.talon?