### PR TITLE
simplify create_spoken_forms and avoid empty spoken forms

### DIFF
--- a/core/create_spoken_forms.py
+++ b/core/create_spoken_forms.py
@@ -312,9 +312,6 @@ class Actions:
     ) -> list[str]:
         """Create spoken forms for a given source"""
 
-        if words_to_exclude is None:
-            words_to_exclude = []
-
         spoken_forms_without_symbols = create_spoken_forms_from_regex(
             source, REGEX_NO_SYMBOLS
         )
@@ -334,7 +331,7 @@ class Actions:
             spoken_forms.update(
                 generate_string_subsequences(
                     spoken_forms_without_symbols[-1],
-                    words_to_exclude,
+                    words_to_exclude or [],
                     minimum_term_length,
                 )
             )

--- a/core/create_spoken_forms.py
+++ b/core/create_spoken_forms.py
@@ -333,7 +333,9 @@ class Actions:
             # the only one that seems relevant are the full spoken form for
             spoken_forms.update(
                 generate_string_subsequences(
-                    spoken_forms_without_symbols[-1], words_to_exclude, minimum_term_length
+                    spoken_forms_without_symbols[-1],
+                    words_to_exclude,
+                    minimum_term_length,
                 )
             )
 

--- a/core/create_spoken_forms.py
+++ b/core/create_spoken_forms.py
@@ -270,7 +270,7 @@ def create_spoken_forms_from_regex(source: str, pattern: re.Pattern):
 def generate_string_subsequences(
     source: str,
     words_to_exclude: list[str],
-    minimum_term_length=DEFAULT_MINIMUM_TERM_LENGTH,
+    minimum_term_length: int,
 ):
     # Includes (lower-cased):
     # 1. Each word in source, eg "foo bar baz" -> "foo", "bar", "baz".

--- a/core/create_spoken_forms.py
+++ b/core/create_spoken_forms.py
@@ -337,7 +337,7 @@ class Actions:
             )
 
         # Avoid empty spoken forms.
-        return list(x for x in spoken_forms if x)
+        return [x for x in spoken_forms if x]
 
     def create_spoken_forms_from_list(
         sources: list[str],

--- a/test/stubs/talon/__init__.py
+++ b/test/stubs/talon/__init__.py
@@ -134,6 +134,15 @@ class Context:
 
         return __funcwrapper
 
+    def capture(self, name: str, rule: str = None):
+        def __funcwrapper(func):
+            def __inner(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return __inner
+
+        return __funcwrapper
+
 
 class ImgUI:
     """
@@ -167,12 +176,30 @@ class Settings:
     """
 
 
+class Resource:
+    """
+    Implements something like the talon resource system
+    """
+
+    def open(self, path: str, mode: str = "r"):
+        return open(path, mode, encoding="utf-8")
+
+
+class App:
+    """
+    Implements something like the talon app variable
+    """
+
+    platform = "mac"
+
+
 actions = Actions()
-app = None
+app = App
 clip = None
 imgui = ImgUI()
 ui = UI()
 settings = Settings()
+resource = Resource()
 
 # Indicate to test files that they should load since we're running in test mode
 test_mode = True

--- a/test/test_create_spoken_forms.py
+++ b/test/test_create_spoken_forms.py
@@ -1,0 +1,119 @@
+import talon
+
+if hasattr(talon, "test_mode"):
+    # Only include this when we're running tests
+
+    import knausj_talon_pkg.core.create_spoken_forms
+    from talon import actions
+
+    import itertools
+
+    def test_excludes_words():
+        result = actions.user.create_spoken_forms(
+            "hi world",
+            ["world"],
+            0,
+            True
+        )
+
+        assert "world" not in result
+        assert "hi world" in result
+
+    def test_handles_empty_input():
+        result = actions.user.create_spoken_forms(
+            "",
+            None,
+            0,
+            True
+        )
+
+        assert result == []
+
+    def test_handles_minimum_term_length():
+        result = actions.user.create_spoken_forms(
+            "hi world",
+            None,
+            3,
+            True
+        )
+
+        assert "hi" not in result
+        assert "world" in result
+
+    def test_handles_generate_subsequences():
+        result = actions.user.create_spoken_forms(
+            "hi world",
+            None,
+            0,
+            False
+        )
+
+        assert "world" not in result
+        assert "hi world" in result
+
+    def test_expands_special_chars():
+        result = actions.user.create_spoken_forms(
+            "hi $world",
+            None,
+            0,
+            True
+        )
+
+        assert "hi dollar sign world" in result
+
+    def test_expands_file_extensions():
+        result = actions.user.create_spoken_forms(
+            "hi .cs",
+            None,
+            0,
+            True
+        )
+
+        assert "hi dot see sharp" in result
+
+    def test_properties():
+        """
+        Throw some random inputs at the function to make sure it behaves itself
+        """
+
+        def _example_generator():
+            pieces = ["hi", "world", "$", ".cs", "1900"]
+            params = list(
+                itertools.product(
+                    [None, ["world"], ["dot"]],  # Dot is from the expanded ".cs"
+                    [0, 3],
+                    [True, False]
+                )
+            )
+            count = 0
+            while True:
+                for exclude, min_count, subseq in params:
+                    for tokens in itertools.combinations(pieces, r=count):
+                        yield (tokens, exclude, min_count, subseq)
+                count += 1
+
+        examples = itertools.islice(_example_generator(), 0, 100)
+        for tokens, exclude, min_count, subseq in examples:
+            source = " ".join(tokens)
+            result = actions.user.create_spoken_forms(
+                source,
+                exclude,
+                min_count,
+                subseq
+            )
+
+            statement = f"create_spoken_forms(\"{source}\", {exclude}, {min_count}, {subseq})"
+
+            # No duplicates in result
+            assert len(result) == len(set(result)), statement
+
+            # No empty strings in result
+            assert "" not in result, statement
+
+            # Generates a form if we give it a non-empty input
+            if len(tokens) > 0:
+                assert len(result) >= 1, statement
+
+            # Generated forms at least as numerous as input if subseq is True
+            if subseq:
+                assert len(result) >= len(tokens), statement

--- a/test/test_create_spoken_forms.py
+++ b/test/test_create_spoken_forms.py
@@ -3,71 +3,41 @@ import talon
 if hasattr(talon, "test_mode"):
     # Only include this when we're running tests
 
+    import itertools
+
     import knausj_talon_pkg.core.create_spoken_forms
     from talon import actions
 
-    import itertools
-
     def test_excludes_words():
-        result = actions.user.create_spoken_forms(
-            "hi world",
-            ["world"],
-            0,
-            True
-        )
+        result = actions.user.create_spoken_forms("hi world", ["world"], 0, True)
 
         assert "world" not in result
         assert "hi world" in result
 
     def test_handles_empty_input():
-        result = actions.user.create_spoken_forms(
-            "",
-            None,
-            0,
-            True
-        )
+        result = actions.user.create_spoken_forms("", None, 0, True)
 
         assert result == []
 
     def test_handles_minimum_term_length():
-        result = actions.user.create_spoken_forms(
-            "hi world",
-            None,
-            3,
-            True
-        )
+        result = actions.user.create_spoken_forms("hi world", None, 3, True)
 
         assert "hi" not in result
         assert "world" in result
 
     def test_handles_generate_subsequences():
-        result = actions.user.create_spoken_forms(
-            "hi world",
-            None,
-            0,
-            False
-        )
+        result = actions.user.create_spoken_forms("hi world", None, 0, False)
 
         assert "world" not in result
         assert "hi world" in result
 
     def test_expands_special_chars():
-        result = actions.user.create_spoken_forms(
-            "hi $world",
-            None,
-            0,
-            True
-        )
+        result = actions.user.create_spoken_forms("hi $world", None, 0, True)
 
         assert "hi dollar sign world" in result
 
     def test_expands_file_extensions():
-        result = actions.user.create_spoken_forms(
-            "hi .cs",
-            None,
-            0,
-            True
-        )
+        result = actions.user.create_spoken_forms("hi .cs", None, 0, True)
 
         assert "hi dot see sharp" in result
 
@@ -82,7 +52,7 @@ if hasattr(talon, "test_mode"):
                 itertools.product(
                     [None, ["world"], ["dot"]],  # Dot is from the expanded ".cs"
                     [0, 3],
-                    [True, False]
+                    [True, False],
                 )
             )
             count = 0
@@ -96,13 +66,12 @@ if hasattr(talon, "test_mode"):
         for tokens, exclude, min_count, subseq in examples:
             source = " ".join(tokens)
             result = actions.user.create_spoken_forms(
-                source,
-                exclude,
-                min_count,
-                subseq
+                source, exclude, min_count, subseq
             )
 
-            statement = f"create_spoken_forms(\"{source}\", {exclude}, {min_count}, {subseq})"
+            statement = (
+                f'create_spoken_forms("{source}", {exclude}, {min_count}, {subseq})'
+            )
 
             # No duplicates in result
             assert len(result) == len(set(result)), statement


### PR DESCRIPTION
Currently `create_spoken_forms` can generate empty spoken forms if passed certain inputs (eg. the empty input). This prevents that, and also cleans up some code along the way.