### PR TITLE
add missing insertion formatter

### DIFF
--- a/core/snippets/snippets/includeSystemStatement.snippet
+++ b/core/snippets/snippets/includeSystemStatement.snippet
@@ -1,6 +1,8 @@
 name: includeSystemStatement
 phrase: include system | include sys
 insertionScope: statement
+
+$0.insertionFormatter: SNAKE_CASE
 ---
 
 language: c | cpp


### PR DESCRIPTION
fixes: #2109

I could only reproduce the linked issue on Talon version 0.4.0. Looking at the code, I would expect this to also fail on the Talon beta, but for some reason it doesn't.