### PR TITLE
Allows the abbreviated/short form to be used as spoken phrase

### DIFF
--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -449,7 +449,7 @@ abbreviations_list = get_list_from_csv(
     default=abbreviations,
 )
 
-# Allows the abbreviated/short form to be used as spoken phrase
+# Allows the abbreviated/short form to be used as spoken phrase. eg "brief app" -> app
 abbreviations_list_with_values = {
     **{v: v for v in abbreviations_list.values()},
     **abbreviations_list,


### PR DESCRIPTION
`"brief application` => `app`
`"brief app"` => `app`