### PR TITLE
Make settings directory configurable

### DIFF
--- a/code/extensions.py
+++ b/code/extensions.py
@@ -1,4 +1,4 @@
-from talon import Context, Module
+from talon import Context, Module, app
 
 from .user_settings import get_list_from_csv
 
@@ -34,11 +34,24 @@ _file_extensions_defaults = {
     "dot text": ".txt",
 }
 
-file_extensions = get_list_from_csv(
-    "file_extensions.csv",
-    headers=("File extension", "Name"),
-    default=_file_extensions_defaults,
-)
-
 ctx = Context()
-ctx.lists["self.file_extension"] = file_extensions
+
+file_extensions: dict[str, str] = {}
+
+
+def on_ready():
+    global file_extensions
+    assert (
+        not file_extensions
+    ), "global dict 'file_extension' should be empty on 'ready'"
+    file_extensions.update(
+        get_list_from_csv(
+            "file_extensions.csv",
+            headers=("File extension", "Name"),
+            default=_file_extensions_defaults,
+        )
+    )
+    ctx.lists["self.file_extension"] = file_extensions
+
+
+app.register("ready", on_ready)

--- a/code/websites_and_search_engines.py
+++ b/code/websites_and_search_engines.py
@@ -1,7 +1,7 @@
 import webbrowser
 from urllib.parse import quote_plus
 
-from talon import Context, Module
+from talon import Context, Module, app
 
 from .user_settings import get_list_from_csv
 
@@ -40,16 +40,22 @@ _search_engine_defaults = {
 }
 
 ctx = Context()
-ctx.lists["self.website"] = get_list_from_csv(
-    "websites.csv",
-    headers=("URL", "Spoken name"),
-    default=website_defaults,
-)
-ctx.lists["self.search_engine"] = get_list_from_csv(
-    "search_engines.csv",
-    headers=("URL Template", "Name"),
-    default=_search_engine_defaults,
-)
+
+
+def load_websites_and_search_engines():
+    ctx.lists["self.website"] = get_list_from_csv(
+        "websites.csv",
+        headers=("URL", "Spoken name"),
+        default=website_defaults,
+    )
+    ctx.lists["self.search_engine"] = get_list_from_csv(
+        "search_engines.csv",
+        headers=("URL Template", "Name"),
+        default=_search_engine_defaults,
+    )
+
+
+app.register("ready", load_websites_and_search_engines)
 
 
 @mod.action_class


### PR DESCRIPTION
The current settings directory is hard-coded to be inside repository root of knausj_talon, which means it's automatically gitignored.

The PR adds the setting `community_settings_directory`, which is used to locate the settings directory anywhere, using the `get_full_path` function adapted from Cursorless. (The default setting remains the same, so this should not be a breaking change.)

As part of this PR, I've moved all uses of `get_list_from_csv` into a "ready" callback, and have them write to their respective global dictionaries on "ready".