### PR TITLE
Change actions shortcuts in go_back and go_forward in Firefox mac

### DIFF
--- a/apps/firefox/firefox_mac.py
+++ b/apps/firefox/firefox_mac.py
@@ -28,10 +28,10 @@ class BrowserActions:
         actions.key("cmd-n")
 
     def go_back():
-        actions.key("cmd-left")
+        actions.key("cmd-[")
 
     def go_forward():
-        actions.key("cmd-right")
+        actions.key("cmd-]")
 
     def go_home():
         actions.key("cmd-shift-h")


### PR DESCRIPTION
When editing text `cmd-left` and `cmd-right` just move the cursor to the start or end of the line. `cmd-[` and `cmd-]` don't have that issue.