### PR TITLE
Remove settings change handler snippet

### DIFF
--- a/core/snippets/snippets/python.snippet
+++ b/core/snippets/snippets/python.snippet
@@ -149,17 +149,6 @@ def $1(path, flags):
 fs.watch($2, $1)
 ---
 
-name: talonSettingChangeHandler
-phrase: setting change handler
-insertionScope: namedFunction
-$1.insertionFormatter: SNAKE_CASE
--
-def $1(*args):
-    $0
-
-settings.register($2, $1)
----
-
 name: talonOnReadyFunction
 phrase: on ready handler
 -


### PR DESCRIPTION
Remove the snippet for registering a Talon settings change handler. Aegis has discouraged using this feature because this is not part of the public API and can have performance implications: https://talonvoice.slack.com/archives/C9MHQ4AGP/p1766608682484069?thread_ts=1766608544.979159&cid=C9MHQ4AGP

I therefore believe we should no longer have a snippet for it.