### PR TITLE
git ignore .DS_Store as #1022 but without extra commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 # Locally generated
 /settings
 .vscode/settings.json
+.DS_Store


### PR DESCRIPTION
Macs litter local directories with .DS_Store. Git should ignore them.