### PR TITLE
c.talon: allow text after #define/undef/ifdef

### DIFF
--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -44,8 +44,12 @@ state type deaf struct:
 
 # XXX - create a preprocessor tag for these, as they will match cpp, etc
 state define: "#define "
-state undefine: "#undef "
-state if define: "#ifdef "
+state (undefine | undeaf): "#undef "
+state if (define | deaf): "#ifdef "
+[state] define <user.text>$: "#define {user.formatted_text(text, 'ALL_CAPS,SNAKE_CASE')}"
+[state] (undefine | undeaf) <user.text>$:
+  "#undef {user.formatted_text(text, 'ALL_CAPS,SNAKE_CASE')}"
+[state] if (define | deaf)$: "#ifdef {user.formatted_text(text, 'ALL_CAPS,SNAKE_CASE')}"
 
 # XXX - preprocessor instead of pre?
 state pre if: "#if "

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -49,7 +49,8 @@ state if (define | deaf): "#ifdef "
 [state] define <user.text>$: "#define {user.formatted_text(text, 'ALL_CAPS,SNAKE_CASE')}"
 [state] (undefine | undeaf) <user.text>$:
   "#undef {user.formatted_text(text, 'ALL_CAPS,SNAKE_CASE')}"
-[state] if (define | deaf)$: "#ifdef {user.formatted_text(text, 'ALL_CAPS,SNAKE_CASE')}"
+[state] if (define | deaf) <user.text>$:
+  "#ifdef {user.formatted_text(text, 'ALL_CAPS,SNAKE_CASE')}"
 
 # XXX - preprocessor instead of pre?
 state pre if: "#if "


### PR DESCRIPTION
In C mode, makes it quicker to use `#define/undef/ifdef` by adding commands `[state] define <user.text>$` etc. eg: `define hello world` -> `#define HELLO_WORLD`.