### PR TITLE
fix library insertion functionality (c & rust)

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -391,4 +391,4 @@ class UserActions:
         actions.user.code_insert_function(result, None)
 
     def code_insert_library(text: str, selection: str):
-        actions.user.paste(f"include <{selection}>")
+        actions.user.paste(f"include <{text}>")

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -370,7 +370,7 @@ class UserActions:
     # tag: libraries_gui
 
     def code_insert_library(text: str, selection: str):
-        actions.user.paste(f"use {selection}")
+        actions.user.paste(f"use {text}")
 
     # tag: operators_array
 


### PR DESCRIPTION
When these functions were called in their respective talon files, the first argument was the name of the library, and the second argument was an empty string. As a result, this function was pasting an empty string ("selection") instead of the library name ("text").