### PR TITLE
Implement delete line action for iterm

### DIFF
--- a/apps/iterm/iterm.talon
+++ b/apps/iterm/iterm.talon
@@ -8,3 +8,4 @@ tag(): user.generic_unix_shell
 tag(): user.git
 tag(): user.kubectl
 tag(): user.tabs
+tag(): user.readline

--- a/core/tags.py
+++ b/core/tags.py
@@ -10,6 +10,7 @@ tagList = [
     "tabs",
     "generic_windows_shell",
     "generic_unix_shell",
+    "readline",
     "taskwarrior",  # commandline tag for taskwarrior commands
     "tmux",
     "windbg",

--- a/tags/terminal/readline.py
+++ b/tags/terminal/readline.py
@@ -1,0 +1,13 @@
+from talon import Context, actions
+
+ctx = Context()
+ctx.matches = r"""
+tag: user.readline
+"""
+
+
+@ctx.action_class("edit")
+class Actions:
+    def delete_line():
+        actions.key("ctrl-e")
+        actions.key("ctrl-u")


### PR DESCRIPTION
This PR implements `delete_line` for iterm. Although, I wonder if this should be in generic_terminal.py? I think most terminals have the same keybindings.