### PR TITLE
edit_mac.py: omit cmd-left for file_start/file_end

### DIFF
--- a/core/edit/edit_mac.py
+++ b/core/edit/edit_mac.py
@@ -84,10 +84,10 @@ class EditActions:
         actions.key("shift-alt-right")
 
     def file_end():
-        actions.key("cmd-down cmd-left")
+        actions.key("cmd-down")
 
     def file_start():
-        actions.key("cmd-up cmd-left")
+        actions.key("cmd-up")
 
     def find(text: str = None):
         actions.key("cmd-f")


### PR DESCRIPTION
The default bindings for `edit.file_start` on mac presses `cmd-up cmd-left` (and `edit.file_end` is `cmd-down cmd-left`). I find this `cmd-left` to be redundant (at least in TextEdit and in Emacs, `cmd-up` goes to the start of the document, including the beginning of the line) and to produce bad behavior in, eg, web browsers, where `cmd-up` successfully scrolls to the top but then `cmd-left` goes back in history.

Are there some applications where this `cmd-left` is necessary?