### PR TITLE
all: formatting changes

### DIFF
--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -487,7 +487,7 @@ class UserActions:
         actions.user.insert_between("if let Some(", ")")
 
     def code_insert_if_let_okay():
-        actions.user.insert_between('if let Ok(', ')')
+        actions.user.insert_between("if let Ok(", ")")
 
     def code_insert_if_let_error():
         actions.user.insert_between("if let Err(", ")")


### PR DESCRIPTION
This applies the Black formatting changes to all files, which picks up changes in between the removal of the formatter in #923 and its reintroduction in #926, which was just one change to rust.py.