### PR TITLE
keys: Use real words for "dub quote"

### DIFF
--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -202,7 +202,7 @@ symbol_key_words = {
     "caret": "^",
     "amper": "&",
     "pipe": "|",
-    "dubquote": '"',
+    "dub quote": '"',
     "double quote": '"',
     # Currencies
     "dollar": "$",


### PR DESCRIPTION
Similar rationale to #944, but targets the more problematic command.