### PR TITLE
vscode: Implement jumping to tab 10+

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -256,6 +256,10 @@ class UserActions:
                 )
             else:
                 actions.key(f"alt-{number}")
+        else:
+            actions.user.vscode_with_plugin(
+                "workbench.action.openEditorAtIndex", number
+            )
 
     def tab_final():
         if is_mac:


### PR DESCRIPTION
This allows jumping to tabs 10 onwards with `go tab ten` and so on.