### PR TITLE
fix: Only pop to click when you have an eye tracker

### DIFF
--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -250,9 +250,9 @@ def show_cursor_helper(show):
 def on_pop(_active):
     # Only want the pop noise to click when we're using an eye tracker
     is_using_eye_tracker = (
-        actions.tracking.control_zoom_enabled() or
-        actions.tracking.control_enabled() or
-        actions.tracking.control1_enabled()
+        actions.tracking.control_zoom_enabled()
+        or actions.tracking.control_enabled()
+        or actions.tracking.control1_enabled()
     )
 
     if setting_mouse_enable_pop_stops_scroll.get() >= 1 and (gaze_job or scroll_job):

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -247,10 +247,17 @@ def show_cursor_helper(show):
         ctrl.cursor_visible(show)
 
 
-def on_pop(active):
+def on_pop(_active):
+    # Only want the pop noise to click when we're using an eye tracker
+    is_using_eye_tracker = (
+        actions.tracking.control_zoom_enabled() or
+        actions.tracking.control_enabled() or
+        actions.tracking.control1_enabled()
+    )
+
     if setting_mouse_enable_pop_stops_scroll.get() >= 1 and (gaze_job or scroll_job):
         stop_scroll()
-    elif not actions.tracking.control_zoom_enabled():
+    elif is_using_eye_tracker and not actions.tracking.control_zoom_enabled():
         if setting_mouse_enable_pop_click.get() >= 1:
             ctrl.mouse_click(button=0, hold=16000)
 


### PR DESCRIPTION
Fixes regression from this PR:
https://github.com/knausj85/knausj_talon/pull/1095/files#diff-bcc9a76bafcd0560a68b01c7c397581731a565bba524207313dbe16c972a80eeL254

Note that I don't have an eye tracker. So we need somebody with one to test pop to click still works when using control mouse and the legacy control mouse.