### PR TITLE
Add tab search command similar to firefox.talon

### DIFF
--- a/apps/chrome/chrome.talon
+++ b/apps/chrome/chrome.talon
@@ -1,9 +1,7 @@
 app: chrome
 -
-tag(): browser
 profile switch: user.chrome_mod("shift-m")
 
-tag(): user.tabs
 tab search: user.chrome_mod("shift-a")
 
 tab search <user.text>$:

--- a/apps/chrome/chrome.talon
+++ b/apps/chrome/chrome.talon
@@ -1,1 +1,15 @@
+app: chrome
+-
+tag(): browser
 profile switch: user.chrome_mod("shift-m")
+
+tag(): user.tabs
+tab search:
+    user.chrome_mod("shift-a")
+
+tab search <user.text>$:
+    user.chrome_mod("shift-a")
+    sleep(200ms)
+    insert("{text}")
+    key(down)
+

--- a/apps/chrome/chrome.talon
+++ b/apps/chrome/chrome.talon
@@ -4,12 +4,10 @@ tag(): browser
 profile switch: user.chrome_mod("shift-m")
 
 tag(): user.tabs
-tab search:
-    user.chrome_mod("shift-a")
+tab search: user.chrome_mod("shift-a")
 
 tab search <user.text>$:
     user.chrome_mod("shift-a")
     sleep(200ms)
     insert("{text}")
     key(down)
-


### PR DESCRIPTION
Tab search command via ctrl/cmd + shift + A

There's already an implementation for firefox that uses the address bar, this pull request mimics that for Chrome