### PR TITLE
pre-commit: removed shed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,3 @@ repos:
     rev: "0.76"
     hooks:
       - id: flynt
-  - repo: https://github.com/Zac-HD/shed
-    rev: 0.10.1
-    hooks:
-      - id: shed
-        args: [--refactor, --py39-plus]
-        types_or: [python, markdown, rst]


### PR DESCRIPTION
We don't want pyupgrade: https://github.com/knausj85/knausj_talon/issues/922

We will add back individual formatters later.