### PR TITLE
remove bogus comments created by migration script

### DIFF
--- a/core/windows_and_tabs/windows_and_tabs_linux.py
+++ b/core/windows_and_tabs/windows_and_tabs_linux.py
@@ -14,8 +14,6 @@ class AppActions:
 
     def tab_close():
         actions.key("ctrl-w")
-        # action(app.tab_detach):
-        #  Move the current tab to a new window
 
     def tab_next():
         actions.key("ctrl-tab")

--- a/core/windows_and_tabs/windows_and_tabs_mac.py
+++ b/core/windows_and_tabs/windows_and_tabs_mac.py
@@ -13,8 +13,6 @@ class AppActions:
 
     def tab_close():
         actions.key("cmd-w")
-        # action(app.tab_detach):
-        #  Move the current tab to a new window
 
     def tab_next():
         actions.key("cmd-shift-]")

--- a/core/windows_and_tabs/windows_and_tabs_win.py
+++ b/core/windows_and_tabs/windows_and_tabs_win.py
@@ -14,8 +14,6 @@ class AppActions:
 
     def tab_close():
         actions.key("ctrl-w")
-        # action(app.tab_detach):
-        #  Move the current tab to a new window
 
     def tab_next():
         actions.key("ctrl-tab")


### PR DESCRIPTION
Removes some comments created by the action migration script. Perhaps we should have TODOs to implement `app.tab_detach` on various platforms instead? I'm not sure there _is_ a standard way to accomplish that action, though.