### PR TITLE
javascript: remove `code_type_dictionary()`

### DIFF
--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -79,9 +79,6 @@ class UserActions:
     def code_insert_is_null():
         actions.auto_insert(" === null")
 
-    def code_type_dictionary():
-        actions.user.insert_between("{", "}")
-
     def code_state_if():
         actions.user.insert_between("if (", ")")
 


### PR DESCRIPTION
There's currently no module implementation for this function, so this leads to a lot of log spam when editing any javascript or typescript file:

```
2022-11-11 12:48:05 WARNING actions: skipped because they have no matching declaration: (user.code_type_dictionary)
2022-11-11 12:48:05 WARNING actions: skipped because they have no matching declaration: (user.code_type_dictionary)
2022-11-11 12:48:05 WARNING actions: skipped because they have no matching declaration: (user.code_type_dictionary)
2022-11-11 12:48:05 WARNING actions: skipped because they have no matching declaration: (user.code_type_dictionary)
2022-11-11 12:48:05 WARNING actions: skipped because they have no matching declaration: (user.code_type_dictionary)
```

Unless we know where this module function should go, it seems like we should probably remove this context override. There are no other implementations of `code_type_dictionary` in any of the other languages.
