### PR TITLE
use pop-to-mark-command not pop-mark

### DIFF
--- a/apps/emacs/emacs.py
+++ b/apps/emacs/emacs.py
@@ -153,11 +153,11 @@ class UserActions:
         if left:
             actions.edit.extend_word_left()
             before = actions.edit.selected_text()
-            actions.user.emacs("pop-mark")
+            actions.user.emacs("pop-to-mark-command")
         if right:
             actions.edit.extend_line_end()
             after = actions.edit.selected_text()
-            actions.user.emacs("pop-mark")
+            actions.user.emacs("pop-to-mark-command")
         return (before, after)
 
 

--- a/apps/emacs/emacs.talon
+++ b/apps/emacs/emacs.talon
@@ -184,7 +184,7 @@ diff (buffer | [buffer] with file):
 
 # ----- MOTION AND EDITING ----- #
 mark: user.emacs("set-mark-command")
-go back: user.emacs("pop-mark")
+go back: user.emacs("pop-to-mark-command")
 global [go] back: user.emacs("pop-global-mark")
 
 auto indent: user.emacs("indent-region")

--- a/apps/emacs/emacs_commands.csv
+++ b/apps/emacs/emacs_commands.csv
@@ -123,7 +123,7 @@ outline-up-heading, ctrl-c @ ctrl-u
 overwrite-mode,, overwr
 package-autoremove
 pop-global-mark, ctrl-x ctrl-@
-pop-mark, ctrl-u ctrl-space
+pop-to-mark-command, ctrl-u ctrl-space
 previous-error, meta-g p
 project-find-file, ctrl-x p f
 project-find-regexp, ctrl-x p g


### PR DESCRIPTION
pop-mark isn't an emacs command (only a function) and doesn't do what we want anyway. The keybinding it was listed with (ctrl-u ctrl-@) has the intended behavior, which is to invoke pop-to-mark-command. This PR means that we'll now do the right thing if `user.emacs` has to fall back to `M-x` or if it gets overridden to use RPC instead of keybindings.