### PR TITLE
Make trigger shortcut more obscure

### DIFF
--- a/apps/vscode/vscode_command_client.py
+++ b/apps/vscode/vscode_command_client.py
@@ -104,4 +104,4 @@ class LinuxUserActions:
     def trigger_command_server_command_execution():
         # Work around bug with upper f-keys in VSCode on Linux. See
         # https://github.com/pokey/command-server/issues/9#issuecomment-963733930
-        actions.key("ctrl-shift-alt-p")
+        actions.key("ctrl-shift-alt-super-`")


### PR DESCRIPTION
The current shortcut [clashes with some extensions](https://github.com/cursorless-dev/cursorless/issues/880#issuecomment-2606151500)

This seems to work on my linux configuration with codium, whereas the f17 mapping didn't