### PR TITLE
fix buffer next/buffer last

### DIFF
--- a/apps/emacs/emacs_commands.csv
+++ b/apps/emacs/emacs_commands.csv
@@ -10,8 +10,8 @@ balance-windows, ctrl-x +
 beginning-of-buffer, meta-<
 browse-kill-ring,, b-k-r
 buffer-menu, ctrl-x ctrl-b
-buffer-next, ctrl-x right
-buffer-previous, ctrl-x left
+next-buffer, ctrl-x right
+previous-buffer, ctrl-x left
 bury-buffer,, bur
 clear-rectangle, ctrl-x r c
 clone-indirect-buffer,, clo-i


### PR DESCRIPTION
I think these are supposed to match `emacs.talon`?
```
buffer next: user.emacs("next-buffer")
buffer last: user.emacs("previous-buffer")
```