### PR TITLE
Force navigation to i3wm numbered workspace by number, not name

### DIFF
--- a/apps/i3wm/i3wm.talon
+++ b/apps/i3wm/i3wm.talon
@@ -2,8 +2,8 @@
 os: linux
 tag: user.i3wm
 -
-port <number_small>: user.system_command("i3-msg workspace {number_small}")
-port ten: user.system_command("i3-msg workspace 10")
+port <number_small>: user.system_command("i3-msg workspace number {number_small}")
+port ten: user.system_command("i3-msg workspace number 10")
 (port flip|flipper): user.system_command("i3-msg workspace back_and_forth")
 port right: user.system_command("i3-msg workspace next")
 port left: user.system_command("i3-msg workspace prev")

--- a/apps/i3wm/i3wm.talon
+++ b/apps/i3wm/i3wm.talon
@@ -61,8 +61,8 @@ vertical (shell|terminal):
 
 # XXX - just replace with shuffle eventually?
 # XXX - like also need to match the generic talon commands
-(shuffle|move (win|window) [to] port) <number_small>:  user.system_command("i3-msg move container to workspace {number_small}")
-(shuffle|move (win|window) [to] port ten): user.system_command("i3-msg move container to workspace 10")
+(shuffle|move (win|window) [to] port) <number_small>:  user.system_command("i3-msg move container to workspace number {number_small}")
+(shuffle|move (win|window) [to] port ten): user.system_command("i3-msg move container to workspace number 10")
 (shuffle|move (win|window) [to] last port): user.system_command("i3-msg move container to workspace back_and_forth")
 (shuffle|move (win|window) left): user.system_command("i3-msg move left")
 (shuffle|move (win|window) right): user.system_command("i3-msg move right")


### PR DESCRIPTION
When using `i3-msg workspace $NUM` we will create the workspace if it
does not exist.

If we have a numbered workspace, with a custom name as per the
documentation:
https://i3wm.org/docs/userguide.html#_named_workspaces

Then we will create a _new_ workspace with a name of `$NUM` and number
`$NUM`

See these commands:
```
> i3-msg -t get_workspaces | jq ".[] | select(.num == 1)"
{
  "id": 94184672696560,
  "num": 1,
  "name": "1: 1 - work",
  "visible": true,
  "focused": true,
  "rect": {
    "x": 1920,
    "y": 24,
    "width": 3840,
    "height": 2136
  },
  "output": "DP-1-4",
  "urgent": false
}
```
then run the command as it _was_ for the utility
```
> i3-msg workspace 1
[{"success":true}]
```
and compare the output again
```
> i3-msg -t get_workspaces | jq ".[] | select(.num == 1)"
Start 15:19:11
{
  "id": 94184671153056,
  "num": 1,
  "name": "1",
  "visible": true,
  "focused": true,
  "rect": {
    "x": 1920,
    "y": 24,
    "width": 3840,
    "height": 2136
  },
  "output": "DP-1-4",
  "urgent": false
}
{
  "id": 94184672696560,
  "num": 1,
  "name": "1: 1 - work",
  "visible": false,
  "focused": false,
  "rect": {
    "x": 1920,
    "y": 24,
    "width": 3840,
    "height": 2136
  },
  "output": "DP-1-4",
  "urgent": false
}
```

If we use the command `i3-msg workspace number $NUM`, this does not
happen, as we are then navigating to the workspace numbered `$NUM`, not
named `$NUM`