### PR TITLE
update talon_settings_csv list

### DIFF
--- a/core/edit_text_file.py
+++ b/core/edit_text_file.py
@@ -14,12 +14,16 @@ mod.list("talon_settings_csv", desc="Absolute paths to talon user settings csv f
 _csvs = {
     name: os.path.join(SETTINGS_DIR, file_name)
     for name, file_name in {
+        "abbreviations": "abbreviations.csv",
+        "additional words": "additional_words.csv",
+        "alphabet": "alphabet.csv",
+        "directories": "directories.csv",
         "file extensions": "file_extensions.csv",
         "search engines": "search_engines.csv",
         "system paths": "system_paths.csv",
+        "unix utilities": "unix_utilities.csv",
         "websites": "websites.csv",
         "words to replace": "words_to_replace.csv",
-        "additional words": "additional_words.csv",
     }.items()
 }
 _csvs["homophones"] = os.path.join(REPO_DIR, "core", "homophones", "homophones.csv")


### PR DESCRIPTION
We have more setting CSVs now. I've added them and also alphabetized the list.

It would be nice if we didn't have to do this manually but somehow derived it from calls to the settings-reading machinery. Not sure how to do that.