### PR TITLE
core/tags: Remove debugger tag definition

### DIFF
--- a/core/tags.py
+++ b/core/tags.py
@@ -3,7 +3,6 @@ from talon import Module
 mod = Module()
 
 tagList = [
-    "debugger",
     "disassembler",
     "gdb",
     "git",  # commandline tag for git commands


### PR DESCRIPTION
The `debugger` tag is already defined in `tags/debugger/`:

https://github.com/knausj85/knausj_talon/blob/0d6bd90e5bb1a45b5cea7bcd7ccbb45973cd9b02/tags/debugger/debugger.py#L7