### PR TITLE
Add common unix utilities to the generic unix terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,20 @@ tag(): user.tabs
 
 For instance, kubectl commands (kubernetes) aren't relevant to everyone.
 
+### Unix utilities
+
+If you have a Unix (e.g. OSX) or Linux computer, you can enable support for a number of
+common terminal utilities like `cat`, `tail`, or `grep` by uncommenting the following
+line in [unix_shell.py](tags/terminal/unix_shell.py):
+
+```
+# ctx.tags = ["user.unix_utilities"]
+```
+
+Once you have uncommented the line, you can customize your utility commands by editing
+`settings/unix_utilities.csv`. Note: this directory is created when first running Talon
+with knausj_talon enabled.
+
 ## Jetbrains commands
 
 For Jetbrains commands to work you must install https://plugins.jetbrains.com/plugin/10504-voice-code-idea

--- a/tags/terminal/unix_shell.py
+++ b/tags/terminal/unix_shell.py
@@ -6,6 +6,9 @@ ctx.matches = r"""
 tag: user.generic_unix_shell
 """
 
+# Uncomment the following line to enable common unix utilities from unix_utilities.py
+# ctx.tags = ["user.unix_utilities"]
+
 
 @ctx.action_class("user")
 class Actions:

--- a/tags/terminal/unix_utilities.py
+++ b/tags/terminal/unix_utilities.py
@@ -1,0 +1,85 @@
+from talon import Context, Module
+
+from ...core.user_settings import get_list_from_csv
+
+ctx = Context()
+mod = Module()
+
+mod.tag(
+    "unix_utilities", desc="tag for enabling unix utility commands in your terminal"
+)
+
+# Do not edit this dictionary. It is just used to initially populate 'settings/unix_utilities.csv'.
+# Edit that file instead if you want to customize your commands.
+default_unix_utilities = {
+    "ark": "awk",
+    "base sixty four decode": "base64 -d",
+    "base sixty four": "base64",
+    "concat": "cat",
+    "change mode recurse": "chmod -R",
+    "change mode": "chmod",
+    "change owner recurse": "chown -R",
+    "change owner": "chown",
+    "curl": "curl",
+    "cut": "cut",
+    "disk free human": "df -h",
+    "disk free": "df",
+    "dig": "dig",
+    "disk usage human": "du -h",
+    "disk usage": "du",
+    "echo": "echo",
+    "false": "false",
+    "find": "find",
+    "grab here": "grep -Hirn",
+    "grab": "grep",
+    "head": "head",
+    "harp top": "htop",
+    "I D user": "id -u",
+    "I D": "id",
+    "less": "less",
+    "link soft": "ln -s",
+    "link": "ln",
+    "M D five sum": "md5sum",
+    "make dear": "mkdir",
+    "paste": "paste",
+    "print format": "printf",
+    "work dear": "pwd",
+    "reverse": "rev",
+    "are sync": "rsync",
+    "said": "sed",
+    "sequence": "seq",
+    "shah two fifty six sum": "sha256sum",
+    "sleep": "sleep",
+    "sort human": "sort -h",
+    "sort numeric": "sort -n",
+    "sort reverse": "sort -r",
+    "sort unique": "sort -u",
+    "sort": "sort",
+    "S S H": "ssh",
+    "stat": "stat",
+    "pseudo": "sudo",
+    "tail follow": "tail -f",
+    "tail": "tail",
+    "tea append": "tee -a",
+    "tea": "tee",
+    "touch": "touch",
+    "translate delete": "tr -d",
+    "translate": "tr",
+    "true": "true",
+    "unique count": "uniq -c",
+    "unique": "uniq",
+    "word count characters": "wc -c",
+    "word count lines": "wc -l",
+    "word count": "wc",
+    "who": "who",
+    "who am I": "whoami",
+}
+
+unix_utilities = get_list_from_csv(
+    "unix_utilities.csv",
+    headers=("command", "spoken"),
+    default=default_unix_utilities,
+)
+
+mod.list("unix_utility", desc="A common utility command")
+ctx.lists["self.unix_utility"] = unix_utilities

--- a/tags/terminal/unix_utilities.talon
+++ b/tags/terminal/unix_utilities.talon
@@ -1,0 +1,3 @@
+tag: user.unix_utilities
+-
+core {user.unix_utility}: "{unix_utility} "


### PR DESCRIPTION
In my daily work, I use a lot of common utilities in my terminals. I extended the `generic_unix_terminal` tag in order to make it easy to run common commands and assemble pipes.

Some of the utilities are quite short and could be replaced by spelling their names out (e.g. `df`) or dictating the word (e.g. `touch`, `true`). I opted to include those cases since I found the flow to be better this way. I assume the accuracy also benefits for words with close pronounciation, like `false`/`falls`.

For several commands, I also added flags which I commonly use. It might be argued that adding those flags introduces unnecessary clutter. Including them was down to personal preference, again. It might make sense to remove them from the `default_unix_utilities.csv` file. The inclusion of flags in the default list might also lead to clashes if the local user has a version of these utilities with differing flags. For example, I found that sometimes the utilities in OSX differ from the ones in my Linux distribution. What do you think?

Some further points about which I'm not quite sure are:
- the lack of integration with the existing terminal commands from `generic_terminal.py`.
- the pronunciation of the some of the spellings. I'm not a native speaker, so some of them might be idiosyncratic. Since I use conformer myself, I also don't know how well they would work with Dragon. I tried to use existing words, as I heard that dragon needs those.

I'm looking for advice on these topics :)

