### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Setup dependabot to automatically open PRs bumping the versions of GitHub actions used in the CI.

For instance, the `actions/setup-python` we use is out of date, which we'll be notified of once this is merged.