### PR TITLE
ci: Fix after main branch migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
This fixes the GitHub Actions CI workflow to run after the `master` branch was renamed to `main`.