### PR TITLE
feat: Allow abbreviation customisation via settings/abbreviations.csv

### DIFF
--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -250,14 +250,12 @@ abbreviations = {
     "work in progress": "wip",
 }
 
-
-def get_abbreviations_list():
-    return get_list_from_csv(
-        "abbreviations.csv",
-        headers=("Abbreviation", "Spoken Form"),
-        default=abbreviations,
-    )
-
+# This variable is also considered exported for the create_spoken_forms module
+abbreviations_list = get_list_from_csv(
+    "abbreviations.csv",
+    headers=("Abbreviation", "Spoken Form"),
+    default=abbreviations,
+)
 
 ctx = Context()
-ctx.lists["user.abbreviation"] = get_abbreviations_list()
+ctx.lists["user.abbreviation"] = abbreviations_list

--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -1,12 +1,11 @@
 # XXX - would be nice to be able pipe these through formatters
 
 from talon import Context, Module
+from ..user_settings import get_list_from_csv
 
 mod = Module()
 mod.list("abbreviation", desc="Common abbreviation")
 
-# TODO: Make this a csv file. Not necessarily a settings/ csv file, it might be
-# better to be like homophones.csv.
 abbreviations = {
     "abbreviate": "abbr",
     "address": "addr",
@@ -251,4 +250,8 @@ abbreviations = {
 }
 
 ctx = Context()
-ctx.lists["user.abbreviation"] = abbreviations
+ctx.lists["user.abbreviation"] = get_list_from_csv(
+    "abbreviations.csv",
+    headers=("Abbreviation", "Spoken Form"),
+    default=abbreviations,
+)

--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -1,6 +1,7 @@
 # XXX - would be nice to be able pipe these through formatters
 
 from talon import Context, Module
+
 from ..user_settings import get_list_from_csv
 
 mod = Module()

--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -250,12 +250,14 @@ abbreviations = {
     "work in progress": "wip",
 }
 
+
 def get_abbreviations_list():
     return get_list_from_csv(
         "abbreviations.csv",
         headers=("Abbreviation", "Spoken Form"),
         default=abbreviations,
     )
+
 
 ctx = Context()
 ctx.lists["user.abbreviation"] = get_abbreviations_list()

--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -250,9 +250,12 @@ abbreviations = {
     "work in progress": "wip",
 }
 
+def get_abbreviations_list():
+    return get_list_from_csv(
+        "abbreviations.csv",
+        headers=("Abbreviation", "Spoken Form"),
+        default=abbreviations,
+    )
+
 ctx = Context()
-ctx.lists["user.abbreviation"] = get_list_from_csv(
-    "abbreviations.csv",
-    headers=("Abbreviation", "Spoken Form"),
-    default=abbreviations,
-)
+ctx.lists["user.abbreviation"] = get_abbreviations_list()

--- a/core/create_spoken_forms.py
+++ b/core/create_spoken_forms.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping, Optional
 
 from talon import Module, actions
 
-from .abbreviate.abbreviate import get_abbreviations_list
+from .abbreviate.abbreviate import abbreviations_list
 from .file_extension.file_extension import file_extensions
 from .keys.keys import symbol_key_words
 from .numbers.numbers import digits_map, scales, teens, tens
@@ -39,7 +39,7 @@ REGEX_WITH_SYMBOLS = re.compile(
 )
 
 REVERSE_PRONUNCIATION_MAP = {
-    **{value: key for key, value in get_abbreviations_list().items()},
+    **{value: key for key, value in abbreviations_list.items()},
     **{value.strip(): key for key, value in file_extensions.items()},
     **{str(value): key for key, value in digits_map.items()},
     **{value: key for key, value in symbol_key_words.items()},

--- a/core/create_spoken_forms.py
+++ b/core/create_spoken_forms.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping, Optional
 
 from talon import Module, actions
 
-from .abbreviate.abbreviate import abbreviations
+from .abbreviate.abbreviate import get_abbreviations_list
 from .file_extension.file_extension import file_extensions
 from .keys.keys import symbol_key_words
 from .numbers.numbers import digits_map, scales, teens, tens
@@ -39,7 +39,7 @@ REGEX_WITH_SYMBOLS = re.compile(
 )
 
 REVERSE_PRONUNCIATION_MAP = {
-    **{value: key for key, value in abbreviations.items()},
+    **{value: key for key, value in get_abbreviations_list().items()},
     **{value.strip(): key for key, value in file_extensions.items()},
     **{str(value): key for key, value in digits_map.items()},
     **{value: key for key, value in symbol_key_words.items()},


### PR DESCRIPTION
This PR implements the results of the discussion in #1048 (and replaces that PR); it seems worthwhile to have abbreviations in the settings/*.csv system.