### PR TITLE
workaround to fix window focus on macOS when using draft editor ("draft submit")

### DIFF
--- a/code/switcher.py
+++ b/code/switcher.py
@@ -277,6 +277,7 @@ class Actions:
     def switcher_focus_window(window: ui.Window):
         """Focus window and wait until switch is made"""
         window.focus()
+        window.app.focus()
         t1 = time.monotonic()
         while ui.active_window() != window:
             if time.monotonic() - t1 > 1:


### PR DESCRIPTION
This fixes an issue on macOS where when using the "draft submit" command the original window cannot be focused for pasting the drafted text into. The target window does get raised in the z-index but does not get focused. This regression may have been caused by a change to Talon (I am on v0.2.0-462-g20b0 (462)) or macOS (I am on 12.3.1). Aegis suggested this solution and it worked.

https://talonvoice.slack.com/archives/C7ENXA7C4/p165188760592726

![Screenshot 2022-05-09T15-23-08 - Slack](https://user-images.githubusercontent.com/92004154/167508371-2b1417af-dbd9-4195-91d3-668f06f16c81.png)

https://user-images.githubusercontent.com/92004154/167508378-203028b5-fd77-4bc3-9c59-5cee2ca53f91.mp4