### PR TITLE
formatters use 'numb' AND now 'numeral' to trigger numerals

### DIFF
--- a/core/text/formatters.py
+++ b/core/text/formatters.py
@@ -199,7 +199,7 @@ class ImmuneString:
 @mod.capture(
     # Add anything else into this that you want to be able to speak during a
     # formatter.
-    rule="(<user.symbol_key> | numb <number>)"
+    rule="(<user.symbol_key> | (numb | numeral) <number>)"
 )
 def formatter_immune(m) -> ImmuneString:
     """Text that can be interspersed into a formatter, e.g. characters.


### PR DESCRIPTION
Non-formatter dictation (say/sentence commands, dictation mode) [uses "numeral"](https://github.com/knausj85/knausj_talon/blob/c830318a4aa96d3855e537c576fc79a5641aa98c/core/text/text_and_dictation.py#L44-L56) to trigger use of numerals, so I thought it would be nice for formatters to support "numeral" as well.

I'm not sure what you want to do about formatters also supporting the word numb.  Maybe 'say' and formatters should only use 'num' but I went with a minimally disruptive change until I get feedback.