### PR TITLE
Detect Chromium as a browser under Manjaro Linux

### DIFF
--- a/apps/chrome/chrome.py
+++ b/apps/chrome/chrome.py
@@ -20,6 +20,7 @@ mod.apps.chrome = """
 os: linux
 app.exe: chrome
 app.exe: chromium-browser
+app.exe: chromium
 """
 mod.apps.chrome = """
 os: linux


### PR DESCRIPTION
On my Manjaro Linux machine, the browser Chromium appears with a executable name which is not yet recognized by `chrome.py`. This pull request makes chromium detect correctly for me.

As a side note: since multiple tags are connected by `or`, shouldn't the entire context match block for Linux be something like
```
os: linux
and app.exe: chrome
os: linux
and app.exe: chromium-browser
os: linux
and app.exe: chromium
```
Also, IMO the subsequent block could also be included (lines 25-28) in this, thus joining all `os: linux` matchers. 

If you agree, I'll gladly amend this in this PR.