### PR TITLE
Improve Discord support

### DIFF
--- a/apps/discord/discord.py
+++ b/apps/discord/discord.py
@@ -1,7 +1,8 @@
-from talon import Context, Module
+from talon import Context, Module, actions
 
 mod = Module()
 apps = mod.apps
+apps.discord = "app.bundle: com.hnc.Discord"
 apps.discord = "app.name: Discord"
 apps.discord = "app.name: Discord.exe"
 apps.discord = """
@@ -18,7 +19,6 @@ app: discord
 
 ctx.lists["user.discord_destination"] = {
     "user": "@",
-    "channel": "#",
     "voice": "!",
     "server": "*",
 }
@@ -50,6 +50,9 @@ class discord_actions:
     def discord_gif_picker():
         """Toggle gif picker"""
 
+    def discord_sticker_picker():
+        """Toggle sticker picker"""
+
     def discord_mark_inbox_read():
         """Mark top inbox channel read"""
 
@@ -73,3 +76,10 @@ class discord_actions:
 
     def discord_toggle_dms():
         """Toggle between dms and your most recent server"""
+
+
+@ctx.action_class("user")
+class UserActions:
+    # Navigation: Channels
+    def messaging_open_channel_picker():
+        actions.user.discord_quick_switcher("#", "")

--- a/apps/discord/discord.talon
+++ b/apps/discord/discord.talon
@@ -3,22 +3,25 @@ app: discord
 tag(): user.messaging
 tag(): user.emoji
 
+# Navigation: QuickSwitcher
+{user.discord_destination} [<user.text>]:
+    user.discord_quick_switcher(user.discord_destination, user.text or "")
+switcher: user.discord_quick_switcher("", "")
+
 # Navigation: Channels
 [channel] mentions last: user.discord_mentions_last()
 [channel] mentions next: user.discord_mentions_next()
 oldest unread: user.discord_oldest_unread()
-{user.discord_destination} [<user.text>]:
-    user.discord_quick_switcher(user.discord_destination, user.text or "")
-switcher: user.discord_quick_switcher("", "")
 current call: user.discord_go_current_call()
-toggle (dee ems | dims): user.discord_toggle_dms()
 
 # UI
 toggle pins: user.discord_toggle_pins()
 toggle inbox: user.discord_toggle_inbox()
 toggle (members | member list): user.discord_toggle_members()
+toggle (dee ems | dims): user.discord_toggle_dms()
 pick emoji: user.discord_emoji_picker()
 pick (jif | gif | gift): user.discord_gif_picker()
+pick sticker: user.discord_sticker_picker()
 
 # Misc
 mark inbox channel read: user.discord_mark_inbox_read()

--- a/apps/discord/discord_mac.py
+++ b/apps/discord/discord_mac.py
@@ -9,6 +9,13 @@ app: discord
 
 @ctx.action_class("user")
 class UserActions:
+    # Navigation: QuickSwitcher
+    def discord_quick_switcher(dest_type: str, dest_search: str):
+        actions.key("cmd-k")
+        actions.insert(dest_type)
+        if dest_search:
+            actions.insert(dest_search)
+
     # Navigation: Servers
     def messaging_workspace_previous():
         actions.key("cmd-alt-up")
@@ -17,9 +24,6 @@ class UserActions:
         actions.key("cmd-alt-down")
 
     # Navigation: Channels
-    def messaging_open_channel_picker():
-        actions.key("cmd-k")
-
     def messaging_channel_previous():
         actions.key("alt-up")
 
@@ -57,6 +61,9 @@ class UserActions:
     def discord_gif_picker():
         actions.key("cmd-g")
 
+    def discord_sticker_picker():
+        actions.key("cmd-s")
+
     # Misc
     def messaging_mark_workspace_read():
         actions.key("shift-esc")
@@ -81,3 +88,9 @@ class UserActions:
 
     def discord_decline_call():
         actions.key("esc")
+
+    def discord_go_current_call():
+        actions.key("cmd-alt-a")
+
+    def discord_toggle_dms():
+        actions.key("cmd-alt-right")

--- a/apps/discord/discord_win.py
+++ b/apps/discord/discord_win.py
@@ -10,6 +10,13 @@ app: discord
 
 @ctx.action_class("user")
 class UserActions:
+    # Navigation: QuickSwitcher
+    def discord_quick_switcher(dest_type: str, dest_search: str):
+        actions.key("ctrl-k")
+        actions.insert(dest_type)
+        if dest_search:
+            actions.insert(dest_search)
+
     # Navigation: Servers
     def messaging_workspace_previous():
         actions.key("ctrl-alt-up")
@@ -18,9 +25,6 @@ class UserActions:
         actions.key("ctrl-alt-down")
 
     # Navigation: Channels
-    def messaging_open_channel_picker():
-        actions.key("ctrl-k")
-
     def messaging_channel_previous():
         actions.key("alt-up")
 
@@ -58,6 +62,9 @@ class UserActions:
     def discord_gif_picker():
         actions.key("ctrl-g")
 
+    def discord_sticker_picker():
+        actions.key("ctrl-s")
+
     # Misc
     def messaging_mark_workspace_read():
         actions.key("shift-esc")
@@ -88,9 +95,3 @@ class UserActions:
 
     def discord_toggle_dms():
         actions.key("ctrl-alt-right")
-
-    def discord_quick_switcher(dest_type: str, dest_search: str):
-        actions.key("ctrl-k")
-        actions.insert(dest_type)
-        if dest_search:
-            actions.insert(dest_search)


### PR DESCRIPTION
Some fixes from #937:

- Remove redundant "channel" command (also in messaging.talon)
- Implement commands on macOS
- Match Discord on macOS by bundle ID in case it's not named "Discord"

Also add command for sticker picker.

Needs testing on Windows.