### PR TITLE
Bugfixes for c, rust

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -391,4 +391,4 @@ class UserActions:
         actions.user.code_insert_function(result, None)
 
     def code_insert_library(text: str, selection: str):
-        actions.user.paste(f"include <{selection}>")
+        actions.user.paste(f"include <{text}>")

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -188,7 +188,7 @@ def c_cast(m) -> str:
 
 
 @mod.capture(rule="[<self.stdint_signed>] <self.stdint_types> [<self.c_pointers>+]")
-def c_stdint_cast(m) -> str:
+def stdint_cast(m) -> str:
     "Returns a string"
     return "(" + "".join(list(m)) + ")"
 

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -370,7 +370,7 @@ class UserActions:
     # tag: libraries_gui
 
     def code_insert_library(text: str, selection: str):
-        actions.user.paste(f"use {selection}")
+        actions.user.paste(f"use {text}")
 
     # tag: operators_array
 


### PR DESCRIPTION
Apologies, I accidentally closed the first pull request for this.

When these insert library functions were called in their respective talon files, the first argument was the name of the library, and the second argument was an empty string. As a result, it was pasting an empty string ("selection") instead of the library name ("text").

Also, one of the capture rules for c didn't match the name used for it in the associated talon file, causing the voice commands to not work.
