### PR TITLE
formatters.py: put spaces in "all down", "all caps"

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -124,8 +124,8 @@ formatters_dict = {
 
 # This is the mapping from spoken phrases to formatters
 formatters_words = {
-    "allcaps": formatters_dict["ALL_CAPS"],
-    "alldown": formatters_dict["ALL_LOWERCASE"],
+    "all caps": formatters_dict["ALL_CAPS"],
+    "all down": formatters_dict["ALL_LOWERCASE"],
     "camel": formatters_dict["PRIVATE_CAMEL_CASE"],
     "dotted": formatters_dict["DOT_SEPARATED"],
     "dubstring": formatters_dict["DOUBLE_QUOTED_STRING"],

--- a/code/formatters.py
+++ b/code/formatters.py
@@ -128,7 +128,7 @@ formatters_words = {
     "all down": formatters_dict["ALL_LOWERCASE"],
     "camel": formatters_dict["PRIVATE_CAMEL_CASE"],
     "dotted": formatters_dict["DOT_SEPARATED"],
-    "dubstring": formatters_dict["DOUBLE_QUOTED_STRING"],
+    "dub string": formatters_dict["DOUBLE_QUOTED_STRING"],
     "dunder": formatters_dict["DOUBLE_UNDERSCORE"],
     "hammer": formatters_dict["PUBLIC_CAMEL_CASE"],
     "kebab": formatters_dict["DASH_SEPARATED"],


### PR DESCRIPTION
addresses part of #851. doesn't change "all caps" to "all cap" because I'm less convinced that won't screw up recognition for people who are used to "all caps", needs testing. I'm gonna merge this the next time I get around to it if nobody objects, we can always go  "all caps" -> "all cap" later.