### PR TITLE
batch, java: remove references to obsolete tags

### DIFF
--- a/lang/batch/batch.py
+++ b/lang/batch/batch.py
@@ -8,6 +8,5 @@ tag: user.batch
 
 @ctx.action_class("user")
 class UserActions:
-    # tag(): user.code_generic
     def code_comment_line_prefix():
         actions.auto_insert("REM ")

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -5,7 +5,6 @@ mod = Module()
 ctx.matches = r"""
 tag: user.java
 """
-ctx.tags = ["user.code_operators", "user.code_generic"]
 
 # Primitive Types
 java_primitive_types = {


### PR DESCRIPTION
These tags aren't defined anymore; let's remove them to reduce confusion.

There was a little bit of discussion about this on https://github.com/knausj85/knausj_talon/pull/743, although they still made it in.