### PR TITLE
Add vscode settings comment for text navigation

### DIFF
--- a/text/text_navigation.talon
+++ b/text/text_navigation.talon
@@ -1,4 +1,5 @@
 ## (2021-03-09) This syntax is experimental and may change. See below for an explanation.
+## If you are having issues with this module not working in vscode try adding the vscode setting "editor.emptySelectionClipboard": false
 navigate [{user.arrow_key}] [{user.navigation_action}] [{user.navigation_target_name}] [{user.before_or_after}] [<user.ordinals>] <user.navigation_target>:
 ## If you use this command a lot, you may wish to have a shorter syntax that omits the navigate keyword. Note that you then at least have to say either a navigation_action or before_or_after:
 #({user.navigation_action} [{user.arrow_key}] [{user.navigation_target_name}] [{user.before_or_after}] | [{user.arrow_key}] {user.before_or_after}) [<user.ordinals>] <user.navigation_target>:


### PR DESCRIPTION
I spent my morning trying to understand why the `text_navigation` module worked in notepad but not VSCode.

Turns out that VSCode has a setting `editor.emptySelectionClipboard` where if your cursor has nothing selected you'll select the whole line instead, which leads `navigate_right` and `navigate_left` actions to fail.

I've been wanting to use these commands for a long time but it kept going into the too hard basket.
Hope this comment might help someone else.