### PR TITLE
Minor homophone fixes

### DIFF
--- a/core/homophones/homophones.py
+++ b/core/homophones/homophones.py
@@ -20,8 +20,9 @@ show_help = False
 
 ctx = Context()
 mod = Module()
-mod.mode("homophones")
+
 mod.list("homophones_canonicals", desc="list of words ")
+mod.tag("homophones_open", desc="Tag for enabling homophones commands when the associated gui is open")
 
 main_screen = ui.main_screen()
 
@@ -57,7 +58,7 @@ is_selection = False
 
 def close_homophones():
     gui.hide()
-    actions.mode.disable("user.homophones")
+    ctx.tags = []
 
 
 PHONES_FORMATTERS = [
@@ -139,7 +140,7 @@ def raise_homophones(word_to_find_homophones_for, forced=False, selection=False)
 
         return
 
-    actions.mode.enable("user.homophones")
+    ctx.tags = ["user.homophones_open"]
     show_help = False
     gui.show()
 
@@ -189,7 +190,7 @@ class Actions:
         """Show homophones for selection, or current word if selection is empty."""
         text = actions.edit.selected_text()
         if text:
-            actions.user.homophones_show(text)
+            raise_homophones(text, False, True)
         else:
             actions.edit.select_word()
             actions.user.homophones_show_selection()

--- a/core/homophones/homophones.py
+++ b/core/homophones/homophones.py
@@ -22,7 +22,10 @@ ctx = Context()
 mod = Module()
 
 mod.list("homophones_canonicals", desc="list of words ")
-mod.tag("homophones_open", desc="Tag for enabling homophones commands when the associated gui is open")
+mod.tag(
+    "homophones_open",
+    desc="Tag for enabling homophones commands when the associated gui is open",
+)
 
 main_screen = ui.main_screen()
 

--- a/core/homophones/homophones_open.talon
+++ b/core/homophones/homophones_open.talon
@@ -1,4 +1,4 @@
-mode: user.homophones
+tag: user.homophones_open
 -
 choose <number_small>:
     result = user.homophones_select(number_small)


### PR DESCRIPTION
- Switch to using a tag instead of a mode 
- Call raise_homophones to ensure the quick replace functionality is used for selected words with only two homophones (addresses #1098)
