### PR TITLE
Add <number_small> to wheel commands

### DIFF
--- a/misc/mouse.talon
+++ b/misc/mouse.talon
@@ -61,6 +61,7 @@ right drag | righty drag:
 end drag | drag end:
     user.mouse_drag_end()
 wheel down: user.mouse_scroll_down()
+wheel down <number_small>: user.mouse_scroll_down(number_small)
 wheel down here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down()
@@ -73,6 +74,7 @@ wheel downer here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down_continuous()
 wheel up: user.mouse_scroll_up()
+wheel up <number_small>: user.mouse_scroll_up(number_small)
 wheel up here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_up()
@@ -93,6 +95,7 @@ wheel stop here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_stop()
 wheel left: user.mouse_scroll_left()
+wheel left <number_small>: user.mouse_scroll_left(number_small)
 wheel left here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_left()
@@ -101,6 +104,7 @@ wheel tiny left here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_left(0.5)
 wheel right: user.mouse_scroll_right()
+wheel right <number_small>: user.mouse_scroll_right(number_small)
 wheel right here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_right()


### PR DESCRIPTION
Adds fine grained control to directional scroll wheel commands. Allows user to keep the default scroll value settings the same.

No need to change these settings:
```
# The amount to scroll up/down (equivalent to mouse wheel on Windows by default)
    user.mouse_wheel_down_amount = 120

# The amount to scroll left/right
    user.mouse_wheel_horizontal_amount = 40
```

### example usage:
🔈 wheel up 🔈=> scroll up by `setting_mouse_wheel_down_amount.get()`
🔈 wheel up seven 🔈=> scroll up by `setting_mouse_wheel_down_amount.get() * 7`
🔈 wheel down 🔈=> scroll down by `setting_mouse_wheel_down_amount.get()`
🔈 wheel down three 🔈=> scroll down by `setting_mouse_wheel_down_amount.get() * 3`
🔈 wheel right 🔈=> scroll right by `setting_mouse_wheel_horizontal_amount.get()`
🔈 wheel right four 🔈=> scroll right by `setting_mouse_wheel_horizontal_amount.get() * 4`
🔈 wheel left 🔈=> scroll left by `setting_mouse_wheel_horizontal_amount.get()`
🔈 wheel left nine 🔈=> scroll left by `setting_mouse_wheel_horizontal_amount.get() * 9`