### PR TITLE
fix #1087 by renaming `dropdown` to `drop down`

### DIFF
--- a/plugin/dropdown/dropdown.talon
+++ b/plugin/dropdown/dropdown.talon
@@ -1,3 +1,3 @@
 # pick item from a dropdown
-dropdown <number_small>: key("down:{number_small-1} enter")
-dropdown up <number_small>: key("up:{number_small} enter")
+drop down <number_small>: key("down:{number_small-1} enter")
+drop down up <number_small>: key("up:{number_small} enter")


### PR DESCRIPTION
rename `dropdown` command to `drop down` to fix #1087.