### PR TITLE
Match emacs using start-anchored match

### DIFF
--- a/apps/emacs/emacs.py
+++ b/apps/emacs/emacs.py
@@ -12,7 +12,7 @@ setting_meta = mod.setting(
 
 mod.apps.emacs = "app.name: Emacs"
 mod.apps.emacs = "app.name: emacs"
-mod.apps.emacs = "app.name: /GNU Emacs/"
+mod.apps.emacs = "app.name: /^GNU Emacs/"
 mod.apps.emacs = """
 os: mac
 app.bundle: org.gnu.Emacs

--- a/apps/emacs/emacs.py
+++ b/apps/emacs/emacs.py
@@ -12,9 +12,14 @@ setting_meta = mod.setting(
 
 mod.apps.emacs = "app.name: Emacs"
 mod.apps.emacs = "app.name: emacs"
+mod.apps.emacs = "app.name: /GNU Emacs/"
 mod.apps.emacs = """
 os: mac
 app.bundle: org.gnu.Emacs
+"""
+mod.apps.emacs = """
+os: windows
+app.exe: emacs.exe
 """
 
 ctx = Context()


### PR DESCRIPTION
as suggested by @auscompgeek  in https://github.com/knausj85/knausj_talon/pull/1174#discussion_r1174344589, start-anchor our emacs `app.name` matcher so it's `/^GNU Emacs/` instead of `/GNU Emacs/`