### PR TITLE
Make Talon icon location description operating system specific

### DIFF
--- a/plugin/new_user_message/new_user_message.py
+++ b/plugin/new_user_message/new_user_message.py
@@ -48,7 +48,7 @@ def new_user_gui(gui: imgui.GUI):
     gui.line()
 
     gui.text(
-        f"You can see the Talon menu by right clicking the Talon icon in the {talon_menu_location}"
+        f"You can see the Talon menu by clicking the Talon icon in the {talon_menu_location}"
     )
 
     gui.line()


### PR DESCRIPTION
Say it is in the system tray on Windows, in the status area on MacOS, and in the system tray or status area on Linux. I tested this on Windows and MacOS but was not sure what to do for Linux.