### PR TITLE
editorconfig: Default to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,10 +5,14 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-indent_size = 2
+indent_size = 4
 indent_style = space
 max_line_length = 80
 trim_trailing_whitespace = true
+
+[*.{md,yaml,yml}]
+indent_style = space
+indent_size = 2
 
 [*.py]
 indent_style = space


### PR DESCRIPTION
As evidenced in #947 the majority of our .talon files use 4-space indents. This changes the default to 4 spaces, overriding it for Markdown and YAML files (which should always be 2 spaces).