### PR TITLE
Update emote to add colons and support formatters

### DIFF
--- a/apps/slack/slack_mac.talon
+++ b/apps/slack/slack_mac.talon
@@ -45,7 +45,10 @@ bold: key(cmd-b)
 (slack | lack) invite: key(a)
 # Miscellaneous
 (slack | lack) shortcuts: key(cmd-/)
-emote <user.text>: "{text}"
+emote <user.text>: ":{text}:"
+emote <user.formatters> <user.text>:
+    insert(':')
+    insert(user.formatted_text(text, formatters))
 toggle left sidebar: key(cmd-shift-d)
 toggle right sidebar: key(cmd-.)
 

--- a/apps/slack/slack_mac.talon
+++ b/apps/slack/slack_mac.talon
@@ -47,7 +47,7 @@ bold: key(cmd-b)
 (slack | lack) shortcuts: key(cmd-/)
 emote <user.text>: ":{text}:"
 emote <user.formatters> <user.text>:
-    insert(':')
+    insert(":")
     insert(user.formatted_text(text, formatters))
 toggle left sidebar: key(cmd-shift-d)
 toggle right sidebar: key(cmd-.)


### PR DESCRIPTION
It seems to me that the `emote` slack command should format the user.text as an emoji in slack, using colons. This adds wrapping colons to the existing emote command, and adds an additional emote command supporting formatters, which leaves off the trailing comma to leave the emoji selection window open.

(if this is not what the emote command is supposed to do, please disregard)