### PR TITLE
keys.py: simplify number key & function key handling a bit

### DIFF
--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -263,7 +263,7 @@ special_keys = {k: k for k in simple_keys}
 special_keys.update(alternate_keys)
 ctx.lists["self.special_key"] = special_keys
 ctx.lists["self.function_key"] = {
-    f"f {name}": f"f{i}" for i, name in enumerate(f_digits, start=1)
+    f"F {name}": f"f{i}" for i, name in enumerate(f_digits, start=1)
 }
 
 

--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -7,9 +7,7 @@ def setup_default_alphabet():
     """set up common default alphabet.
 
     no need to modify this here, change your alphabet using alphabet.csv"""
-    initial_default_alphabet = "air bat cap drum each fine gust harp sit jury crunch look made near odd pit quench red sun trap urge vest whale plex yank zip".split(
-        " "
-    )
+    initial_default_alphabet = "air bat cap drum each fine gust harp sit jury crunch look made near odd pit quench red sun trap urge vest whale plex yank zip".split()
     initial_letters_string = "abcdefghijklmnopqrstuvwxyz"
     initial_default_alphabet_dict = dict(
         zip(initial_default_alphabet, initial_letters_string)
@@ -22,11 +20,9 @@ alphabet_list = get_list_from_csv(
     "alphabet.csv", ("Letter", "Spoken Form"), setup_default_alphabet()
 )
 
-default_digits = "zero one two three four five six seven eight nine".split(" ")
-numbers = [str(i) for i in range(10)]
-default_f_digits = (
-    "one two three four five six seven eight nine ten eleven twelve".split(" ")
-)
+# used for number keys & function keys respectively
+digits = "zero one two three four five six seven eight nine".split()
+f_digits = "one two three four five six seven eight nine ten eleven twelve".split()
 
 mod = Module()
 mod.list("letter", desc="The spoken phonetic alphabet")
@@ -230,7 +226,7 @@ symbol_key_words = {
 symbol_key_words.update(punctuation_words)
 ctx.lists["self.punctuation"] = punctuation_words
 ctx.lists["self.symbol_key"] = symbol_key_words
-ctx.lists["self.number_key"] = dict(zip(default_digits, numbers))
+ctx.lists["self.number_key"] = {name: str(i) for i, name in enumerate(digits)}
 ctx.lists["self.arrow_key"] = {
     "down": "down",
     "left": "left",
@@ -267,7 +263,7 @@ special_keys = {k: k for k in simple_keys}
 special_keys.update(alternate_keys)
 ctx.lists["self.special_key"] = special_keys
 ctx.lists["self.function_key"] = {
-    f"F {default_f_digits[i]}": f"f{i + 1}" for i in range(12)
+    f"f {name}": f"f{i}" for i, name in enumerate(f_digits, start=1)
 }
 
 


### PR DESCRIPTION
small cleanup. drop the `default` prefix, it means nothing; use `str.split()` instead of `str.split(" ")`; use `enumerate` instead of a `numbers` array; add a comment explaining what the lists are for.