### PR TITLE
git_arguments.csv: add --set-upstream-to

### DIFF
--- a/apps/git/git_arguments.csv
+++ b/apps/git/git_arguments.csv
@@ -39,6 +39,7 @@ Option, Spoken form
 --rebase, rebase
 --remote, remote
 --set-upstream, set up stream
+--set-upstream-to, set up stream to
 --short, short
 --shortstat, short stat
 --skip, skip


### PR DESCRIPTION
this is an argument to `git branch` which is confusingly similar to `--set-upstream` but apparently `git branch --set-upstream` is deprecated.