### PR TITLE
use Python for Jupyter notebooks

### DIFF
--- a/core/modes/code_languages.py
+++ b/core/modes/code_languages.py
@@ -39,7 +39,7 @@ code_languages = [
     Language("php", "p h p", ["php"]),
     # Language("powershell", "power shell", ["ps1"]),
     Language("protobuf", "proto buf", ["proto"]),
-    Language("python", "python", ["py"]),
+    Language("python", "python", ["py", "ipynb"]),
     Language("r", "are language", ["r"]),
     # Language("racket", "racket", ["rkt"]),
     Language("ruby", "ruby", ["rb"]),


### PR DESCRIPTION
While it is technically possible to use different programming languages in Jupyter notebooks, I suppose the most common use case is to use Python. Hence, I would add this here until we find the way to do a more fine grained language detection inside Jupyter notebooks (e.g. for the Jupyter extension for VSCode)