### PR TITLE
Add action to enable/disable control mouse explicitly

### DIFF
--- a/code/mouse.py
+++ b/code/mouse.py
@@ -130,9 +130,12 @@ class Actions:
         """Start calibration"""
         eye_mouse.calib_start()
 
-    def mouse_toggle_control_mouse():
-        """Toggles control mouse"""
-        toggle_control(not config.control_mouse)
+    def mouse_toggle_control_mouse(enabled: bool = None):
+        """Toggles control mouse. Pass in a bool to enable it, otherwise toggle the current state"""
+        if enabled is not None:
+            toggle_control(enabled)
+        else:
+            toggle_control(not config.control_mouse)
 
     def mouse_toggle_camera_overlay():
         """Toggles camera overlay"""


### PR DESCRIPTION
Updating the behavior of the action to match the original `toggle_control` function, which allows passing a bool to enable or disable the control mouse mode. I want to enable and disable the control mouse mode via hotkeys specified in a talon file. This allows a hot key to have a consistent behavior regardless of whether the mode was initially enabled or disabled. If no bool is passed in, it maintains the current behavior of flipping the current mode.