### PR TITLE
make window management on mac work a bit better

### DIFF
--- a/plugin/desktops/desktops_mac.py
+++ b/plugin/desktops/desktops_mac.py
@@ -14,14 +14,16 @@ def _drag_window_mac(win=None):
     if win is None:
         win = ui.active_window()
     fs = win.children.find(AXSubrole="AXFullScreenButton")[0]
-    rect = fs.AXFrame["$rect2d"]
-    x = rect["x"] + rect["width"] + 5
-    y = rect["y"] + rect["height"] / 2
+    rect = fs.AXFrame
+    x = rect.x + rect.width + 5
+    y = rect.y + rect.height / 2
+    previous_position = ctrl.mouse_pos()
     ctrl.mouse_move(x, y)
     ctrl.mouse_click(button=0, down=True)
     yield
     time.sleep(0.1)
     ctrl.mouse_click(button=0, up=True)
+    ctrl.mouse_move(*previous_position)
 
 
 @ctx.action_class("user")
@@ -41,15 +43,16 @@ class MacActions:
 
     def window_move_desktop_left():
         with _drag_window_mac():
-            actions.key("ctrl-cmd-alt-left")
+            actions.user.desktop_last()
 
     def window_move_desktop_right():
         with _drag_window_mac():
-            actions.key("ctrl-cmd-alt-right")
+            actions.user.desktop_next()
 
     def window_move_desktop(desktop_number: int):
+        # TODO: amethyst stuff should be pulled out into a separate file
         if ui.apps(bundle="com.amethyst.Amethyst"):
             actions.key(f"ctrl-alt-shift-{desktop_number}")
         else:
             with _drag_window_mac():
-                actions.key(f"ctrl-{desktop_number}")
+                actions.user.desktop(desktop_number)


### PR DESCRIPTION
At least for me on a MacBook pro on ventura, the current implementations of `window_move_desktop_{left,right}` produce an error, and even if they didn't they would use keybindings that don't work by default. This fixes that error and uses the default keybindings of ctrl-left/right.