### PR TITLE
Fix draft window failing on 0.4

### DIFF
--- a/plugin/talon_draft_window/draft_talon_helpers.py
+++ b/plugin/talon_draft_window/draft_talon_helpers.py
@@ -54,11 +54,15 @@ mod.setting(
 
 
 draft_manager = None
+
+
 def on_ready():
     global draft_manager
     draft_manager = DraftManager()
 
+
 app.register("ready", on_ready)
+
 
 @ctx_focused.action_class("user")
 class ContextSensitiveDictationActions:

--- a/plugin/talon_draft_window/draft_ui.py
+++ b/plugin/talon_draft_window/draft_ui.py
@@ -72,9 +72,11 @@ class DraftManager:
         update the style based on the passed in parameters.
         """
         theme_changes = {}
-        name_setting_pairs = (("text_size", "text_size"), 
-                              ("label_size", "label_size"), 
-                              ("label", "label_color"))
+        name_setting_pairs = (
+            ("text_size", "text_size"),
+            ("label_size", "label_size"),
+            ("label", "label_color"),
+        )
         for name, setting in name_setting_pairs:
             if (value := settings.get(f"user.draft_window_{setting}")) is not None:
                 theme_changes[name] = value


### PR DESCRIPTION
@nriley This worked on public and the September 24 beta. The main issue was probably trying to define the draft manager at the top level instead of using on_ready. During the debugging process, I simplified the logic for defining the theme_changes dictionary.