### PR TITLE
Allow specifying a path to ls

### DIFF
--- a/apps/iterm/iterm.py
+++ b/apps/iterm/iterm.py
@@ -54,12 +54,12 @@ class user_actions:
     #     """selects the file"""
     #     actions.insert(path)
 
-    def terminal_list_directories():
-        actions.insert("ls")
+    def terminal_list_directories(path: str):
+        actions.insert(f"ls {path}")
         actions.key("enter")
 
-    def terminal_list_all_directories():
-        actions.insert("ls -a")
+    def terminal_list_all_directories(path: str):
+        actions.insert(f"ls -a {path}")
         actions.key("enter")
 
     def terminal_change_directory(path: str):

--- a/apps/mintty/mintty_win.py
+++ b/apps/mintty/mintty_win.py
@@ -109,12 +109,12 @@ class UserActions:
         """file_manager_open_volume"""
         actions.user.file_manager_open_directory(volume)
 
-    def terminal_list_directories():
-        actions.insert("ls")
+    def terminal_list_directories(path: str):
+        actions.insert(f"ls {path}")
         actions.key("enter")
 
-    def terminal_list_all_directories():
-        actions.insert("ls -a")
+    def terminal_list_all_directories(path: str):
+        actions.insert(f"ls -a {path}")
         actions.key("enter")
 
     def terminal_change_directory(path: str):

--- a/apps/windows_command_processor/command_processor_win.py
+++ b/apps/windows_command_processor/command_processor_win.py
@@ -83,12 +83,12 @@ class UserActions:
         """file_manager_open_volume"""
         actions.user.file_manager_open_directory(volume)
 
-    def terminal_list_directories():
+    def terminal_list_directories(path: str):
         """Lists directories"""
         actions.insert("dir")
         actions.key("enter")
 
-    def terminal_list_all_directories():
+    def terminal_list_all_directories(path: str):
         actions.insert("dir /a")
         actions.key("enter")
 

--- a/apps/wsl/wsl.py
+++ b/apps/wsl/wsl.py
@@ -483,12 +483,12 @@ class UserActions:
     def file_manager_open_volume(volume: str):
         actions.user.file_manager_open_directory(volume)
 
-    def terminal_list_directories():
-        actions.insert("ls")
+    def terminal_list_directories(path: str):
+        actions.insert(f"ls {path}")
         actions.key("enter")
 
-    def terminal_list_all_directories():
-        actions.insert("ls -a")
+    def terminal_list_all_directories(path: str):
+        actions.insert(f"ls -a {path}")
         actions.key("enter")
 
     def terminal_change_directory(path: str):

--- a/tags/terminal/terminal.py
+++ b/tags/terminal/terminal.py
@@ -5,10 +5,10 @@ mod = Module()
 
 @mod.action_class
 class Actions:
-    def terminal_list_directories():
+    def terminal_list_directories(path: str):
         """Lists directories"""
 
-    def terminal_list_all_directories():
+    def terminal_list_all_directories(path: str):
         """Lists all directories including hidden"""
 
     def terminal_change_directory(path: str):

--- a/tags/terminal/terminal.talon
+++ b/tags/terminal/terminal.talon
@@ -2,8 +2,8 @@ tag: terminal
 -
 # tags should be activated for each specific terminal in the respective talon file
 
-lisa: user.terminal_list_directories()
-lisa all: user.terminal_list_all_directories()
+lisa [<user.text>]: user.terminal_list_directories(text or "")
+lisa all [<user.text>]: user.terminal_list_all_directories(text or "")
 katie [dir] [<user.text>]: user.terminal_change_directory(text or "")
 katie root: user.terminal_change_directory_root()
 katie (up | back): user.terminal_change_directory("..")

--- a/tags/terminal/unix_shell.py
+++ b/tags/terminal/unix_shell.py
@@ -14,14 +14,14 @@ tag: user.generic_unix_shell
 class Actions:
     # Implements the functions from terminal.py for unix shells
 
-    def terminal_list_directories():
+    def terminal_list_directories(path: str):
         """Lists directories"""
-        actions.insert("ls")
+        actions.insert(f"ls {path}")
         actions.key("enter")
 
-    def terminal_list_all_directories():
+    def terminal_list_all_directories(path: str):
         """Lists all directories including hidden"""
-        actions.insert("ls -a")
+        actions.insert(f"ls -a {path}")
         actions.key("enter")
 
     def terminal_change_directory(path: str):

--- a/tags/terminal/windows_shell.py
+++ b/tags/terminal/windows_shell.py
@@ -11,12 +11,12 @@ tag: user.generic_windows_shell
 class Actions:
     # Implements the functions from terminal.py for unix shells
 
-    def terminal_list_directories():
+    def terminal_list_directories(path: str):
         """Lists directories"""
         actions.insert("ls")
         actions.key("enter")
 
-    def terminal_list_all_directories():
+    def terminal_list_all_directories(path: str):
         """Lists all directories including hidden"""
         actions.insert("ls -force")
         actions.key("enter")


### PR DESCRIPTION
Allow specifying a path to `ls` for unix terminals. Because I can't test on Windows, I only fixed the function signature without making use of the path in these cases. I still made the change for unix terminals on Windows like WSL, but I did not test these. If you think we need to test these, I can just make the change for unix terminals on Linux/macOS.