### PR TITLE
Switch screenshot_rect to become a user action

### DIFF
--- a/plugin/screenshot/screenshot.py
+++ b/plugin/screenshot/screenshot.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from typing import Optional
 
-from talon import Context, Module, actions, app, clip, cron, screen, ui
+from talon import Context, Module, actions, app, clip, cron, registry, screen, ui
 from talon.canvas import Canvas
 
 mod = Module()
@@ -26,16 +26,25 @@ class Actions:
     def screenshot(screen_number: Optional[int] = None):
         """Takes a screenshot of the entire screen and saves it to the pictures folder.
         Optional screen number can be given to use screen other than main."""
-        screen = get_screen(screen_number)
-        screenshot_rect(screen.rect)
+        selected_screen = get_screen(screen_number)
+        actions.user.screenshot_rect(selected_screen.rect)
 
     def screenshot_window():
         """Takes a screenshot of the active window and saves it to the pictures folder"""
         win = ui.active_window()
-        screenshot_rect(win.rect, win.app.name)
+        actions.user.screenshot_rect(win.rect, win.app.name)
 
     def screenshot_selection():
         """Triggers an application that is capable of taking a screenshot of a portion of the screen"""
+        if "user.selection_overlay_enabled" in registry.tags:
+            actions.user.selection_overlay_activate()
+        else:
+            if app.platform == "windows":
+                actions.key("super-shift-s")
+            elif app.platform == "mac":
+                actions.key("ctrl-shift-cmd-4")
+            elif app.platform == "linux":
+                actions.key("shift-printscr")
 
     def screenshot_selection_clip():
         """Triggers an application that is capable of taking a screenshot of a portion of the screen and adding to clipboard"""
@@ -52,20 +61,23 @@ class Actions:
     def screenshot_clipboard(screen_number: Optional[int] = None):
         """Takes a screenshot of the entire screen and saves it to the clipboard.
         Optional screen number can be given to use screen other than main."""
-        screen = get_screen(screen_number)
-        clipboard_rect(screen.rect)
+        selected_screen = get_screen(screen_number)
+        clipboard_rect(selected_screen.rect)
 
     def screenshot_window_clipboard():
         """Takes a screenshot of the active window and saves it to the clipboard"""
         win = ui.active_window()
         clipboard_rect(win.rect)
 
-
-def screenshot_rect(rect: ui.Rect, title: str = ""):
-    flash_rect(rect)
-    img = screen.capture_rect(rect)
-    path = get_screenshot_path(title)
-    img.write_file(path)
+    def screenshot_rect(
+        rect: ui.Rect, screen_num: Optional[int] = None, title: str = ""
+    ):
+        """Allow other modules this screenshot a rectangle"""
+        selected_screen = get_screen(screen_num)
+        flash_rect(rect)
+        img = screen.capture_rect(rect)
+        path = get_screenshot_path(title)
+        img.write_file(path)
 
 
 def clipboard_rect(rect: ui.Rect):

--- a/plugin/screenshot/screenshot.py
+++ b/plugin/screenshot/screenshot.py
@@ -32,7 +32,7 @@ class Actions:
     def screenshot_window():
         """Takes a screenshot of the active window and saves it to the pictures folder"""
         win = ui.active_window()
-        actions.user.screenshot_rect(win.rect, win.app.name)
+        actions.user.screenshot_rect(win.rect, title=win.app.name)
 
     def screenshot_selection():
         """Triggers an application that is capable of taking a screenshot of a portion of the screen"""

--- a/plugin/screenshot/screenshot.py
+++ b/plugin/screenshot/screenshot.py
@@ -36,15 +36,6 @@ class Actions:
 
     def screenshot_selection():
         """Triggers an application that is capable of taking a screenshot of a portion of the screen"""
-        if "user.selection_overlay_enabled" in registry.tags:
-            actions.user.selection_overlay_activate()
-        else:
-            if app.platform == "windows":
-                actions.key("super-shift-s")
-            elif app.platform == "mac":
-                actions.key("ctrl-shift-cmd-4")
-            elif app.platform == "linux":
-                actions.key("shift-printscr")
 
     def screenshot_selection_clip():
         """Triggers an application that is capable of taking a screenshot of a portion of the screen and adding to clipboard"""

--- a/plugin/screenshot/screenshot.py
+++ b/plugin/screenshot/screenshot.py
@@ -61,7 +61,7 @@ class Actions:
         clipboard_rect(win.rect)
 
     def screenshot_rect(
-        rect: ui.Rect, screen_num: Optional[int] = None, title: str = ""
+        rect: ui.Rect, title: str = "", screen_num: Optional[int] = None
     ):
         """Allow other modules this screenshot a rectangle"""
         selected_screen = get_screen(screen_num)

--- a/plugin/screenshot/screenshot.py
+++ b/plugin/screenshot/screenshot.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from typing import Optional
 
-from talon import Context, Module, actions, app, clip, cron, registry, screen, ui
+from talon import Context, Module, actions, app, clip, cron, screen, ui
 from talon.canvas import Canvas
 
 mod = Module()


### PR DESCRIPTION
As part of writing a screenshot tool a long time ago, I changed `screenshot_rect` to a user action. As I'm hoping to eventually push or share the other tool for others to use, I figured I'd push this change.

For reference the other tool is called shotbox https://github.com/fidgetingbits/knausj_talon/tree/master/plugin/shotbox, and the usage of this action is specifically https://github.com/fidgetingbits/knausj_talon/blob/master/plugin/shotbox/shotbox.py#L659

I vaguely recall when I wrote this the general consensus was that we shouldn't be importing other local python files (I think because of potential negative affects on talon dynamic module reloading), which is why I did this as a user action instead of just `from .. import screenshot_rect`. If this is no longer the case than it may be not necessary and I can just change my shotbox code, so I'll leave it up to you folks to decide.