### PR TITLE
add paste-to-insert plugin & setting

### DIFF
--- a/plugin/paste_to_insert.py
+++ b/plugin/paste_to_insert.py
@@ -1,0 +1,22 @@
+from talon import Module, Context, actions
+import logging
+
+mod = Module()
+ctx = Context()
+
+paste_to_insert_threshold_setting = mod.setting(
+    "paste_to_insert_threshold",
+    type=int,
+    default=-1,
+    desc="""Use paste to insert text longer than this many characters.
+Zero means always paste; -1 means never paste.
+""")
+
+@ctx.action_class("main")
+class MainActions:
+    def insert(text):
+        threshold = paste_to_insert_threshold_setting.get()
+        if 0 <= threshold < len(text):
+            actions.user.paste(text)
+            return
+        actions.next(text)

--- a/plugin/paste_to_insert.py
+++ b/plugin/paste_to_insert.py
@@ -1,5 +1,6 @@
-from talon import Module, Context, actions
 import logging
+
+from talon import Context, Module, actions
 
 mod = Module()
 ctx = Context()
@@ -10,7 +11,9 @@ paste_to_insert_threshold_setting = mod.setting(
     default=-1,
     desc="""Use paste to insert text longer than this many characters.
 Zero means always paste; -1 means never paste.
-""")
+""",
+)
+
 
 @ctx.action_class("main")
 class MainActions:

--- a/settings.talon
+++ b/settings.talon
@@ -43,6 +43,10 @@ settings():
     # "command history more" to display all of them, "command history less" to restore
     user.command_history_size = 50
 
+    # Uncomment the below to insert text longer than 10 characters (customizable) by
+    # pasting from the clipboard. This is often faster than typing.
+    #user.paste_to_insert_threshold = 10
+
     # Uncomment the below to enable context-sensitive dictation. This determines
     # how to format (capitalize, space) dictation-mode speech by selecting &
     # copying surrounding text before inserting. This can be slow and may not


### PR DESCRIPTION
Adds a plugin that lets users use `user.paste` to insert text longer than certain # of characters. Disabled by default, with a commented-out setting in `settings.talon`.