### PR TITLE
Use `"coma"` for `,` to work around conformer b-series issue

### DIFF
--- a/code/keys.py
+++ b/code/keys.py
@@ -132,6 +132,8 @@ punctuation_words = {
     "back tick": "`",
     "grave": "`",
     "comma": ",",
+    # Workaround for issue with conformer b-series; see #946
+    "coma": ",",
     "period": ".",
     "full stop": ".",
     "semicolon": ";",


### PR DESCRIPTION
Fixes #946