### PR TITLE
add space between grammar rule words

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -179,23 +179,19 @@ def stdint_signed(m) -> str:
     return m.stdint_signed
 
 
-# NOTE: we purposely we don't have a space after signed, to faciltate stdint
-# style uint8_t constructions
-@mod.capture(rule="[<self.c_signed>]<self.c_types> [<self.c_pointers>+]")
+@mod.capture(rule="[<self.c_signed>] <self.c_types> [<self.c_pointers>+]")
 def c_cast(m) -> str:
     "Returns a string"
     return "(" + " ".join(list(m)) + ")"
 
 
-# NOTE: we purposely we don't have a space after signed, to faciltate stdint
-# style uint8_t constructions
-@mod.capture(rule="[<self.stdint_signed>]<self.stdint_types> [<self.c_pointers>+]")
+@mod.capture(rule="[<self.stdint_signed>] <self.stdint_types> [<self.c_pointers>+]")
 def c_stdint_cast(m) -> str:
     "Returns a string"
     return "(" + "".join(list(m)) + ")"
 
 
-@mod.capture(rule="[<self.c_signed>]<self.c_types>[<self.c_pointers>]")
+@mod.capture(rule="[<self.c_signed>] <self.c_types> [<self.c_pointers>]")
 def c_variable(m) -> str:
     "Returns a string"
     return " ".join(list(m))

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -227,7 +227,7 @@ ctx.lists['user.code_type_modifier'] = {
 }
 
 
-@ctx.capture("user.code_type", rule='[{user.code_type_modifier}]{user.code_type}')
+@ctx.capture("user.code_type", rule='[{user.code_type_modifier}] {user.code_type}')
 def code_type(m) -> str:
     """Returns a macro name"""
     return ''.join(m)


### PR DESCRIPTION
I'm adding a DeprecationWarning to Talon when you don't put a space between distinct words in grammar rules, e.g.

```python
2022-05-10 14:50:04 DEBUG [+] /Users/aegis/.talon/user/knausj_talon/lang/c/c.py
2022-05-10 14:50:04 DEBUG DeprecationWarning: Rule needs a space between tokens:
    [<self.c_signed>]<self.c_types> [<self.c_pointers>+]
                    ^^
2022-05-10 14:50:04 DEBUG DeprecationWarning: Rule needs a space between tokens:
    [<self.stdint_signed>]<self.stdint_types> [<self.c_pointers>+]
                         ^^
2022-05-10 14:50:04 DEBUG DeprecationWarning: Rule needs a space between tokens:
    [<self.c_signed>]<self.c_types>[<self.c_pointers>]
                    ^^            ^^
```

This commit fixes all cases of the warning in upstream knausj_talon. Note that I removed some incorrect comments about the spacing in lang/c in the process. I'll file a new issue for those.