### PR TITLE
Support Discord and Slack in browser

### DIFF
--- a/apps/discord/discord.py
+++ b/apps/discord/discord.py
@@ -4,6 +4,10 @@ mod = Module()
 apps = mod.apps
 apps.discord = "app.name: Discord"
 apps.discord = "app.name: Discord.exe"
+apps.discord = """
+tag: browser
+browser.host: discord.com
+"""
 
 
 @mod.action_class

--- a/apps/slack/slack.py
+++ b/apps/slack/slack.py
@@ -14,6 +14,10 @@ apps.slack = """
 os: mac
 and app.bundle: com.tinyspeck.slackmacgap
 """
+apps.slack = """
+tag: browser
+browser.host: app.slack.com
+"""
 ctx.matches = r"""
 app: slack
 """


### PR DESCRIPTION
This adds support for the Discord and Slack webapps.

Some of the keyboard shortcuts conflict with browser shortcuts, but this may vary from browser to browser, so I figured leaving them as is for now is probably fine, e.g. <kbd>cmd-k</kbd> to open the Slack channel picker on macOS conflicts with Firefox's focus search bar shortcut.