### PR TITLE
Firefox: Fix commands 'tab previous' and 'tab next'.

### DIFF
--- a/apps/firefox/firefox.talon
+++ b/apps/firefox/firefox.talon
@@ -10,6 +10,9 @@ tab search <user.text>$:
     browser.focus_address()
     insert("% {text}")
     key(down)
+    
+tab (last | previous | left): key(ctrl-pageup)
+tab (next | right): key(ctrl-pagedown)
 
 (sidebar | panel) bookmarks: user.firefox_bookmarks_sidebar()
 (sidebar | panel) history: user.firefox_history_sidebar()

--- a/apps/firefox/firefox.talon
+++ b/apps/firefox/firefox.talon
@@ -11,8 +11,8 @@ tab search <user.text>$:
     insert("% {text}")
     key(down)
 
-tab (last | previous | left): key(ctrl-pageup)
-tab (next | right): key(ctrl-pagedown)
+tab (last | previous): key(ctrl-pageup)
+tab next: key(ctrl-pagedown)
 
 (sidebar | panel) bookmarks: user.firefox_bookmarks_sidebar()
 (sidebar | panel) history: user.firefox_history_sidebar()

--- a/apps/firefox/firefox.talon
+++ b/apps/firefox/firefox.talon
@@ -10,7 +10,7 @@ tab search <user.text>$:
     browser.focus_address()
     insert("% {text}")
     key(down)
-    
+
 tab (last | previous | left): key(ctrl-pageup)
 tab (next | right): key(ctrl-pagedown)
 


### PR DESCRIPTION
Default commands do not have the intended behavior in new versions of Firefox. Ctrl + PageUp and Ctrl + PageDown is the best universal alternative for moving left and right between tabs.