### PR TITLE
Add spoken commands for bitwise and/or assignment

### DIFF
--- a/lang/tags/operators_assignment.talon
+++ b/lang/tags/operators_assignment.talon
@@ -15,9 +15,8 @@ op mod equals: user.code_operator_modulo_assignment()
 [op] increment: user.code_operator_increment()
 
 #bitwise operators
-(op | logical | bitwise) (ex | exclusive) or equals:
-    user.code_operator_bitwise_exclusive_or_assignment()
-[(op | logical | bitwise)] (left shift | shift left) equals:
-    user.code_operator_bitwise_left_shift_assignment()
-[(op | logical | bitwise)] (right shift | shift right) equals:
-    user.code_operator_bitwise_right_shift_assignment()
+[op] bit[wise] and equals: user.code_operator_bitwise_and_assignment()
+[op] bit[wise] or equals: user.code_operator_bitwise_or_assignment()
+(op | logical | bitwise) (ex | exclusive) or equals: user.code_operator_bitwise_exclusive_or_assignment()
+[(op | logical | bitwise)] (left shift | shift left) equals: user.code_operator_bitwise_left_shift_assignment()
+[(op | logical | bitwise)] (right shift | shift right) equals: user.code_operator_bitwise_right_shift_assignment()

--- a/lang/tags/operators_assignment.talon
+++ b/lang/tags/operators_assignment.talon
@@ -15,8 +15,11 @@ op mod equals: user.code_operator_modulo_assignment()
 [op] increment: user.code_operator_increment()
 
 #bitwise operators
-[op] bit[wise] and equals: user.code_operator_bitwise_and_assignment()
-[op] bit[wise] or equals: user.code_operator_bitwise_or_assignment()
-(op | logical | bitwise) (ex | exclusive) or equals: user.code_operator_bitwise_exclusive_or_assignment()
-[(op | logical | bitwise)] (left shift | shift left) equals: user.code_operator_bitwise_left_shift_assignment()
-[(op | logical | bitwise)] (right shift | shift right) equals: user.code_operator_bitwise_right_shift_assignment()
+[op] bit [wise] and equals: user.code_operator_bitwise_and_assignment()
+[op] bit [wise] or equals: user.code_operator_bitwise_or_assignment()
+(op | logical | bitwise) (ex | exclusive) or equals:
+    user.code_operator_bitwise_exclusive_or_assignment()
+[(op | logical | bitwise)] (left shift | shift left) equals:
+    user.code_operator_bitwise_left_shift_assignment()
+[(op | logical | bitwise)] (right shift | shift right) equals:
+    user.code_operator_bitwise_right_shift_assignment()


### PR DESCRIPTION
As far as I can tell, these actions were never given spoken forms. I am not sure if there is a reason for this, so I wanted to add some in case it was an error.

I made "wise" optional in the command so it does not get too long, but the square brackets can be removed if that does not seem necessary. If this is useful in reducing command length, maybe similar commands could be formatted to make the "wise" in "bitwise" optional.