### PR TITLE
add lists, link, more code block options; improve level

### DIFF
--- a/lang/markdown/markdown.py
+++ b/lang/markdown/markdown.py
@@ -8,4 +8,8 @@ ctx.lists["user.markdown_code_block_language"] = {
     "typescript": "typescript",
     "python": "python",
     "code": "",
+    "ruby": "ruby",
+    "shell": "shell",
+    "bash": "bash",
+    "json": "json"
 }

--- a/lang/markdown/markdown.py
+++ b/lang/markdown/markdown.py
@@ -11,5 +11,5 @@ ctx.lists["user.markdown_code_block_language"] = {
     "ruby": "ruby",
     "shell": "shell",
     "bash": "bash",
-    "json": "json"
+    "json": "json",
 }

--- a/lang/markdown/markdown.talon
+++ b/lang/markdown/markdown.talon
@@ -1,14 +1,49 @@
 tag: user.markdown
 -
-level one: "# "
-level two: "## "
-level three: "### "
-level four: "#### "
-level five: "##### "
-level six: "###### "
+(level | heading | header) one:
+    edit.line_start()
+    "# "
+(level | heading | header) two:
+    edit.line_start()
+    "## "
+(level | heading | header) three:
+    edit.line_start()
+    "### "
+(level | heading | header) four:
+    edit.line_start()
+    "#### "
+(level | heading | header) five:
+    edit.line_start()
+    "##### "
+(level | heading | header) six:
+    edit.line_start()
+    "###### "
+
+list [one]:
+    edit.line_start()
+    "- "
+list two:
+    edit.line_start()
+    "    - "
+list three:
+    edit.line_start()
+    "        - "
+list four:
+    edit.line_start()
+    "            - "
+list five:
+    edit.line_start()
+    "                - "
+list six:
+    edit.line_start()
+    "                    - "
 
 {user.markdown_code_block_language} block:
     "```{markdown_code_block_language}"
     key(enter:2)
     "```"
     key(up)
+
+link:
+    "[]()"
+    key(left:3)


### PR DESCRIPTION
Markdown
* add `heading` or `header` alternatives for `level`
* fix `level` to edit at line start
* add `list` commands
* add `link` command
* add more code block languages: `ruby`, `shell`, `bash`, `json`
