### PR TITLE
Fix unformat text for snake case

### DIFF
--- a/code/formatters.py
+++ b/code/formatters.py
@@ -277,7 +277,7 @@ class Actions:
 
 def unformat_text(text: str) -> str:
     """Remove format from text"""
-    unformatted = re.sub(r"[^\w]+", " ", text)
+    unformatted = re.sub(r"[\W_]+", " ", text)
     # Split on camelCase, including numbers
     # FIXME: handle non-ASCII letters!
     unformatted = re.sub(


### PR DESCRIPTION
Currently, we can't unformat snake case.  For example, selecting `hello_world` and saying "camel that" won't do anything

Thanks to @AndreasArvidsson for the pairing session to fix