### PR TITLE
Add command for adding padding around symbols

### DIFF
--- a/core/edit/standard.talon
+++ b/core/edit/standard.talon
@@ -16,7 +16,7 @@ file save: edit.save()
 file save all: edit.save_all()
 (pad | padding): user.insert_between(" ", " ")
 (pad | padding) <user.symbol_key>+:
-    insert(" {symbol_key_list} ")
+    insert(" ")
     user.insert_many(symbol_key_list)
     insert(" ")
 slap: edit.line_insert_down()

--- a/core/edit/standard.talon
+++ b/core/edit/standard.talon
@@ -15,4 +15,8 @@ paste match: edit.paste_match_style()
 file save: edit.save()
 file save all: edit.save_all()
 (pad | padding): user.insert_between(" ", " ")
+(pad | padding) <user.symbol_key>+:
+    insert(" {symbol_key_list} ")
+    user.insert_many(symbol_key_list)
+    insert(" ")
 slap: edit.line_insert_down()


### PR DESCRIPTION
The current pad command leaves the cursor in the middle of two spaces. I think it would be much more convenient if we could say something like "pad equals" and have " = " with the cursor already at the end of the inserted text, making it easier to continue typing.