### PR TITLE
add F keys 13-20

### DIFF
--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -22,7 +22,7 @@ alphabet_list = get_list_from_csv(
 
 # used for number keys & function keys respectively
 digits = "zero one two three four five six seven eight nine".split()
-f_digits = "one two three four five six seven eight nine ten eleven twelve".split()
+f_digits = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty".split()
 
 mod = Module()
 mod.list("letter", desc="The spoken phonetic alphabet")


### PR DESCRIPTION
Even though most keyboards do not have F13-F20, they are valid keys and some people use them, especially people with disabilities that they use alternate input devices like foot pedals.

My foot pedals are mapped to keys {F13, F14, F15} and that really simplifies creating "listeners" for the pedals.  It is also good that I can simply say F13 to get Talon to trigger those same listeners. 