### PR TITLE
git_arguments.csv: add origin/main, origin/master

### DIFF
--- a/apps/git/git_arguments.csv
+++ b/apps/git/git_arguments.csv
@@ -63,3 +63,5 @@ main
 master
 origin
 upstream
+origin/main,origin main
+origin/master,origin master


### PR DESCRIPTION
Allows users to say eg. `git reset origin main` to produce `git reset origin/main`.