### PR TITLE
Flexible funky modifiers

### DIFF
--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -26,11 +26,6 @@ settings():
     # whether or not to use uint_8 style datatypes
     #    user.use_stdint_datatypes = 1
 
-
-
-^funky <user.text>$: user.code_default_function(text)
-^static funky <user.text>$: user.code_private_static_function(text)
-
 # NOTE: migrated from generic, as they were only used here, though once cpp support is added, perhaps these should be migrated to a tag together with the commands below
 state include:
     insert('#include ')

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -248,6 +248,16 @@ class UserActions:
         actions.user.paste(text)
         actions.edit.left()
 
+    def code_default_function(text: str):
+        """Inserts function declaration without modifiers"""
+        result = "function {}".format(
+            actions.user.formatted_text(
+                text, settings.get("user.code_private_function_formatter")
+            )
+        )
+
+        actions.user.code_insert_function(result, None)
+
     def code_private_function(text: str):
         """Inserts private function declaration"""
         result = "function {}".format(

--- a/lang/tags/functions.py
+++ b/lang/tags/functions.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union
 
 from talon import Context, Module, actions, settings
 
@@ -41,7 +41,7 @@ setting_public_variable_formatter = mod.setting("code_public_variable_formatter"
 
 @mod.action_class
 class Actions:
-    def code_modified_function(modifiers: Union[List[str], int], text: str):
+    def code_modified_function(modifiers: Union[list[str], int], text: str):
         """
         Inserts function declaration with the given modifiers. modifiers == 0
         implies no modifiers (.talon files don't have empty list literal

--- a/lang/tags/functions.py
+++ b/lang/tags/functions.py
@@ -1,6 +1,5 @@
 from talon import Context, Module, actions, settings
 
-
 ctx = Context()
 mod = Module()
 
@@ -14,7 +13,7 @@ mod.list(
 )
 mod.list(
     "code_function_modifiers",
-    desc="List of function modifiers (e.g. private, async, static)"
+    desc="List of function modifiers (e.g. private, async, static)",
 )
 
 ctx.lists["user.code_function_modifiers"] = ["pub", "pro", "private", "static"]
@@ -50,21 +49,21 @@ class Actions:
         """Inserts function declaration with the given modifiers"""
         mods = set(modifiers.split(" "))
 
-        if mods == set([""]):
+        if mods == {""}:
             return actions.user.code_default_function(text)
-        elif mods == set(["static"]):
+        elif mods == {"static"}:
             return actions.user.code_private_static_function(text)
-        elif mods == set(["private"]):
+        elif mods == {"private"}:
             return actions.user.code_private_function(text)
-        elif mods == set(["private", "static"]):
+        elif mods == {"private", "static"}:
             return actions.user.code_private_static_function(text)
-        elif mods == set(["pro"]):
+        elif mods == {"pro"}:
             return actions.user.code_protected_function(text)
-        elif mods == set(["pro", "static"]):
+        elif mods == {"pro", "static"}:
             return actions.user.code_protected_static_function(text)
-        elif mods == set(["pub"]):
+        elif mods == {"pub"}:
             return actions.user.code_public_function(text)
-        elif mods == set(["pub", "static"]):
+        elif mods == {"pub", "static"}:
             return actions.user.code_public_static_function(text)
         else:
             raise RuntimeError(f"Unhandled modifier set: {modifiers}")

--- a/lang/tags/functions.py
+++ b/lang/tags/functions.py
@@ -18,7 +18,12 @@ mod.list(
     desc="List of function modifiers (e.g. private, async, static)",
 )
 
-ctx.lists["user.code_function_modifier"] = ["pub", "pro", "private", "static"]
+ctx.lists["user.code_function_modifier"] = {
+    "pub": "public",
+    "pro": "protected",
+    "private": "private",
+    "static": "static",
+}
 
 
 @mod.capture(rule="{user.code_type}")
@@ -57,13 +62,13 @@ class Actions:
             return actions.user.code_private_function(text)
         elif mods == {"private", "static"}:
             return actions.user.code_private_static_function(text)
-        elif mods == {"pro"}:
+        elif mods == {"protected"}:
             return actions.user.code_protected_function(text)
-        elif mods == {"pro", "static"}:
+        elif mods == {"protected", "static"}:
             return actions.user.code_protected_static_function(text)
-        elif mods == {"pub"}:
+        elif mods == {"public"}:
             return actions.user.code_public_function(text)
-        elif mods == {"pub", "static"}:
+        elif mods == {"public", "static"}:
             return actions.user.code_public_static_function(text)
         else:
             raise RuntimeError(f"Unhandled modifier set: {mods}")

--- a/lang/tags/functions.talon
+++ b/lang/tags/functions.talon
@@ -15,10 +15,8 @@ tag: user.code_functions
 #   * pro static funky -> code_protected_static_function
 #   * pub static funky -> code_public_static_function
 #
-^funky <user.text>$:
-  user.code_modified_function("", text)
-^<user.code_function_modifiers> funky <user.text>$:
-  user.code_modified_function(code_function_modifiers, text)
+^{user.code_function_modifier}* funky <user.text>$:
+  user.code_modified_function(code_function_modifier_list or 0, text)
 
 # for annotating function parameters
 is type <user.code_type>: user.code_insert_type_annotation(code_type)

--- a/lang/tags/functions.talon
+++ b/lang/tags/functions.talon
@@ -1,11 +1,24 @@
 tag: user.code_functions
 -
-^funky <user.text>$: user.code_default_function(text)
-^pro funky <user.text>$: user.code_protected_function(text)
-^pub funky <user.text>$: user.code_public_function(text)
-^static funky <user.text>$: user.code_private_static_function(text)
-^pro static funky <user.text>$: user.code_protected_static_function(text)
-^pub static funky <user.text>$: user.code_public_static_function(text)
+# Default implementation of capture listens for the following keywords in any
+# order: private pro pub static
+#
+# The default action implementation looks for the token combination on the left
+# (funky is added here for searchability) and calls the function on the right:
+#
+#   * funky -> code_default_function
+#   * private funky -> code_private_function
+#   * pro funky -> code_protected_function
+#   * pub funky -> code_public_function
+#   * static funky -> code_private_static_function
+#   * private static funky -> code_private_static_function
+#   * pro static funky -> code_protected_static_function
+#   * pub static funky -> code_public_static_function
+#
+^funky <user.text>$:
+  user.code_modified_function("", text)
+^<user.code_function_modifiers> funky <user.text>$:
+  user.code_modified_function(code_function_modifiers, text)
 
 # for annotating function parameters
 is type <user.code_type>: user.code_insert_type_annotation(code_type)

--- a/lang/typescript/typescript.py
+++ b/lang/typescript/typescript.py
@@ -18,6 +18,16 @@ ctx.lists["user.code_type"] = {
 
 @ctx.action_class("user")
 class UserActions:
+    def code_default_function(text: str):
+        """Inserts function declaration without modifiers"""
+        result = "function {}".format(
+            actions.user.formatted_text(
+                text, settings.get("user.code_private_function_formatter")
+            )
+        )
+
+        actions.user.code_insert_function(result, None)
+
     def code_private_function(text: str):
         """Inserts private function declaration"""
         result = "private function {}".format(
@@ -28,16 +38,6 @@ class UserActions:
 
         actions.user.code_insert_function(result, None)
 
-    # def code_private_static_function(text: str):
-    #     """Inserts private static function"""
-    #     result = "private static void {}".format(
-    #         actions.user.formatted_text(
-    #             text, settings.get("user.code_private_function_formatter")
-    #         )
-    #     )
-
-    #     actions.user.code_insert_function(result, None)
-
     def code_protected_function(text: str):
         result = "protected function {}".format(
             actions.user.formatted_text(
@@ -47,15 +47,6 @@ class UserActions:
 
         actions.user.code_insert_function(result, None)
 
-    # def code_protected_static_function(text: str):
-    #     result = "protected static void {}".format(
-    #         actions.user.formatted_text(
-    #             text, settings.get("user.code_protected_function_formatter")
-    #         )
-    #     )
-
-    #     actions.user.code_insert_function(result, None)
-
     def code_public_function(text: str):
         result = "public function {}".format(
             actions.user.formatted_text(
@@ -64,15 +55,6 @@ class UserActions:
         )
 
         actions.user.code_insert_function(result, None)
-
-    # def code_public_static_function(text: str):
-    #     result = "public static void {}".format(
-    #         actions.user.formatted_text(
-    #             text, settings.get("user.code_public_function_formatter")
-    #         )
-    #     )
-
-    #     actions.user.code_insert_function(result, None)
 
     def code_insert_type_annotation(type: str):
         actions.insert(f": {type}")

--- a/lang/typescript/typescript.py
+++ b/lang/typescript/typescript.py
@@ -18,16 +18,6 @@ ctx.lists["user.code_type"] = {
 
 @ctx.action_class("user")
 class UserActions:
-    def code_default_function(text: str):
-        """Inserts function declaration without modifiers"""
-        result = "function {}".format(
-            actions.user.formatted_text(
-                text, settings.get("user.code_private_function_formatter")
-            )
-        )
-
-        actions.user.code_insert_function(result, None)
-
     def code_private_function(text: str):
         """Inserts private function declaration"""
         result = "private function {}".format(

--- a/tests/stubs/talon/__init__.py
+++ b/tests/stubs/talon/__init__.py
@@ -1,6 +1,5 @@
-from typing import Callable
-
 import inspect
+from typing import Callable
 
 
 class RegisteredActionsAccessor:

--- a/tests/stubs/talon/__init__.py
+++ b/tests/stubs/talon/__init__.py
@@ -17,6 +17,8 @@ class RegisteredActionsAccessor:
         raise AttributeError(f"Couldn't find action {self.namespace}.{name}")
 
     def __call__(self, *args, **kwargs):
+        # Provide a useful error message if people try something like
+        # actions.my_action() when they should do actions.user.my_action()
         raise RuntimeError(f"actions.{self.namespace}() is not an available action")
 
 
@@ -30,7 +32,6 @@ class Actions:
         self.registered_actions = {
             "module": {},
             "test": {},
-            # "contexts": []
         }
 
         # Some built in actions

--- a/tests/test_code_modified_function.py
+++ b/tests/test_code_modified_function.py
@@ -1,12 +1,10 @@
 import talon
 
-
 if hasattr(talon, "test_mode"):
     from unittest.mock import MagicMock
-    from talon import actions
 
     # Load our code under test (register code_* actions)
-    import knausj_talon_pkg.lang.tags.functions
+    from talon import actions
 
     def setup_function():
         actions.reset_test_actions()

--- a/tests/test_code_modified_function.py
+++ b/tests/test_code_modified_function.py
@@ -22,10 +22,10 @@ if hasattr(talon, "test_mode"):
             (["static"], "code_private_static_function"),
             (["private"], "code_private_function"),
             (["private", "static"], "code_private_static_function"),
-            (["pro"], "code_protected_function"),
-            (["pro", "static"], "code_protected_static_function"),
-            (["pub"], "code_public_function"),
-            (["pub", "static"], "code_public_static_function"),
+            (["protected"], "code_protected_function"),
+            (["protected", "static"], "code_protected_static_function"),
+            (["public"], "code_public_function"),
+            (["public", "static"], "code_public_static_function"),
         ]
         for modifiers, target_action in examples:
             mock = MagicMock()

--- a/tests/test_code_modified_function.py
+++ b/tests/test_code_modified_function.py
@@ -1,0 +1,36 @@
+import talon
+
+
+if hasattr(talon, "test_mode"):
+    from unittest.mock import MagicMock
+    from talon import actions
+
+    # Load our code under test (register code_* actions)
+    import knausj_talon_pkg.lang.tags.functions
+
+    def setup_function():
+        actions.reset_test_actions()
+
+    def test_calls_expected_function():
+        """
+        Test that the given combination of modifiers ends up delegating to the
+        correct function
+        """
+
+        examples = [
+            ("", "code_default_function"),
+            ("static", "code_private_static_function"),
+            ("private", "code_private_function"),
+            ("private static", "code_private_static_function"),
+            ("pro", "code_protected_function"),
+            ("pro static", "code_protected_static_function"),
+            ("pub", "code_public_function"),
+            ("pub static", "code_public_static_function"),
+        ]
+        for modifiers, target_action in examples:
+            mock = MagicMock()
+            actions.register_test_action("user", target_action, mock)
+
+            talon.actions.user.code_modified_function(modifiers, "test func")
+
+            mock.assert_called_once()

--- a/tests/test_code_modified_function.py
+++ b/tests/test_code_modified_function.py
@@ -3,8 +3,10 @@ import talon
 if hasattr(talon, "test_mode"):
     from unittest.mock import MagicMock
 
-    # Load our code under test (register code_* actions)
     from talon import actions
+
+    # Load our code under test (register code_* actions)
+    import knausj_talon_pkg.lang.tags.functions  # isort:skip
 
     def setup_function():
         actions.reset_test_actions()
@@ -16,14 +18,14 @@ if hasattr(talon, "test_mode"):
         """
 
         examples = [
-            ("", "code_default_function"),
-            ("static", "code_private_static_function"),
-            ("private", "code_private_function"),
-            ("private static", "code_private_static_function"),
-            ("pro", "code_protected_function"),
-            ("pro static", "code_protected_static_function"),
-            ("pub", "code_public_function"),
-            ("pub static", "code_public_static_function"),
+            (0, "code_default_function"),
+            (["static"], "code_private_static_function"),
+            (["private"], "code_private_function"),
+            (["private", "static"], "code_private_static_function"),
+            (["pro"], "code_protected_function"),
+            (["pro", "static"], "code_protected_static_function"),
+            (["pub"], "code_public_function"),
+            (["pub", "static"], "code_public_static_function"),
         ]
         for modifiers, target_action in examples:
             mock = MagicMock()

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -7,8 +7,8 @@ if hasattr(talon, "test_mode"):
     from talon import actions
 
     def setup_function():
-        actions.reset_actions()
-        actions.register_test_action("user.add_phrase_to_history", lambda x: None)
+        actions.reset_test_actions()
+        actions.register_test_action("user", "add_phrase_to_history", lambda x: None)
 
     def test_snake_case():
         result = formatters.Actions.formatted_text("hello world", "SNAKE_CASE")


### PR DESCRIPTION
Adds the following:
* Allow flexible combination of function modifiers (static, public etc.) in funky command. Allows for easier addition of 'non standard' modifiers (e.g. async in javascript), and suppression of irrelevant ones (e.g. static in javascript).
* Adds the 'private' modifier and makes the unadorned 'funky' in Typescript emit an unmodified function.
* Updates the test stubs so that the @mod.action_class decorator registers actions in a similar way to Talon.

Addresses #825 and replaces #824 .