### PR TITLE
Fix issue with alt-d not always focusing address bar in Firefox Windows

### DIFF
--- a/apps/firefox/firefox.py
+++ b/apps/firefox/firefox.py
@@ -18,24 +18,21 @@ and app.bundle: org.mozilla.firefox
 """
 
 ctx.matches = r"""
+os: windows
+os: linux
+os: mac
+tag: browser
 app: firefox
 """
-
-cmd_ctrl = "cmd" if app.platform == "mac" else "ctrl"
 
 
 @mod.action_class
 class Actions:
     def firefox_bookmarks_sidebar():
         """Toggles the Firefox bookmark sidebar"""
-        actions.key(f"{cmd_ctrl}-b")
 
     def firefox_history_sidebar():
         """Toggles the Firefox history sidebar"""
-        if app.platform == "mac":
-            actions.key("cmd-shift-h")
-        else:
-            actions.key("ctrl-h")
 
 
 @ctx.action_class("user")
@@ -47,19 +44,6 @@ class UserActions:
 
 @ctx.action_class("browser")
 class BrowserActions:
-    def bookmarks():
-        actions.key(f"{cmd_ctrl}-shift-o")
-
-    def focus_address():
-        if app.platform == "mac":
-            actions.key("cmd-l")
-        else:
-            # Only using "ctrl-l" might fail and clear the console if the user
-            # is focused in the devtools
-            actions.key("f6")
-            actions.sleep("100ms")
-            actions.key("ctrl-l")
-
     def focus_page():
         actions.browser.focus_address()
         actions.edit.find()
@@ -68,21 +52,3 @@ class BrowserActions:
 
     def go_home():
         actions.key("alt-home")
-
-    def open_private_window():
-        actions.key(f"{cmd_ctrl}-shift-p")
-
-    def show_downloads():
-        if app.platform == "linux":
-            actions.key("ctrl-shift-y")
-        else:
-            actions.key(f"{cmd_ctrl}-j")
-
-    def show_extensions():
-        actions.key(f"{cmd_ctrl}-shift-a")
-
-    def show_history():
-        if app.platform == "mac":
-            actions.key("cmd-y")
-        else:
-            actions.key("ctrl-shift-h")

--- a/apps/firefox/firefox.py
+++ b/apps/firefox/firefox.py
@@ -50,6 +50,14 @@ class BrowserActions:
     def bookmarks():
         actions.key(f"{cmd_ctrl}-shift-o")
 
+    def focus_address():
+        if app.platform == "mac":
+            actions.key("cmd-l")
+        else:
+            # Only using "ctrl-l" might fail and clear the console if the user
+            # is focused in the devtools
+            actions.key("f6 ctrl-l")
+
     def focus_page():
         actions.browser.focus_address()
         actions.edit.find()

--- a/apps/firefox/firefox.py
+++ b/apps/firefox/firefox.py
@@ -17,6 +17,8 @@ os: mac
 and app.bundle: org.mozilla.firefox
 """
 
+# Make the context match more specifically than anything else. This is important, eg. to
+# override the browser.go_home() implementation in tags/browser/browser_mac.py.
 ctx.matches = r"""
 os: windows
 os: linux

--- a/apps/firefox/firefox.py
+++ b/apps/firefox/firefox.py
@@ -56,7 +56,9 @@ class BrowserActions:
         else:
             # Only using "ctrl-l" might fail and clear the console if the user
             # is focused in the devtools
-            actions.key("f6 ctrl-l")
+            actions.key("f6")
+            actions.sleep("100ms")
+            actions.key("ctrl-l")
 
     def focus_page():
         actions.browser.focus_address()

--- a/apps/firefox/firefox_mac.py
+++ b/apps/firefox/firefox_mac.py
@@ -1,0 +1,33 @@
+from talon import Context, actions
+
+ctx = Context()
+
+ctx.matches = r"""
+os: mac
+tag: browser
+app: firefox
+"""
+
+
+@ctx.action_class("user")
+class UserActions:
+    def firefox_bookmarks_sidebar():
+        actions.key("cmd-b")
+
+    def firefox_history_sidebar():
+        actions.key("cmd-shift-h")
+
+
+@ctx.action_class("browser")
+class BrowserActions:
+    def bookmarks():
+        actions.key("cmd-shift-o")
+
+    def open_private_window():
+        actions.key("cmd-shift-p")
+
+    def show_downloads():
+        actions.key("cmd-j")
+
+    def show_extensions():
+        actions.key("cmd-shift-a")

--- a/apps/firefox/firefox_win_linux.py
+++ b/apps/firefox/firefox_win_linux.py
@@ -1,0 +1,44 @@
+from talon import Context, actions, app
+
+ctx = Context()
+
+ctx.matches = r"""
+os: windows
+os: linux
+tag: browser
+app: firefox
+"""
+
+
+@ctx.action_class("user")
+class UserActions:
+    def firefox_bookmarks_sidebar():
+        actions.key("ctrl-b")
+
+    def firefox_history_sidebar():
+        actions.key("ctrl-h")
+
+
+@ctx.action_class("browser")
+class BrowserActions:
+    def focus_address():
+        # Only using "ctrl-l" might fail and clear the console if the user
+        # is focused in the devtools
+        actions.key("f6")
+        actions.sleep("100ms")
+        actions.key("ctrl-l")
+
+    def open_private_window():
+        actions.key("ctrl-shift-p")
+
+    def show_downloads():
+        if app.platform == "linux":
+            actions.key("ctrl-shift-y")
+        else:
+            actions.key("ctrl-j")
+
+    def show_extensions():
+        actions.key("ctrl-shift-a")
+
+    def show_history():
+        actions.key("ctrl-shift-h")


### PR DESCRIPTION
If the user uses German menus that shortcut doesn't work and opens the file "Datei" menu instead.

Pressing F6 before pressing ctrl-l also ensures that the command will work if the user is focused in the devtools (instead of clearing the console).