### PR TITLE
simple_keys, add {super, alt}

### DIFF
--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -244,6 +244,8 @@ simple_keys = [
     "pageup",
     "space",
     "tab",
+    "super",
+    "alt",
 ]
 
 alternate_keys = {


### PR DESCRIPTION
It is useful to simulate a super key press to toggle the start menu. Likewise, it is useful to simulate an alt key press to toggle showing of keyboard shortcuts or alt modes in apps.