### PR TITLE
on_pop requires mouse control to be active

### DIFF
--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -250,7 +250,10 @@ def show_cursor_helper(show):
 def on_pop(active):
     if setting_mouse_enable_pop_stops_scroll.get() >= 1 and (gaze_job or scroll_job):
         stop_scroll()
-    elif not actions.tracking.control_zoom_enabled():
+    elif (
+        actions.tracking.control1_enabled()
+        and not actions.tracking.control_zoom_enabled()
+    ):
         if setting_mouse_enable_pop_click.get() >= 1:
             ctrl.mouse_click(button=0, hold=16000)
 


### PR DESCRIPTION
Before this fix, pop to click would work even if you were not controlling the mouse.  I don't understand why `not actions.tracking.control_zoom_enabled()` was there before, so it just kept it.