### PR TITLE
Fix withStatement wrapping for SQL and Python

### DIFF
--- a/core/snippets/snippets/sql.snippet
+++ b/core/snippets/snippets/sql.snippet
@@ -9,12 +9,3 @@ CREATE TABLE $1(
     $0
 );
 ---
-
-name: withStatement
-phrase: with
-insertionScope: statement
--
-WITH $1 AS (
-        SELECT $0
-)
----

--- a/core/snippets/snippets/withStatement.snippet
+++ b/core/snippets/snippets/withStatement.snippet
@@ -11,3 +11,10 @@ language: python
 with $1:
     $0
 ---
+
+language: sql
+-
+WITH $1 AS (
+	$0
+)
+---


### PR DESCRIPTION
Because community sends all the language snippets to Visual Studio Code, the inability to wrap in SQL means you can't wrap in Python either:

```
ValueError: No variable '0' in Snippet(name='withStatement', body='WITH $1 AS (\n\tSELECT $0\n)', description=None, phrases=['with'], insertion_scopes=['statement'], languages=['sql'], variables=[])
```