### PR TITLE
edit_mac: Set the find pasteboard

### DIFF
--- a/core/edit/edit_mac.py
+++ b/core/edit/edit_mac.py
@@ -1,4 +1,4 @@
-from talon import Context, actions
+from talon import Context, actions, clip
 
 ctx = Context()
 ctx.matches = r"""
@@ -90,8 +90,9 @@ class EditActions:
         actions.key("cmd-up")
 
     def find(text: str = None):
+        if text is not None:
+            clip.set_text(text, mode="find")
         actions.key("cmd-f")
-        # actions.insert(text)
 
     def find_next():
         actions.key("cmd-g")


### PR DESCRIPTION
The `edit.find(text)` implementation for Linux and Windows insert the text:

https://github.com/knausj85/knausj_talon/blob/38cb583db62593165c9938dd481b5f2b159e4d53/core/edit/edit_linux.py#L94-L96

https://github.com/knausj85/knausj_talon/blob/38cb583db62593165c9938dd481b5f2b159e4d53/core/edit/edit_win.py#L94-L96

The Mac implementation ignored the text parameter however.

This sets the [find pasteboard](https://blog.robenkleene.com/2019/08/26/the-move-find-replace-using-the-find-pasteboard-in-macos/) if `text` is passed.