### PR TITLE
Add wrapper phrases to markdown snippets

### DIFF
--- a/core/snippets/snippets/markdown.snippet
+++ b/core/snippets/snippets/markdown.snippet
@@ -39,7 +39,7 @@ $0.wrapperPhrase: italic | emph | emphasis
 
 name: italic bold
 phrase: italic bold | bold italic | strong emphasis | strong emph
-$0.wrapperPhrase: strong emph
+$0.wrapperPhrase: italic bold | bold italic | strong emphasis | strong emph
 -
 ***$0***
 ---


### PR DESCRIPTION
## Why?
Make it easier to edit markdown document by re-formatting already written text. This is particularly useful when using cursorless.

## What?
Add wrapper phrases for: link, image, bold, italic, bold italic, and quote.