### PR TITLE
windows_and_tabs_mac.py: use accessibility to implement app.window_close

### DIFF
--- a/core/windows_and_tabs/windows_and_tabs_mac.py
+++ b/core/windows_and_tabs/windows_and_tabs_mac.py
@@ -1,5 +1,5 @@
+import talon.mac.ui  # ActionFailed
 from talon import Context, actions, ui
-import talon.mac.ui # ActionFailed
 
 ctx = Context()
 ctx.matches = r"""
@@ -33,16 +33,18 @@ class AppActions:
         # Try to use accessibility, but fall back on cmd-w.
         try:
             w = ui.active_window()
-            button = w.element['AXCloseButton']
-            assert button.actions['AXPress'] == 'press'
+            button = w.element["AXCloseButton"]
+            assert button.actions["AXPress"] == "press"
         except Exception as e:
             actions.key("cmd-w")
         else:
             # This can fail with talon.mac.ui.ActionFailed if the window opens a
             # confirmation dialog. But pressing cmd-w or clicking the close
             # button would do the same, so we don't regard this as failure.
-            try: button.perform("AXPress")
-            except talon.mac.ui.ActionFailed: pass
+            try:
+                button.perform("AXPress")
+            except talon.mac.ui.ActionFailed:
+                pass
 
     def window_hide():
         actions.key("cmd-m")

--- a/core/windows_and_tabs/windows_and_tabs_mac.py
+++ b/core/windows_and_tabs/windows_and_tabs_mac.py
@@ -1,4 +1,5 @@
-from talon import Context, actions
+from talon import Context, actions, ui
+import talon.mac.ui # ActionFailed
 
 ctx = Context()
 ctx.matches = r"""
@@ -29,7 +30,19 @@ class AppActions:
         actions.key("cmd-shift-t")
 
     def window_close():
-        actions.key("cmd-w")
+        # Try to use accessibility, but fall back on cmd-w.
+        try:
+            w = ui.active_window()
+            button = w.element['AXCloseButton']
+            assert button.actions['AXPress'] == 'press'
+        except Exception as e:
+            actions.key("cmd-w")
+        else:
+            # This can fail with talon.mac.ui.ActionFailed if the window opens a
+            # confirmation dialog. But pressing cmd-w or clicking the close
+            # button would do the same, so we don't regard this as failure.
+            try: button.perform("AXPress")
+            except talon.mac.ui.ActionFailed: pass
 
     def window_hide():
         actions.key("cmd-m")


### PR DESCRIPTION
This works more reliably than `cmd-w` because that really tries to close the current tab. But we can't use `cmd-shift-w` because that shortcut doesn't exist unless there's more than one tab.

However, the mac accessibility API might be experimental, so I'd like signoff from @lunixbochs on this one.