### PR TITLE
faster dictation dance

### DIFF
--- a/code/dictation.py
+++ b/code/dictation.py
@@ -437,12 +437,18 @@ class Actions:
         # Insert space to ensure something to select (see dictation_peek_left).
         actions.insert(" ")
         actions.edit.left()
-        # We select to end of line because it's usually a single keypress and we
-        # only depend on what's on the current line. Without this trick we might
-        # need to select at least three characters to the right: one for the the
-        # space we inserted, and up to two for no_space_before -- for example,
-        # inserting before "' hello" we don't want to add space, while inserting
-        # before "'hello" we do.
+        # We want to select at least two characters to the right, plus the space
+        # we inserted, because no_space_before needs two characters in the worst
+        # case -- for example, inserting before "' hello" we don't want to add
+        # space, while inserted before "'hello" we do.
+        #
+        # We use 2x extend_word_right() because it's fewer keypresses (lower
+        # latency) than 3x extend_right(). Other options all seem to have
+        # problems. For instance, extend_line_end() might not select all the way
+        # to the next newline if text has been wrapped across multiple lines;
+        # extend_line_down() sometimes escapes the current text box (eg. in a
+        # browser address bar). 1x extend_word_right() _usually_ works, but on
+        # Windows in Firefox it doesn't always select enough characters.
         actions.edit.extend_word_right()
         actions.edit.extend_word_right()
         after = actions.edit.selected_text()

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -410,14 +410,13 @@ class Actions:
         # Inserting a space ensures we select something even if we're at
         # document start; some editors 'helpfully' copy the current line if we
         # edit.copy() while nothing is selected.
-        actions.key(" ")
+        actions.insert(" ")
         # In principle the previous word should suffice, but some applications
         # have a funny concept of what the previous word is (for example, they
         # may only take the "`" at the end of "`foo`"). To be double sure we
         # take two words left. I also tried taking a line up + a word left, but
         # edit.extend_up() = key(shift-up) doesn't work consistently in the
         # Slack webapp (sometimes escapes the text box).
-        actions.key(" ")
         actions.edit.extend_word_left()
         actions.edit.extend_word_left()
         text = actions.edit.selected_text()

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -443,7 +443,8 @@ class Actions:
         # space we inserted, and up to two for no_space_before -- for example,
         # inserting before "' hello" we don't want to add space, while inserting
         # before "'hello" we do.
-        actions.edit.extend_line_end()
+        actions.edit.extend_word_right()
+        actions.edit.extend_word_right()
         after = actions.edit.selected_text()
         actions.edit.left()
         actions.key("delete")  # remove space

--- a/talon_draft_window/draft_talon_helpers.py
+++ b/talon_draft_window/draft_talon_helpers.py
@@ -74,7 +74,7 @@ class ContextSensitiveDictationActions:
     see https://github.com/knausj85/knausj_talon/pull/356
     """
 
-    def dictation_peek_left(clobber=False):
+    def dictation_peek_left():
         area = draft_manager.area
         return area[max(0, area.sel.left - 50) : area.sel.left]
 


### PR DESCRIPTION
I optimized the fixes made in #902 to involve fewer keypresses, which will help when these are expensive (eg. on Linux :P). Mainly:

1. I removed the clobber argument to dictation_peek_left, we only ever call it with clobber=True and inserting space will already clobber the selection, so this gets rid of a space-backspace pair.

2. I used edit.extend_line_end in dictation_peek_right instead of edit.extend_right multiple times.


# Todo

- [ ] Test linux firefox