### PR TITLE
Update tags read me

### DIFF
--- a/tags/README.md
+++ b/tags/README.md
@@ -2,8 +2,10 @@
 
 The tags folder has several other subfolders containing various commands:
 
+- `address` has commands for navigating by address, such as through an address bar or Finder's go-to-folder functionality". 
 - `browser` has generic web browser commands, such as for changing the current webpage and bookmarking pages
 - `chapters` has commands for navigating between chapters in a reader application
+ - `command_search` provides a command for running an arbitrary command based on a search, such as through VSCode's command palette.
 - `debugger` has commands for use within debuggers such as GDB and WinDbg
 - `emoji` has commands for using emojis, emoticons, and kaomoji. In this repository, the tags activating them are only present within the Discord and Slack `.talon` files
 - `file_manager` has commands for navigating files and folders within a file explorer or terminal, as described in the top level [README](https://github.com/talonhub/community?tab=readme-ov-file#file-manager-commands)

--- a/tags/README.md
+++ b/tags/README.md
@@ -2,7 +2,7 @@
 
 The tags folder has several other subfolders containing various commands:
 
-- `address` has commands for navigating by address, such as through an address bar or Finder's go-to-folder functionality". 
+- `address` has commands for navigating by address, such as through an address bar or Finder's go-to-folder functionality. 
 - `browser` has generic web browser commands, such as for changing the current webpage and bookmarking pages
 - `chapters` has commands for navigating between chapters in a reader application
  - `command_search` provides a command for running an arbitrary command based on a search, such as through VSCode's command palette.

--- a/tags/README.md
+++ b/tags/README.md
@@ -2,10 +2,10 @@
 
 The tags folder has several other subfolders containing various commands:
 
-- `address` has commands for navigating by address, such as through an address bar or Finder's go-to-folder functionality. 
+- `address` has commands for navigating by address, such as through an address bar or Finder's go-to-folder functionality.
 - `browser` has generic web browser commands, such as for changing the current webpage and bookmarking pages
 - `chapters` has commands for navigating between chapters in a reader application
- - `command_search` provides a command for running an arbitrary command based on a search, such as through VSCode's command palette.
+- `command_search` provides a command for running an arbitrary command based on a search, such as through VSCode's command palette.
 - `debugger` has commands for use within debuggers such as GDB and WinDbg
 - `emoji` has commands for using emojis, emoticons, and kaomoji. In this repository, the tags activating them are only present within the Discord and Slack `.talon` files
 - `file_manager` has commands for navigating files and folders within a file explorer or terminal, as described in the top level [README](https://github.com/talonhub/community?tab=readme-ov-file#file-manager-commands)


### PR DESCRIPTION
closes https://github.com/talonhub/community/issues/2169. 

Documents the newer `address`  and `command_search` directories under tags. 