### PR TITLE
#920 Inconsistent function names/descriptions in operators_assignment.py and operators_assignment.talon

### DIFF
--- a/code/create_spoken_forms.py
+++ b/code/create_spoken_forms.py
@@ -1,8 +1,9 @@
 import itertools
 import re
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Optional
 
 from talon import Module, actions
 

--- a/code/help.py
+++ b/code/help.py
@@ -2,8 +2,8 @@ import itertools
 import math
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from itertools import islice
-from typing import Iterable
 
 from talon import Context, Module, actions, imgui, registry
 

--- a/code/numbers.py
+++ b/code/numbers.py
@@ -1,4 +1,5 @@
-from typing import Iterator, Union
+from collections.abc import Iterator
+from typing import Union
 
 from talon import Context, Module
 

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -1,6 +1,7 @@
 import logging
 import re
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 from talon import Context, Module, actions
 from talon.grammar import Phrase

--- a/lang/tags/operators_assignment.py
+++ b/lang/tags/operators_assignment.py
@@ -12,7 +12,7 @@ class Actions:
         """code_operator_assignment"""
 
     def code_operator_subtraction_assignment():
-        """code_operator_subtraction_equals"""
+        """code_operator_subtraction_assignment"""
 
     def code_operator_addition_assignment():
         """code_operator_addition_assignment"""
@@ -30,7 +30,7 @@ class Actions:
         """code_operator_modulo_assignment"""
 
     def code_operator_bitwise_and_assignment():
-        """code_operator_and"""
+        """code_operator_and_assignment"""
 
     def code_operator_bitwise_or_assignment():
         """code_operator_or_assignment"""

--- a/lang/tags/operators_assignment.talon
+++ b/lang/tags/operators_assignment.talon
@@ -17,4 +17,4 @@ op mod equals: user.code_operator_modulo_assignment()
 #bitwise operators
 (op | logical | bitwise) (ex | exclusive) or equals: user.code_operator_bitwise_exclusive_or_assignment()
 [(op | logical | bitwise)] (left shift | shift left) equals: user.code_operator_bitwise_left_shift_assignment()
-[(op | logical | bitwise)] (left right | shift right) equals: user.code_operator_bitwise_right_shift_assignment()
+[(op | logical | bitwise)] (right shift | shift right) equals: user.code_operator_bitwise_right_shift_assignment()

--- a/lang/tags/operators_assignment.talon
+++ b/lang/tags/operators_assignment.talon
@@ -15,6 +15,6 @@ op mod equals: user.code_operator_modulo_assignment()
 [op] increment: user.code_operator_increment()
 
 #bitwise operators
-(op | logical | bitwise) (ex | exclusive) or equals: user.code_operator_bitwise_exclusive_or_equals()
-[(op | logical | bitwise)] (left shift | shift left) equals: user.code_operator_bitwise_left_shift_equals()
-[(op | logical | bitwise)] (left right | shift right) equals: user.code_operator_bitwise_right_shift_equals()
+(op | logical | bitwise) (ex | exclusive) or equals: user.code_operator_bitwise_exclusive_or_assignment()
+[(op | logical | bitwise)] (left shift | shift left) equals: user.code_operator_bitwise_left_shift_assignment()
+[(op | logical | bitwise)] (left right | shift right) equals: user.code_operator_bitwise_right_shift_assignment()


### PR DESCRIPTION
#920 
This should make it so that the bitwise assignment operators are now able to be used.