### PR TITLE
Add support for programming language keywords

### DIFF
--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -44,6 +44,32 @@ ctx.lists["user.code_common_member_function"] = {
     "then": "then",
 }
 
+ctx.lists["user.code_keyword"] = {
+    "a sink": "async ",
+    "await": "await ",
+    "break": "break",
+    "class": "class ",
+    "const": "const ",
+    "continue": "continue",
+    "default": "default ",
+    "export": "export ",
+    "false": "false",
+    "function": "function ",
+    "import": "import ",
+    "let": "let ",
+    "new": "new ",
+    "null": "null",
+    "private": "private ",
+    "protected": "protected ",
+    "public": "public ",
+    "return": "return ",
+    "throw": "throw ",
+    "true": "true",
+    "try": "try ",
+    "undefined": "undefined",
+    "yield": "yield ",
+}
+
 
 @ctx.action_class("user")
 class UserActions:

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -9,6 +9,7 @@ tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
 tag(): user.code_functions_common
+tag(): user.code_keywords
 tag(): user.code_libraries
 tag(): user.code_operators_array
 tag(): user.code_operators_assignment

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -59,6 +59,20 @@ ctx.lists["user.code_type"] = {
     "no return": "NoReturn",
 }
 
+ctx.lists["user.code_keyword"] = {
+    "break": "break",
+    "continue": "continue",
+    "class": "class ",
+    "return": "return ",
+    "import": "import ",
+    "null": "None",
+    "none": "None",
+    "true": "True",
+    "false": "False",
+    "yield": "yield ",
+    "from": "from ",
+}
+
 exception_list = [
     "BaseException",
     "SystemExit",

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -9,6 +9,7 @@ tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
 tag(): user.code_functions_common
+tag(): user.code_keywords
 tag(): user.code_libraries
 tag(): user.code_libraries_gui
 tag(): user.code_operators_array

--- a/lang/tags/keywords.py
+++ b/lang/tags/keywords.py
@@ -1,0 +1,20 @@
+from talon import Module, actions
+
+mod = Module()
+
+mod.tag("code_keywords", desc="Tag for enabling commands for keywords")
+
+mod.list("code_keyword", desc="List of keywords for active language")
+
+
+@mod.capture(rule=("{user.code_keyword}"))
+def code_keyword(m) -> str:
+    return str(m)
+
+
+@mod.action_class
+class Actions:
+    def code_keyword(keywords: list[str]):
+        """Adds keywords"""
+        for keyword in keywords:
+            actions.insert(keyword)

--- a/lang/tags/keywords.talon
+++ b/lang/tags/keywords.talon
@@ -1,0 +1,3 @@
+tag: user.code_keywords
+-
+keyword (<user.code_keyword>+): user.code_keyword(code_keyword_list)


### PR DESCRIPTION
Fixes #807

Adds support for keywords, such as "return", "export", etc.  Note that these differ from the usual "state" commands (eg "state if"), because they insert only the keyword, rather than building the statement, which would include adding parentheses, etc

They can be chained, so you can say eg "keyword return false"

Note that there is definitely some overlap with many of the "state" commands; might be worth thinking whether that is a problem

We may want to consider removing a few of the JS "state" commands that are just keywords https://github.com/knausj85/knausj_talon/blob/796bb9ec84e7e897f1fde141ee664b944e303a1e/lang/javascript/javascript.talon#L31-L41