### PR TITLE
Support help customize (1 line)

### DIFF
--- a/core/help/help.talon
+++ b/core/help/help.talon
@@ -21,6 +21,7 @@ help keywords: user.help_list("user.code_keyword")
 help keywords unprefixed: user.help_list("user.code_keyword_unprefixed")
 help common methods: user.help_list("user.code_common_method")
 help pairs: user.help_list("user.delimiter_pair")
+help customize: user.help_list("user.edit_text_file")
 
 (help formatters | help format | format help):
     user.help_formatters(user.get_formatters_words(), false)


### PR DESCRIPTION
`help customize` now shows the files you can open with the `customize` command. I named the help command after the corresponding command instead of the actual list name to make it easier to remember. 