### PR TITLE
python.talon: allow optional "state" before "raise"/"except"

### DIFF
--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -36,8 +36,9 @@ self taught: "self."
 pie test: "pytest"
 state past: "pass"
 
-raise {user.python_exception}: user.insert_between("raise {python_exception}(", ")")
-except {user.python_exception}: "except {python_exception}:"
+[state] raise {user.python_exception}:
+    user.insert_between("raise {python_exception}(", ")")
+[state] except {user.python_exception}: "except {python_exception}:"
 
 dock string: user.code_comment_documentation()
 dock {user.python_docstring_fields}:


### PR DESCRIPTION
Currently we have `state raise` and `raise {user.python_exception}` commands. This annoyingly requires you to remember whether you are going to say an exception name in order to know whether to say `state` or not. Simpler to always allow it.