### PR TITLE
Remove unneeded jump in clear line command

### DIFF
--- a/tags/line_commands/line_commands.talon
+++ b/tags/line_commands/line_commands.talon
@@ -14,7 +14,6 @@ comment <number> until <number>:
     user.select_range(number_1, number_2)
     code.toggle_comment()
 clear [line] <number>:
-    edit.jump_line(number)
     user.select_range(number, number)
     edit.delete()
 clear <number> until <number>:


### PR DESCRIPTION
`select_range` already includes the `jump_line` action.