### PR TITLE
alternate capitalization for windows_explorer app.exe

### DIFF
--- a/apps/windows_explorer/windows_explorer.py
+++ b/apps/windows_explorer/windows_explorer.py
@@ -12,6 +12,8 @@ os: windows
 and app.name: Windows-Explorer
 os: windows
 and app.exe: explorer.exe
+os: windows
+and app.exe: Explorer.EXE
 """
 
 # many commands should work in most save/open dialog.

--- a/apps/windows_explorer/windows_explorer.py
+++ b/apps/windows_explorer/windows_explorer.py
@@ -11,9 +11,7 @@ and app.name: Windows Explorer
 os: windows
 and app.name: Windows-Explorer
 os: windows
-and app.exe: explorer.exe
-os: windows
-and app.exe: Explorer.EXE
+and app.exe: /explorer.exe/i
 """
 
 # many commands should work in most save/open dialog.


### PR DESCRIPTION
Issue [called out in slack](https://talonvoice.slack.com/archives/CJ2EE3LEB/p1673705822738799) by user Gabriele. 

On their Windows 10 machine and my Windows 11 machine, app.exe for windows explorer is cased as "Explorer.EXE".

On non english machines, the title may not match the English "Windows Explorer", and so having an accurate exe matcher is essential.

Testing: I confirmed on my Windows 11 machine that (if I remove the app.name matchers), the context matches with the new capitalization, but not with the old capitalization.