### PR TITLE
Make repetition work when repeating a command more than 99 times

### DIFF
--- a/plugin/repeater/repeater.talon
+++ b/plugin/repeater/repeater.talon
@@ -1,5 +1,5 @@
 # -1 because we are repeating, so the initial command counts as one
 <user.ordinals>: core.repeat_command(ordinals - 1)
-<number_small> times: core.repeat_command(number_small - 1)
+<number> times: core.repeat_command(number - 1)
 (repeat that | twice): core.repeat_command(1)
-repeat that <number_small> [times]: core.repeat_command(number_small)
+repeat that <number> [times]: core.repeat_command(number)


### PR DESCRIPTION
**Problem:**
Currently, you can only use repetition eg `touch 75 times` up to 99 times. If you try to say `touch 100 times`, the command doesn't work properly.

This is useful in various contexts. An example where you might want to repeat commands more than 99 times is when playing a single-player game, or when creating a template. 

This cap has affected me many times, so it likely affects others too.

**Solution Applied:**
This edits the repetition logic to allow repetition any number of times rather than applying a cap of 99 times.