### PR TITLE
Remove line length argument to `talonfmt` in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         files: \.talon$
         args: ["--whitespaces-count=4"]
   - repo: https://github.com/wenkokke/talonfmt
-    rev: 1.8.1
+    rev: 1.9.0
     hooks:
       - id: talonfmt
-        args: ["--in-place", "--max-line-width=88"]
+        args: ["--in-place"]


### PR DESCRIPTION
Now that `talonfmt` respects `.editorconfig` (https://github.com/wenkokke/talonfmt/issues/57 / https://github.com/wenkokke/talonfmt/commit/de8d338fb71857967e43513501abbd261a5f5e94), we shouldn't need to add the line length as an argument to pre-commit