### PR TITLE
Add Google Chrome Canary support on Mac

### DIFF
--- a/apps/chrome/chrome_mac.py
+++ b/apps/chrome/chrome_mac.py
@@ -5,6 +5,7 @@ ctx = Context()
 ctx.matches = r"""
 os: mac
 app: chrome
+app: com.google.Chrome.canary
 """
 ctx.tags = ["browser", "user.tabs"]
 


### PR DESCRIPTION
Adds `app: com.google.Chrome.canary` 