### PR TITLE
rust: Delete duplicate action declaration

### DIFF
--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -11,9 +11,6 @@ mod.list("code_trait", desc="List of traits for active language")
 
 @mod.action_class
 class Actions:
-    def code_operator_structure_dereference():
-        """Inserts a reference operator"""
-
     def code_state_implements():
         """Inserts implements block, positioning the cursor appropriately"""
 


### PR DESCRIPTION
code_operator_structure_dereference is already defined in lang/tags/operators_pointer.py.

Fixes: #967