### PR TITLE
feat(#755) Pop to click setting for all users

### DIFF
--- a/core/noise.py
+++ b/core/noise.py
@@ -2,8 +2,7 @@
 Map noises (like pop) to actions so they can have contextually differing behavior
 """
 
-from talon import Module, noise, actions
-
+from talon import Module, actions, noise
 
 mod = Module()
 

--- a/core/noise.py
+++ b/core/noise.py
@@ -1,0 +1,21 @@
+"""
+Map noises (like pop) to actions so they can have contextually differing behavior
+"""
+
+from talon import Module, noise, actions
+
+
+mod = Module()
+
+
+@mod.action_class
+class Actions:
+    def noise_trigger_pop():
+        """
+        Called when the user makes a 'pop' noise. Listen to
+        https://noise.talonvoice.com/static/previews/pop.mp3 for an
+        example.
+        """
+
+
+noise.register("pop", lambda _: actions.user.noise_trigger_pop())

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -50,7 +50,7 @@ setting_mouse_enable_pop_click = mod.setting(
     "mouse_enable_pop_click",
     type=int,
     default=0,
-    desc="Pop noise clicks left mouse button. 0 = off, 1 = on with eyetracker but not zoom mode, 2 = on",
+    desc="Pop noise clicks left mouse button. 0 = off, 1 = on with eyetracker but not with zoom mouse mode, 2 = on but not with zoom mouse mode",
 )
 setting_mouse_enable_pop_stops_scroll = mod.setting(
     "mouse_enable_pop_stops_scroll",

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -1,6 +1,6 @@
 import os
 
-from talon import Module, actions, app, clip, cron, ctrl, imgui, noise, ui
+from talon import Module, Context, actions, app, clip, cron, ctrl, imgui, ui
 from talon_plugins import eye_zoom_mouse
 
 key = actions.key
@@ -38,6 +38,8 @@ hidden_cursor = os.path.join(
 )
 
 mod = Module()
+ctx = Context()
+
 mod.list(
     "mouse_button", desc="List of mouse button words to mouse_click index parameter"
 )
@@ -247,7 +249,8 @@ def show_cursor_helper(show):
         ctrl.cursor_visible(show)
 
 
-def on_pop(_active):
+@ctx.action("user.noise_trigger_pop")
+def on_pop():
     # Only want the pop noise to click when we're using an eye tracker
     is_using_eye_tracker = (
         actions.tracking.control_zoom_enabled()
@@ -260,9 +263,6 @@ def on_pop(_active):
     elif is_using_eye_tracker and not actions.tracking.control_zoom_enabled():
         if setting_mouse_enable_pop_click.get() >= 1:
             ctrl.mouse_click(button=0, hold=16000)
-
-
-noise.register("pop", on_pop)
 
 
 def mouse_scroll(amount):

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -1,6 +1,6 @@
 import os
 
-from talon import Module, Context, actions, app, clip, cron, ctrl, imgui, ui
+from talon import Context, Module, actions, app, clip, cron, ctrl, imgui, ui
 from talon_plugins import eye_zoom_mouse
 
 key = actions.key
@@ -263,13 +263,10 @@ def on_pop():
             or actions.tracking.control_enabled()
             or actions.tracking.control1_enabled()
         )
-        should_click = (
-            setting_val == 2 or
-            (
-                setting_val == 1 and
-                is_using_eye_tracker and
-                not actions.tracking.control_zoom_enabled()
-            )
+        should_click = setting_val == 2 or (
+            setting_val == 1
+            and is_using_eye_tracker
+            and not actions.tracking.control_zoom_enabled()
         )
         if should_click:
             ctrl.mouse_click(button=0, hold=16000)

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -263,7 +263,9 @@ def on_pop():
             or actions.tracking.control_enabled()
             or actions.tracking.control1_enabled()
         )
-        should_click = setting_val == 2 or (
+        should_click = (
+            setting_val == 2 and not actions.tracking.control_zoom_enabled()
+        ) or (
             setting_val == 1
             and is_using_eye_tracker
             and not actions.tracking.control_zoom_enabled()

--- a/settings.talon
+++ b/settings.talon
@@ -20,8 +20,8 @@ settings():
 
     # Enable pop click with 'control mouse' mode.
     # 0 = off
-    # 1 = on with eyetracker but not zoom mode
-    # 2 = on
+    # 1 = on with eyetracker but not zoom mouse mode
+    # 2 = on but not with zoom mouse mode
     user.mouse_enable_pop_click = 1
 
     # When enabled, the 'Scroll Mouse' GUI will not be shown.

--- a/settings.talon
+++ b/settings.talon
@@ -18,8 +18,11 @@ settings():
     # Stop continuous scroll/gaze scroll with a pop
     user.mouse_enable_pop_stops_scroll = 1
 
-    # Enable pop click with 'control mouse' mode
-    user.mouse_enable_pop_click = 1
+    # Enable pop click with 'control mouse' mode.
+    # 0 = off
+    # 1 = on with eyetracker but not zoom mode
+    # 2 = on
+    user.mouse_enable_pop_click = 2
 
     # When enabled, the 'Scroll Mouse' GUI will not be shown.
     user.mouse_hide_mouse_gui = 0

--- a/settings.talon
+++ b/settings.talon
@@ -22,7 +22,7 @@ settings():
     # 0 = off
     # 1 = on with eyetracker but not zoom mode
     # 2 = on
-    user.mouse_enable_pop_click = 2
+    user.mouse_enable_pop_click = 1
 
     # When enabled, the 'Scroll Mouse' GUI will not be shown.
     user.mouse_hide_mouse_gui = 0


### PR DESCRIPTION
This PR addresses #755 and replaces #858 . It does two things:

1. The pop noise triggers an action `user.noise_trigger_pop`.
2. The existing setting `user.mouse_enable_pop_click` gets a third value '2' which says always pop to click.

The first point lets people 'take over' the pop noise so they don't have to worry about whatever knausj talon is doing with it. It also provides a nice scaffold in case you want it to do different things in different contexts.

The second point differs a bit from the pop_click = yes/no boolean discussed in #755 . This is for backwards compatibility. With a yes/no setting I'd either have to turn it on by default for people without eye trackers (i.e. undo https://github.com/knausj85/knausj_talon/pull/1119) or turn it off and break the expected behaviour for most eyetracker users. If I figured out a way to conditionally enable the setting when an eye tracker was on (not trivial given how you have to check for this) then this would break for eyetracker users who had turned the setting off because they didn't want pop to click.

Hopefully the addition of a new value is simple enough for people to use if they want pop to click in a non-eyetracker context.

