### PR TITLE
implement "clone that", "clone line" in more places

### DIFF
--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -18,6 +18,20 @@ class EditActions:
         actions.edit.line_end()
         actions.key("enter")
 
+    def selection_clone():
+        actions.edit.copy()
+        actions.edit.select_none()
+        actions.edit.paste()
+
+    def line_clone():
+        # This may not work if editor auto-indents. Is there a better way?
+        actions.edit.line_start()
+        actions.edit.extend_line_end()
+        actions.edit.copy()
+        actions.edit.right()
+        actions.key("enter")
+        actions.edit.paste()
+
 
 @mod.action_class
 class Actions:

--- a/core/edit/edit.talon
+++ b/core/edit/edit.talon
@@ -174,3 +174,7 @@ cut line: user.cut_line()
 (pace | paste) all:
     edit.select_all()
     edit.paste()
+
+# duplication
+clone that: edit.selection_clone()
+clone line: edit.line_clone()

--- a/tags/line_commands/line_commands.py
+++ b/tags/line_commands/line_commands.py
@@ -37,3 +37,5 @@ class Actions:
 
     def line_clone(line: int):
         """Clones specified line at current position"""
+        actions.edit.jump_line(line)
+        actions.edit.line_clone()

--- a/tags/line_commands/line_commands.talon
+++ b/tags/line_commands/line_commands.talon
@@ -65,7 +65,7 @@ drag down [line] <number>:
 drag down <number> until <number>:
     user.select_range(number_1, number_2)
     edit.line_swap_down()
-clone (line | that): edit.line_clone()
+clone [line] <number>: user.line_clone(number)
 
 select camel left: user.extend_camel_left()
 select camel right: user.extend_camel_right()


### PR DESCRIPTION
This:

1. Makes `clone that` and `clone line` globally available rather than only when the line_commands tag is active.
2. Makes `clone that` duplicate the current selection, in line with our normal naming conventions. (Previously it duplicated the current line, a synonym for `clone line`.)
3. Provides default implementations of `edit.selection_clone`, `edit.line_clone`, and `user.line_clone`.