### PR TITLE
Make the tmux modifier key configurable

### DIFF
--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -7,16 +7,10 @@ ctx.matches = r"""
 tag: user.tmux
 """
 
-setting_tmux_mod_key = mod.setting(
-    "tmux_mod_key",
-    type=str,
-    default="ctrl",
-    desc="The modifier key used to call the tmux prefix",
-)
 setting_tmux_prefix_key = mod.setting(
     "tmux_prefix_key",
     type=str,
-    default="b",
+    default="ctrl-b",
     desc="The key used to prefix all tmux commands",
 )
 
@@ -26,7 +20,7 @@ class TmuxActions:
     def tmux_prefix():
         """press control and the configured tmux prefix key"""
         actions.key(
-            f"{setting_tmux_mod_key.get()}-{setting_tmux_prefix_key.get()}")
+            f"{setting_tmux_prefix_key.get()}")
 
     def tmux_keybind(key: str):
         """press tmux prefix followed by a key bind"""

--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -7,6 +7,12 @@ ctx.matches = r"""
 tag: user.tmux
 """
 
+setting_tmux_mod_key = mod.setting(
+    "tmux_mod_key",
+    type=str,
+    default="ctrl",
+    desc="The modifier key used to call the tmux prefix",
+)
 setting_tmux_prefix_key = mod.setting(
     "tmux_prefix_key",
     type=str,
@@ -19,7 +25,8 @@ setting_tmux_prefix_key = mod.setting(
 class TmuxActions:
     def tmux_prefix():
         """press control and the configured tmux prefix key"""
-        actions.key(f"ctrl-{setting_tmux_prefix_key.get()}")
+        actions.key(
+            f"{setting_tmux_mod_key.get()}-{setting_tmux_prefix_key.get()}")
 
     def tmux_keybind(key: str):
         """press tmux prefix followed by a key bind"""
@@ -60,7 +67,10 @@ class AppActions:
 @ctx.action_class("user")
 class UserActions:
     def tab_jump(number: int):
-        actions.user.tmux_execute_command(f"select-window -t {number}")
+        if number < 10:
+            actions.user.tmux_keybind(f"{number}")
+        else:
+            actions.user.tmux_execute_command(f"select-window -t {number}")
 
     def tab_close_wrapper():
         actions.user.tmux_execute_command_with_confirmation(


### PR DESCRIPTION
Make it possible to configure the modifier key for the people that use alternative keybindings (like I do with `alt-a` :smile:).

This pull request also updates how windows are switched to use the keybind and numbers from 0 to 9 if possible, for a slightly faster user experience.