### PR TITLE
Add equivalent cursorless commands as options for the draft_window

### DIFF
--- a/talon_draft_window/draft_window.talon
+++ b/talon_draft_window/draft_window.talon
@@ -6,37 +6,34 @@ settings():
   user.context_sensitive_dictation = 1
 
 # Replace a single word with a phrase
-replace <user.draft_anchor> with <user.text>:
+[change | replace] <user.draft_anchor> [with] <user.text>:
   user.draft_select("{draft_anchor}")
   result = user.formatted_text(text, "NOOP")
   insert(result)
 
 # Position cursor before word
-cursor <user.draft_anchor>:
-  user.draft_position_caret("{draft_anchor}")
-
-cursor before <user.draft_anchor>:
+[pre | cursor | cursor before] <user.draft_anchor>:
   user.draft_position_caret("{draft_anchor}")
 
 # Position cursor after word
-cursor after <user.draft_anchor>:
+[post | cursor after] <user.draft_anchor>:
   user.draft_position_caret("{draft_anchor}", 1)
 
 # Select a whole word
-select <user.draft_anchor>:
+[take | select] <user.draft_anchor>:
   user.draft_select("{draft_anchor}")
 
 # Select a range of words
-select <user.draft_anchor> through <user.draft_anchor>:
+[take | select] <user.draft_anchor> [through | past] <user.draft_anchor>:
   user.draft_select("{draft_anchor_1}", "{draft_anchor_2}")
 
 # Delete a word
-clear <user.draft_anchor>:
+[chuck |clear] <user.draft_anchor>:
   user.draft_select("{draft_anchor}", "", 1)
   key(backspace)
 
 # Delete a range of words
-clear <user.draft_anchor> through <user.draft_anchor>:
+[chuck |clear] <user.draft_anchor> [through | past] <user.draft_anchor>:
   user.draft_select(draft_anchor_1, draft_anchor_2, 1)
   key(backspace)
 
@@ -46,6 +43,6 @@ clear <user.draft_anchor> through <user.draft_anchor>:
   user.formatters_reformat_selection(user.formatters)
 
 # reformat range
-<user.formatters> <user.draft_anchor> through <user.draft_anchor>:
+<user.formatters> <user.draft_anchor> [through | past] <user.draft_anchor>:
     user.draft_select(draft_anchor_1, draft_anchor_2, 1)
     user.formatters_reformat_selection(user.formatters)


### PR DESCRIPTION
For anyone familiar with cursorless these may be baked into their memory. I learned cursorless before I used the draft window and saw the commands could be fairly easily expanded to allow for the cursorless style phrasing. Obviously this is only snapshot in time and cursorless could evolve in future but perhaps this small selection will always be compatible.

Interested to know if folks think this is an appropriate addition or not.

I can also make a small addition to the draft_window README mentioning cursorless compatibility if this is desired.