### PR TITLE
feat: Case-insensitive extention match for language mode

### DIFF
--- a/core/modes/language_modes.py
+++ b/core/modes/language_modes.py
@@ -37,7 +37,7 @@ class CodeActions:
         if file_name in code_special_file_map:
             return code_special_file_map[file_name]
 
-        file_extension = actions.win.file_ext()
+        file_extension = actions.win.file_ext().lower()
         return extension_lang_map.get(file_extension, "")
 
 


### PR DESCRIPTION
e.g. for .R or .BAT