### PR TITLE
Remove direct noting of port 10

### DIFF
--- a/apps/i3wm/i3wm.talon
+++ b/apps/i3wm/i3wm.talon
@@ -3,7 +3,6 @@ os: linux
 tag: user.i3wm
 -
 port <number_small>: user.system_command("i3-msg workspace {number_small}")
-port ten: user.system_command("i3-msg workspace 10")
 (port flip|flipper): user.system_command("i3-msg workspace back_and_forth")
 port right: user.system_command("i3-msg workspace next")
 port left: user.system_command("i3-msg workspace prev")
@@ -62,7 +61,6 @@ vertical (shell|terminal):
 # XXX - just replace with shuffle eventually?
 # XXX - like also need to match the generic talon commands
 (shuffle|move (win|window) [to] port) <number_small>:  user.system_command("i3-msg move container to workspace {number_small}")
-(shuffle|move (win|window) [to] port ten): user.system_command("i3-msg move container to workspace 10")
 (shuffle|move (win|window) [to] last port): user.system_command("i3-msg move container to workspace back_and_forth")
 (shuffle|move (win|window) left): user.system_command("i3-msg move left")
 (shuffle|move (win|window) right): user.system_command("i3-msg move right")


### PR DESCRIPTION
We use `number_small` as the capture for all port commands, which includes 10.

Comment at https://github.com/knausj85/knausj_talon/pull/871#discussion_r889588800
suggests it was initially included for debugging and is no longer required.