### PR TITLE
Add support for relative home paths

### DIFF
--- a/apps/generic_terminal/generic_terminal.talon
+++ b/apps/generic_terminal/generic_terminal.talon
@@ -8,7 +8,7 @@ lisa all:
     user.terminal_list_all_directories()
 katie [<user.text>]: user.terminal_change_directory(text or "")
 katie root: user.terminal_change_directory_root()
-go <user.system_path>: insert("cd \"{system_path}\"\n")
+go <user.system_path>: insert("cd {system_path} \n")
 clear screen: user.terminal_clear_screen()
 run last: user.terminal_run_last()
 rerun [<user.text>]: user.terminal_rerun_search(text or "")


### PR DESCRIPTION
The change will allow us to have the entries like below in the settings/system_path.csv. 
`~/Downloads/screenshots, screenshots`

This can be useful if we're using this same file for multiple machines having different usernames using dotFiles approach.