### PR TITLE
Improve `edit.select_word()`

### DIFF
--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -3,6 +3,10 @@ from talon import Context, Module, actions, clip
 ctx = Context()
 mod = Module()
 
+PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD = \
+    ['.', '!', '?', ';', ':', '—', '_', '/', '\\', '|',
+     '@', '#', '$', '%', '^', '&', '*', '(', ')', '[', ']',
+     '{', '}', '<', '>', '=', '+', '-', '~', '`']
 
 @ctx.action_class("edit")
 class EditActions:
@@ -31,6 +35,18 @@ class EditActions:
         actions.edit.right()
         actions.key("enter")
         actions.edit.paste()
+
+    def select_word():
+        actions.edit.extend_right()
+        character_to_right_of_initial_caret_position = actions.edit.selected_text()
+        actions.edit.left()  # in order to return to original caret position
+
+        if (character_to_right_of_initial_caret_position in
+                PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD):
+            actions.edit.extend_word_left()
+        else:
+            actions.edit.word_right()
+            actions.edit.extend_word_left()
 
 
 @mod.action_class

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -39,7 +39,7 @@ class EditActions:
     def select_word():
         actions.edit.extend_right()
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
-        actions.edit.left()  # in order to return to original caret position
+        actions.edit.left()
 
         if (character_to_right_of_initial_caret_position in
                 PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD):

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -77,11 +77,11 @@ class EditActions:
         did_select_text = character_to_right_of_initial_caret_position != ""
 
         if did_select_text:
-        
+
             # .strip() is to handle newline characters which become an empty string.
             if (
-                (character_to_right_of_initial_caret_position.strip()
-                    in SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD)
+                character_to_right_of_initial_caret_position.strip()
+                in SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD
             ):
                 # Come out of the highlight in the initial position.
                 actions.edit.left()

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -72,24 +72,25 @@ class EditActions:
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
 
         # Occasionally apps won't let you edit.extend_right()
-        # if your caret is on the rightmost character such as in the Chrome URL bar
-        if character_to_right_of_initial_caret_position != '':
-            actions.edit.left()
+        # and therefore won't select text if your caret is on the rightmost character
+        # such as in the Chrome URL bar
+        did_select_text = character_to_right_of_initial_caret_position != ''
 
         # .strip() is to handle newline characters which become an empty string.
-        if (
-            character_to_right_of_initial_caret_position.strip()
-            in PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD
-        ):
-            # The reason we don't extend directly left
-            # even though we are on the right edge of a word
-            # is that there may be a symbol to the left that it would be
-            # preferable to leave out by going far to the left and extending right
-            actions.edit.word_left()
-            actions.edit.extend_word_right()
-        else:
-            actions.edit.word_right()
-            actions.edit.extend_word_left()
+        if did_select_text:
+            if (
+                (character_to_right_of_initial_caret_position.strip()
+                    in PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD)
+            ):
+                # Come out of the highlight in the initial position.
+                actions.edit.left()
+            else:
+                # Come out of the highlight one character
+                # to the right of the initial position.
+                actions.edit.right()
+
+        actions.edit.word_left()
+        actions.edit.extend_word_right()
 
 
 @mod.action_class

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -6,7 +6,7 @@ mod = Module()
 PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD = \
     ['.', '!', '?', ';', ':', '—', '_', '/', '\\', '|',
      '@', '#', '$', '%', '^', '&', '*', '(', ')', '[', ']',
-     '{', '}', '<', '>', '=', '+', '-', '~', '`']
+     '{', '}', '<', '>', '=', '+', '-', '~', '`', ' ']
 
 @ctx.action_class("edit")
 class EditActions:

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -71,12 +71,14 @@ class EditActions:
         actions.edit.extend_right()
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
 
+        # Always go left immediately so highlighting doesn't have time to be shown
+        # to end user even if we might not have selected anything.
+        actions.edit.left()
+
         # Occasionally apps won't let you edit.extend_right()
         # if your caret is on the rightmost character such as in the Chrome URL bar
-        # Thus, only go back to our original position if we managed to
-        # extend_right() successfully
-        if len(character_to_right_of_initial_caret_position) > 0:
-            actions.edit.left()
+        if len(character_to_right_of_initial_caret_position) == 0:
+            actions.edit.right()
 
         # .strip() is to handle newline characters which become an empty string.
         if (

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -39,7 +39,13 @@ class EditActions:
     def select_word():
         actions.edit.extend_right()
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
-        actions.edit.left()
+
+        # Occasionally apps won't let you edit.extend_right()
+        # if your caret is on the rightmost character such as in the Chrome URL bar
+        # Thus, only go back to our original position if we managed to
+        # extend_right() successfully
+        if len(character_to_right_of_initial_caret_position) > 0:
+            actions.edit.left()
 
         # .strip() is to handle newline characters which become an empty string.
         if (character_to_right_of_initial_caret_position.strip() in

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -85,10 +85,16 @@ class EditActions:
             character_to_right_of_initial_caret_position.strip()
             in PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD
         ):
-            actions.edit.extend_word_left()
+            # The reason we don't extend directly left
+            # even though we are on the right edge of a word
+            # is that there may be a comma to the left that it would be
+            # preferable to skip by going left and extending right
+            actions.edit.word_left()
+            actions.edit.extend_word_right()
         else:
             actions.edit.word_right()
             actions.edit.extend_word_left()
+
 
 
 @mod.action_class

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -3,41 +3,7 @@ from talon import Context, Module, actions, clip
 ctx = Context()
 mod = Module()
 
-SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD = [
-    ".",
-    "!",
-    "?",
-    ";",
-    ":",
-    "—",
-    "_",
-    "/",
-    "\\",
-    "|",
-    "@",
-    "#",
-    "$",
-    "%",
-    "^",
-    "&",
-    "*",
-    "(",
-    ")",
-    "[",
-    "]",
-    "{",
-    "}",
-    "<",
-    ">",
-    "=",
-    "+",
-    "-",
-    "~",
-    "`",
-    " ",
-    "",
-]
-
+END_OF_WORD_SYMBOLS = ".!?;:—_/\\|@#$%^&*()[]{}<>=+-~`"
 
 @ctx.action_class("edit")
 class EditActions:
@@ -67,6 +33,13 @@ class EditActions:
         actions.key("enter")
         actions.edit.paste()
 
+    # # This simpler implementation of select_word mostly works, but in some apps it doesn't.
+    # # See https://github.com/knausj85/knausj_talon/issues/1084.
+    # def select_word():
+    #     actions.edit.right()
+    #     actions.edit.word_left()
+    #     actions.edit.extend_word_right()
+
     def select_word():
         actions.edit.extend_right()
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
@@ -77,11 +50,11 @@ class EditActions:
         did_select_text = character_to_right_of_initial_caret_position != ""
 
         if did_select_text:
-
-            # .strip() is to handle newline characters which become an empty string.
+            # .strip() turns newline & space characters into empty string; the empty
+            # string is in any other string, so this works.
             if (
                 character_to_right_of_initial_caret_position.strip()
-                in SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD
+                in END_OF_WORD_SYMBOLS
             ):
                 # Come out of the highlight in the initial position.
                 actions.edit.left()

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -76,8 +76,9 @@ class EditActions:
         # such as in the Chrome URL bar
         did_select_text = character_to_right_of_initial_caret_position != ""
 
-        # .strip() is to handle newline characters which become an empty string.
         if did_select_text:
+        
+            # .strip() is to handle newline characters which become an empty string.
             if (
                 (character_to_right_of_initial_caret_position.strip()
                     in SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD)

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -5,6 +5,7 @@ mod = Module()
 
 END_OF_WORD_SYMBOLS = ".!?;:—_/\\|@#$%^&*()[]{}<>=+-~`"
 
+
 @ctx.action_class("edit")
 class EditActions:
     def selected_text() -> str:

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -71,14 +71,10 @@ class EditActions:
         actions.edit.extend_right()
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
 
-        # Always go left immediately so highlighting doesn't have time to be shown
-        # to end user even if we might not have selected anything.
-        actions.edit.left()
-
         # Occasionally apps won't let you edit.extend_right()
         # if your caret is on the rightmost character such as in the Chrome URL bar
-        if len(character_to_right_of_initial_caret_position) == 0:
-            actions.edit.right()
+        if character_to_right_of_initial_caret_position != '':
+            actions.edit.left()
 
         # .strip() is to handle newline characters which become an empty string.
         if (
@@ -87,8 +83,8 @@ class EditActions:
         ):
             # The reason we don't extend directly left
             # even though we are on the right edge of a word
-            # is that there may be a comma to the left that it would be
-            # preferable to skip by going left and extending right
+            # is that there may be a symbol to the left that it would be
+            # preferable to leave out by going far to the left and extending right
             actions.edit.word_left()
             actions.edit.extend_word_right()
         else:

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -41,7 +41,7 @@ class EditActions:
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
         actions.edit.left()
 
-        # .strip() is to handle newline characters
+        # .strip() is to handle newline characters which become an empty string.
         if (character_to_right_of_initial_caret_position.strip() in
                 PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD):
             actions.edit.extend_word_left()

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -6,7 +6,7 @@ mod = Module()
 PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD = \
     ['.', '!', '?', ';', ':', '—', '_', '/', '\\', '|',
      '@', '#', '$', '%', '^', '&', '*', '(', ')', '[', ']',
-     '{', '}', '<', '>', '=', '+', '-', '~', '`', ' ']
+     '{', '}', '<', '>', '=', '+', '-', '~', '`', ' ', '']
 
 @ctx.action_class("edit")
 class EditActions:
@@ -41,7 +41,8 @@ class EditActions:
         character_to_right_of_initial_caret_position = actions.edit.selected_text()
         actions.edit.left()
 
-        if (character_to_right_of_initial_caret_position in
+        # .strip() is to handle newline characters
+        if (character_to_right_of_initial_caret_position.strip() in
                 PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD):
             actions.edit.extend_word_left()
         else:

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -3,7 +3,7 @@ from talon import Context, Module, actions, clip
 ctx = Context()
 mod = Module()
 
-PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD = [
+SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD = [
     ".",
     "!",
     "?",
@@ -80,7 +80,7 @@ class EditActions:
         if did_select_text:
             if (
                 (character_to_right_of_initial_caret_position.strip()
-                    in PUNCTUATION_SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD)
+                    in SYMBOLS_WHICH_SIGNIFY_THE_END_OF_A_WORD)
             ):
                 # Come out of the highlight in the initial position.
                 actions.edit.left()

--- a/core/edit/edit_linux.py
+++ b/core/edit/edit_linux.py
@@ -169,11 +169,6 @@ class EditActions:
         # action(edit.select_paragraph):
         # action(edit.select_sentence):
 
-    def select_word():
-        actions.edit.right()
-        actions.edit.word_left()
-        actions.edit.extend_word_right()
-
     def undo():
         actions.key("ctrl-z")
 

--- a/core/edit/edit_mac.py
+++ b/core/edit/edit_mac.py
@@ -171,11 +171,6 @@ class EditActions:
         # action(edit.select_paragraph):
         # action(edit.select_sentence):
 
-    def select_word():
-        actions.edit.right()
-        actions.edit.word_left()
-        actions.edit.extend_word_right()
-
     def undo():
         actions.key("cmd-z")
 

--- a/core/edit/edit_win.py
+++ b/core/edit/edit_win.py
@@ -169,11 +169,6 @@ class EditActions:
         # action(edit.select_paragraph):
         # action(edit.select_sentence):
 
-    def select_word():
-        actions.edit.right()
-        actions.edit.word_left()
-        actions.edit.extend_word_right()
-
     def undo():
         actions.key("ctrl-z")
 


### PR DESCRIPTION
`select_word()` has several issues as per https://github.com/knausj85/knausj_talon/issues/1084.

Notably accidental selection of symbols and word selection breaking if the caret is before a new line.

This pull request aims to resolve these.

Note: This is only tested on MacOS, though it uses higher level functions for all operations, so I don't foresee any major issues on other operating systems.
