### PR TITLE
Add help command to show the options for any list

### DIFF
--- a/core/help/help.py
+++ b/core/help/help.py
@@ -9,7 +9,7 @@ from talon import Context, Module, actions, imgui, registry
 
 mod = Module()
 mod.list("help_contexts", desc="list of available contexts")
-mod.list("help_lists", desc="list of lists") # TODO: Better desc
+mod.list("help_lists", desc="list of lists")  # TODO: Better desc
 mod.mode("help", "mode for commands that are available only when help is visible")
 setting_help_max_contexts_per_page = mod.setting(
     "help_max_contexts_per_page",
@@ -26,10 +26,11 @@ setting_help_max_command_lines_per_page = mod.setting(
 
 ctx = Context()
 
+
 def update_lists():
     mapping = {}
     for name in registry.lists.keys():
-        list_name = name.split('.')[-1]
+        list_name = name.split(".")[-1]
         display_name = list_name.replace("_", " ")
 
         short_names = actions.user.create_spoken_forms(
@@ -40,6 +41,7 @@ def update_lists():
             mapping[short_name] = list_name
 
     ctx.lists["user.help_lists"] = mapping
+
 
 update_lists()
 # context name -> commands

--- a/core/help/help.py
+++ b/core/help/help.py
@@ -9,6 +9,7 @@ from talon import Context, Module, actions, imgui, registry
 
 mod = Module()
 mod.list("help_contexts", desc="list of available contexts")
+mod.list("help_lists", desc="list of lists") # TODO: Better desc
 mod.mode("help", "mode for commands that are available only when help is visible")
 setting_help_max_contexts_per_page = mod.setting(
     "help_max_contexts_per_page",
@@ -24,6 +25,23 @@ setting_help_max_command_lines_per_page = mod.setting(
 )
 
 ctx = Context()
+
+def update_lists():
+    mapping = {}
+    for name in registry.lists.keys():
+        list_name = name.split('.')[-1]
+        display_name = list_name.replace("_", " ")
+
+        short_names = actions.user.create_spoken_forms(
+            display_name,
+            generate_subsequences=False,
+        )
+        for short_name in short_names:
+            mapping[short_name] = list_name
+
+    ctx.lists["user.help_lists"] = mapping
+
+update_lists()
 # context name -> commands
 context_command_map = {}
 

--- a/core/help/help.talon
+++ b/core/help/help.talon
@@ -6,6 +6,7 @@ help modifier: user.help_list("user.modifier_key")
 help special keys: user.help_list("user.special_key")
 help function keys: user.help_list("user.function_key")
 help arrows: user.help_list("user.arrow_key")
+help list {user.help_lists}$: user.help_list("user." + help_lists)
 (help formatters | help format | format help):
     user.help_formatters(user.get_formatters_words())
 help context$: user.help_context()


### PR DESCRIPTION
Adds a 'help list {user.help_lists}' command to display the available options for any list. For example, with this PR you can say 'help list window snap positions' and see the following window:

![image](https://user-images.githubusercontent.com/1012677/201496367-f7a1a5e0-680f-4300-b17c-c9f487385b47.png)

This is currently more of a PoC, as I'm not sure if I'm doing things correctly.
