### PR TITLE
Add PHP back to code/code.py

### DIFF
--- a/code/code.py
+++ b/code/code.py
@@ -27,6 +27,7 @@ language_extensions = {
     # 'lua': 'lua',
     'markdown': 'md',
     # 'perl': 'pl',
+    'php': 'php',
     # 'powershell': 'ps1',
     'python': 'py',
     'protobuf': 'proto',


### PR DESCRIPTION
For some reason in bcb318c PHP was removed from the languages list even though it has full support, so I'm adding it back in.