### PR TITLE
java: Add `state var`

### DIFF
--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -23,6 +23,8 @@ settings():
     user.code_protected_variable_formatter = "PRIVATE_CAMEL_CASE"
     user.code_public_variable_formatter = "PRIVATE_CAMEL_CASE"
 
+state var: "var "
+
 # Types Commands
 boxed [type] {user.java_boxed_type}:
     insert(user.java_boxed_type + " ")


### PR DESCRIPTION
This adds a convenient way to insert the Java 10+ keyword for local variable type inference, as in:
```java
var url = new URL("http://example.com/");
```