### PR TITLE
end-anchor git diff command

### DIFF
--- a/apps/git/git.talon
+++ b/apps/git/git.talon
@@ -18,7 +18,7 @@ git stash [push] [<user.git_arguments>] message [<user.prose>]:
 git status$: "git status\n"
 git add patch$: "git add --patch\n"
 git show head$: "git show HEAD\n"
-git diff: "git diff\n"
+git diff$: "git diff\n"
 git diff (cached | cashed)$: "git diff --cached\n"
 
 # Convenience


### PR DESCRIPTION
The `git diff` command ought to be end-anchored, otherwise you can't follow it by another command (eg. `git diff say test` to produce "git diff test") as you can with the other optimistically executed git commands. I think I just forgot the end-anchor in my git.talon rewrite.