### PR TITLE
Add Gnome-terminal support to app_name_overrides.linux.csv

### DIFF
--- a/core/app_switcher/app_name_overrides.linux.csv
+++ b/core/app_switcher/app_name_overrides.linux.csv
@@ -1,3 +1,3 @@
 grip, DataGrip
 py, jetbrains-pycharm-ce
-term, Gnome-terminal
+terminal, Gnome-terminal

--- a/core/app_switcher/app_name_overrides.linux.csv
+++ b/core/app_switcher/app_name_overrides.linux.csv
@@ -1,2 +1,3 @@
 grip, DataGrip
 py, jetbrains-pycharm-ce
+term, Gnome-terminal


### PR DESCRIPTION
I don't have the link (it's older than 90 days, no longer searchable) but at least one other person ran into this issue/confusion, I found this fix via the Talon Slack.