### PR TITLE
match emacs on windows

### DIFF
--- a/apps/emacs/emacs.py
+++ b/apps/emacs/emacs.py
@@ -12,9 +12,14 @@ setting_meta = mod.setting(
 
 mod.apps.emacs = "app.name: Emacs"
 mod.apps.emacs = "app.name: emacs"
+mod.apps.emacs = "app.name: /GNU Emacs/"
 mod.apps.emacs = """
 os: mac
 app.bundle: org.gnu.Emacs
+"""
+mod.apps.emacs = """
+os: windows
+app.exe: emacs.exe
 """
 
 ctx = Context()


### PR DESCRIPTION
without this the new code doesn't activate on Windows. tested on Mac to make sure the matchers are not not conflicting