### PR TITLE
Add gamepad tester getters for stick and trigger

### DIFF
--- a/plugin/gamepad/gamepad_tester.py
+++ b/plugin/gamepad/gamepad_tester.py
@@ -288,3 +288,11 @@ class Actions:
     def gamepad_tester_stick(id: str, x: float, y: float):
         """Indicates that a gamepad stick has changed state"""
         sticks[id] = (x, y)
+
+    def gamepad_tester_get_stick(id: str) -> tuple[float, float]:
+        """Get current stick value as reported by hardware"""
+        return sticks.get(id, (0.0, 0.0))
+
+    def gamepad_tester_get_trigger(id: str) -> float:
+        """Get current trigger value as reported by hardware"""
+        return triggers.get(id, 0.0)


### PR DESCRIPTION
I've been working on a test suite for my [talon-gamepad-rig](https://github.com/rokubop/talon-gamepad-rig) repository, and found the need for these extra functions when testing for [deadzones](https://github.com/rokubop/talon-gamepad-rig/blob/b0ed11bd78077d6b71b558bd96691288fb58cdeb/tests/test_deadzone.py#L13-L19).