### PR TITLE
Correctly capitalize words with the CAPITALIZE_ALL_WORDS and CAPITALIZE_FIRST_WORD formatters

### DIFF
--- a/core/text/formatters.py
+++ b/core/text/formatters.py
@@ -125,10 +125,10 @@ formatters_dict = {
     "DOT_SEPARATED": words_with_joiner("."),
     "DOT_SNAKE": (NOSEP, lambda i, word, _: "." + word if i == 0 else "_" + word),
     "SLASH_SEPARATED": (NOSEP, every_word(lambda w: "/" + w)),
-    "CAPITALIZE_FIRST_WORD": (SEP, first_vs_rest(lambda w: w.capitalize())),
+    "CAPITALIZE_FIRST_WORD": (SEP, first_vs_rest(lambda w: w[:1].upper() + w[1:])),
     "CAPITALIZE_ALL_WORDS": (
         SEP,
-        lambda i, word, _: word.capitalize()
+        lambda i, word, _: word[:1].upper() + word[1:]
         if i == 0 or word not in words_to_keep_lowercase
         else word,
     ),


### PR DESCRIPTION
The `CAPITALIZE_ALL_WORDS` and `CAPITALIZE_FIRST_WORD` formatters currently uppercase the first letter of words but lowercase the rest. That means `NBA` becomes `Nba` and a custom word like `McGregor` become `Mcgregor`. 

Since both formatters are primarily used to dictate text, this is undesirable.

This pull request fixes that, capitalizing the first letter without lowercasing the rest.
