### PR TITLE
Deprecate `murder`, add `shuffle flipper` to i3wm

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,6 +7,7 @@ and merged.
 
 ---
 
+* 2023-01-04 Deprecate `murder` command for i3wm. Use 'win kill' instead.
 * 2022-12-11 Deprecate user.insert_with_history. Just use `user.add_phrase_to_history(text);
 insert(text)` instead. See #939.
 * 2022-10-01 Large refactoring of code base that moves many files into new locations. No

--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,7 +7,7 @@ and merged.
 
 ---
 
-* 2023-01-04 Deprecate `murder` command for i3wm. Use 'win kill' instead.
+* 2023-02-04 Deprecate `murder` command for i3wm. Use 'win kill' instead.
 * 2022-12-11 Deprecate user.insert_with_history. Just use `user.add_phrase_to_history(text);
 insert(text)` instead. See #939.
 * 2022-10-01 Large refactoring of code base that moves many files into new locations. No

--- a/apps/i3wm/i3wm.talon
+++ b/apps/i3wm/i3wm.talon
@@ -65,7 +65,8 @@ vertical (shell | terminal):
     user.system_command("i3-msg move container to workspace number 10")
 (shuffle | move (win | window) [to] last port):
     user.system_command("i3-msg move container to workspace back_and_forth")
-(shuffle|move) flipper: user.system_command("i3-msg move container to workspace back_and_forth")
+(shuffle | move) flipper:
+    user.system_command("i3-msg move container to workspace back_and_forth")
 (shuffle | move (win | window) left): user.system_command("i3-msg move left")
 (shuffle | move (win | window) right): user.system_command("i3-msg move right")
 (shuffle | move (win | window) up): user.system_command("i3-msg move up")

--- a/apps/i3wm/i3wm.talon
+++ b/apps/i3wm/i3wm.talon
@@ -1,9 +1,8 @@
-# NOTE: If you want to use i3wm you must enable the tag settings.talon. ex: `tag(): user.i3wm`
+# NOTE: If you want to use i3wm you must enable the tag settings.talon. i.e.: `tag(): user.i3wm`
 os: linux
 tag: user.i3wm
 -
 port <number_small>: user.system_command("i3-msg workspace number {number_small}")
-port ten: user.system_command("i3-msg workspace number 10")
 (port flip | flipper): user.system_command("i3-msg workspace back_and_forth")
 port right: user.system_command("i3-msg workspace next")
 port left: user.system_command("i3-msg workspace prev")
@@ -12,7 +11,7 @@ port left: user.system_command("i3-msg workspace prev")
 (win | window) right: user.system_command("i3-msg focus right")
 (win | window) up: user.system_command("i3-msg focus up")
 (win | window) down: user.system_command("i3-msg focus down")
-((win | window) kill | murder): user.system_command("i3-msg kill")
+(win | window) kill: user.system_command("i3-msg kill")
 (win | window) stacking: user.system_command("i3-msg layout stacking")
 (win | window) default: user.system_command("i3-msg layout toggle split")
 (win | window) tabbed: user.system_command("i3-msg layout tabbed")
@@ -66,6 +65,7 @@ vertical (shell | terminal):
     user.system_command("i3-msg move container to workspace number 10")
 (shuffle | move (win | window) [to] last port):
     user.system_command("i3-msg move container to workspace back_and_forth")
+(shuffle|move) flipper: user.system_command("i3-msg move container to workspace back_and_forth")
 (shuffle | move (win | window) left): user.system_command("i3-msg move left")
 (shuffle | move (win | window) right): user.system_command("i3-msg move right")
 (shuffle | move (win | window) up): user.system_command("i3-msg move up")
@@ -95,3 +95,7 @@ new scratch (shell | window):
     sleep(200ms)
     user.system_command("i3-msg move scratchpad")
     user.system_command("i3-msg scratchpad show")
+
+murder:
+    user.deprecate_command("2023-01-04", "murder", "win kill")
+    user.system_command("i3-msg kill")

--- a/apps/i3wm/i3wm.talon
+++ b/apps/i3wm/i3wm.talon
@@ -61,8 +61,6 @@ vertical (shell | terminal):
 # XXX - like also need to match the generic talon commands
 (shuffle | move (win | window) [to] port) <number_small>:
     user.system_command("i3-msg move container to workspace number {number_small}")
-(shuffle | move (win | window) [to] port ten):
-    user.system_command("i3-msg move container to workspace number 10")
 (shuffle | move (win | window) [to] last port):
     user.system_command("i3-msg move container to workspace back_and_forth")
 (shuffle | move) flipper:
@@ -98,5 +96,5 @@ new scratch (shell | window):
     user.system_command("i3-msg scratchpad show")
 
 murder:
-    user.deprecate_command("2023-01-04", "murder", "win kill")
+    user.deprecate_command("2023-02-04", "murder", "win kill")
     user.system_command("i3-msg kill")


### PR DESCRIPTION
Also remove redundant 'port ten' command.

Replaces #928 