### PR TITLE
Abstract browser copy address to its own function with fallback

### DIFF
--- a/apps/generic_browser.talon
+++ b/apps/generic_browser.talon
@@ -1,10 +1,7 @@
 tag: browser
 -
 address bar | go address | go url: browser.focus_address()
-address copy | url copy | copy address | copy url:
-    browser.focus_address()
-    sleep(50ms)
-    edit.copy()
+address copy | url copy | copy address | copy url: user.browser_copy_address()
 go home: browser.go_home()
 [go] forward: browser.go_forward()
 go (back | backward): browser.go_back()

--- a/code/browser.py
+++ b/code/browser.py
@@ -18,6 +18,28 @@ def is_url(url):
         return False
 
 
+@ctx.action_class("user")
+class UserActions:
+    def browser_address_fallback() -> str:
+        try:
+            address = actions.browser.address()
+            if address:
+                return address
+        except Exception:
+            pass
+        actions.browser.focus_address()
+        actions.sleep("50ms")
+        with clip.capture() as s:
+            actions.edit.copy()
+        actions.key("escape")
+        actions.key("tab")
+        return s.text()
+
+    def browser_copy_address():
+        address = actions.user.browser_address_fallback()
+        clip.set_text(address)
+
+
 @ctx.action_class("browser")
 class BrowserActions:
     def address():


### PR DESCRIPTION
Creates action user.browser_copy_address() and user.browser_address_fallback().

My reason for doing this is so I can reimplement browser_copy_address in Rango so it uses the extension to get the address.

I also changed the way the fallback works so it doesn't leave the focus on the address bar.