### PR TITLE
pre-commit updates with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-minimum_pre_commit_version: "3.2.0"
+minimum_pre_commit_version: "4.5.0"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -13,7 +13,7 @@ repos:
       - id: detect-private-key
       - id: fix-byte-order-marker
       # NB. To avoid sometimes needing multiple runs, we need:
-      # - trailing-whitespace BEFORE end-of-file-fixer,
+      # - trailing-whitespace BEFORE end-of-sfile-fixer,
       #   otherwise trailing newline followed by whitespace, "\n ",
       #   will need multiple runs.
       # - end-of-file-fixer   BEFORE mixed-line-ending,
@@ -34,7 +34,8 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff-check
-        types_or: [python, pyproject]
+        # Want to use pyproject instead of toml, but pre-commit.ci doesn't yet support it.
+        types_or: [python, toml]
         args: [--fix]
       # Run the formatter.
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,20 +28,16 @@ repos:
     hooks:
       - id: prettier
 
-  - repo: https://github.com/ikamensh/flynt
-    rev: "1.0.6"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.15.12
     hooks:
-      - id: flynt
-
-  - repo: https://github.com/pycqa/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
-    hooks:
-      - id: black
+      # Run the linter.
+      - id: ruff-check
+        types_or: [python, pyproject]
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
 
   - repo: https://github.com/cursorless-dev/talon-tools
     rev: v0.10.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: detect-private-key
       - id: fix-byte-order-marker
       # NB. To avoid sometimes needing multiple runs, we need:
-      # - trailing-whitespace BEFORE end-of-sfile-fixer,
+      # - trailing-whitespace BEFORE end-of-file-fixer,
       #   otherwise trailing newline followed by whitespace, "\n ",
       #   will need multiple runs.
       # - end-of-file-fixer   BEFORE mixed-line-ending,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,15 +29,12 @@ repos:
       - id: prettier
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.15.12
     hooks:
-      # Run the linter.
       - id: ruff-check
         # Want to use pyproject instead of toml, but pre-commit.ci doesn't yet support it.
         types_or: [python, toml]
         args: [--fix]
-      # Run the formatter.
       - id: ruff-format
 
   - repo: https://github.com/cursorless-dev/talon-tools

--- a/apps/brave/brave.py
+++ b/apps/brave/brave.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, app
+from talon import Context, Module, actions
 
 ctx = Context()
 mod = Module()

--- a/apps/firefox/firefox.py
+++ b/apps/firefox/firefox.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, app
+from talon import Context, Module, actions
 
 ctx = Context()
 mod = Module()

--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -158,7 +158,6 @@ and app.bundle: com.jetbrains.jbr.java
 
 @mod.action_class
 class Actions:
-
     def idea(commands: str):
         """Send a command to Jetbrains product"""
         command_list = commands.split(",")
@@ -305,7 +304,6 @@ class WinActions:
 
 @ctx.action_class("user")
 class UserActions:
-
     def command_server_directory() -> str:
         return "jetbrains-command-server"
 

--- a/apps/mintty/mintty_win.py
+++ b/apps/mintty/mintty_win.py
@@ -67,8 +67,8 @@ class EditActions:
 @ctx.action_class("user")
 class UserActions:
     def file_manager_current_path():
-        path = ui.active_window().title
-        path = get_win_path(path)
+        title = ui.active_window().title
+        path = get_win_path(title)
 
         if path in directories_to_remap:
             path = directories_to_remap[title]

--- a/apps/mintty/mintty_win.py
+++ b/apps/mintty/mintty_win.py
@@ -71,7 +71,7 @@ class UserActions:
         path = get_win_path(title)
 
         if path in directories_to_remap:
-            path = directories_to_remap[title]
+            path = directories_to_remap[path]
 
         if path in directories_to_exclude:
             path = ""

--- a/apps/opera/opera_win_linux.py
+++ b/apps/opera/opera_win_linux.py
@@ -1,4 +1,4 @@
-from talon import Context, actions, app
+from talon import Context, actions
 
 ctx = Context()
 ctx.matches = r"""

--- a/apps/vivaldi/vivaldi.py
+++ b/apps/vivaldi/vivaldi.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, app
+from talon import Context, Module, actions
 
 ctx = Context()
 mod = Module()

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -115,7 +115,7 @@ class CodeActions:
 # Only do this for editor, so that e.g. modal windows can still be pasted into with
 # ctrl-v.
 @ctx_editor.action_class("edit")
-class EditActions:
+class EditorEditActions:
     def undo():
         actions.user.vscode("undo")
 

--- a/apps/windows_explorer/windows_explorer.py
+++ b/apps/windows_explorer/windows_explorer.py
@@ -85,7 +85,6 @@ if app.platform == "windows":
 
 @ctx.action_class("user")
 class UserActions:
-
     def file_manager_open_parent():
         actions.key("alt-up")
 

--- a/apps/windows_terminal/windows_terminal.py
+++ b/apps/windows_terminal/windows_terminal.py
@@ -32,7 +32,6 @@ class EditActions:
 
 @ctx.action_class("user")
 class UserActions:
-
     def tab_jump(number: int):
         actions.key(f"ctrl-alt-{number}")
 

--- a/core/deprecations.py
+++ b/core/deprecations.py
@@ -140,7 +140,7 @@ class Actions:
         msg = (
             f'The "{name}" command is deprecated since {time_deprecated}.'
             f' Instead, say: "{replacement}".'
-            f' See {os.path.join(REPO_DIR, "BREAKING_CHANGES.txt")}'
+            f" See {os.path.join(REPO_DIR, 'BREAKING_CHANGES.txt')}"
         )
         warnings.warn(msg, DeprecationWarning)
 
@@ -156,7 +156,7 @@ class Actions:
 
         msg = (
             f"The `{name}` capture is deprecated since {time_deprecated}."
-            f' See {os.path.join(REPO_DIR, "BREAKING_CHANGES.txt")}'
+            f" See {os.path.join(REPO_DIR, 'BREAKING_CHANGES.txt')}"
             f"{calculate_rule_info()}"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=3)
@@ -176,7 +176,7 @@ class Actions:
         msg = (
             f"The `{name}` action is deprecated since {time_deprecated}."
             f"{replacement_msg}"
-            f' See {os.path.join(REPO_DIR, "BREAKING_CHANGES.txt")}'
+            f" See {os.path.join(REPO_DIR, 'BREAKING_CHANGES.txt')}"
             f"{calculate_rule_info()}"
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=5)

--- a/core/dragon_engine.py
+++ b/core/dragon_engine.py
@@ -7,11 +7,11 @@ mod = Module()
 class Actions:
     def dragon_engine_sleep():
         """Sleep the dragon engine"""
-        speech_system.engine_mimic("go to sleep"),
+        speech_system.engine_mimic("go to sleep")
 
     def dragon_engine_wake():
         """Wake the dragon engine"""
-        speech_system.engine_mimic("wake up"),
+        speech_system.engine_mimic("wake up")
 
     def dragon_engine_command_mode():
         """Switch dragon to command mode. Requires Pro."""

--- a/core/homophones/homophones.py
+++ b/core/homophones/homophones.py
@@ -120,8 +120,9 @@ def raise_homophones(word_to_find_homophones_for, forced=False, selection=False)
     # Move current word to end of list to reduce searcher's cognitive load
     valid_homophones_reordered = list(
         filter(
-            lambda word_from_list: word_from_list.lower()
-            != word_to_find_homophones_for,
+            lambda word_from_list: (
+                word_from_list.lower() != word_to_find_homophones_for
+            ),
             valid_homophones,
         )
     ) + [word_to_find_homophones_for]

--- a/core/menu_choose/menu_choose.py
+++ b/core/menu_choose/menu_choose.py
@@ -7,7 +7,7 @@ mod = Module()
 class Actions:
     def choose(number_small: int):
         """Choose the nth item"""
-        actions.key(f"down:{number_small-1} enter")
+        actions.key(f"down:{number_small - 1} enter")
 
     def choose_up(number_small: int):
         """Choose the nth item up"""

--- a/core/mouse_grid/mouse_grid.py
+++ b/core/mouse_grid/mouse_grid.py
@@ -155,9 +155,9 @@ class MouseSnapNine:
                 for col in range(3):
                     text_string = ""
                     if settings.get("user.grids_put_one_bottom_left"):
-                        text_string = f"{(2 - row)*3+col+1}"
+                        text_string = f"{(2 - row) * 3 + col + 1}"
                     else:
-                        text_string = f"{row*3+col+1}"
+                        text_string = f"{row * 3 + col + 1}"
                     text_rect = canvas.paint.measure_text(text_string)[1]
                     background_rect = text_rect.copy()
                     background_rect.center = Point2d(

--- a/core/snippets/snippets_parser.py
+++ b/core/snippets/snippets_parser.py
@@ -458,8 +458,8 @@ def parse_vector_value(value: str) -> list[str]:
 
 
 def error(file: str, line: int, message: str):
-    logging.error(f"{file}:{line+1} | {message}")
+    logging.error(f"{file}:{line + 1} | {message}")
 
 
 def warn(file: str, line: int, message: str):
-    logging.warning(f"{file}:{line+1} | {message}")
+    logging.warning(f"{file}:{line + 1} | {message}")

--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -370,7 +370,9 @@ def auto_capitalize(text, state=None):
     return output, (
         "sentence start"
         if charge or sentence_end
-        else "after newline" if newline else None
+        else "after newline"
+        if newline
+        else None
     )
 
 

--- a/core/vocabulary/vocabulary.py
+++ b/core/vocabulary/vocabulary.py
@@ -65,8 +65,7 @@ class PhraseReplacer:
             words = spoken_form.split()
             if not words:
                 logging.warning(
-                    "Found empty spoken form for written form"
-                    f"{written_form}, ignored"
+                    f"Found empty spoken form for written form{written_form}, ignored"
                 )
                 continue
             first_word, n_next = words[0], len(words) - 1

--- a/core/windows_and_tabs/tabs.py
+++ b/core/windows_and_tabs/tabs.py
@@ -1,4 +1,4 @@
-from talon import Module, actions, app
+from talon import Module, actions
 
 mod = Module()
 

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -97,9 +97,9 @@ def _move_to_screen(
     moved.
 
     """
-    assert (
-        screen_number or offset and not (screen_number and offset)
-    ), "Provide exactly one of `screen_number` or `offset`."
+    assert screen_number or offset and not (screen_number and offset), (
+        "Provide exactly one of `screen_number` or `offset`."
+    )
 
     src_screen = window.screen
 

--- a/lang/terraform/terraform.py
+++ b/lang/terraform/terraform.py
@@ -90,13 +90,13 @@ class UserActions:
         actions.user.insert_between(text + ' "', '"')
 
     def code_terraform_resource(text: str):
-        result = f"resource \"{actions.user.formatted_text(text, 'SNAKE_CASE')}\" \"\""
+        result = f'resource "{actions.user.formatted_text(text, "SNAKE_CASE")}" ""'
 
         actions.insert(result)
         actions.key("left")
 
     def code_terraform_data_source(text: str):
-        result = f"data \"{actions.user.formatted_text(text, 'SNAKE_CASE')}\" \"\""
+        result = f'data "{actions.user.formatted_text(text, "SNAKE_CASE")}" ""'
 
         actions.insert(result)
         actions.key("left")

--- a/plugin/draft_editor/draft_editor.py
+++ b/plugin/draft_editor/draft_editor.py
@@ -44,8 +44,8 @@ def get_editor_names():
 
 def handle_app_running(_app):
     editor_names = get_editor_names()
-    for app in ui.apps(background=False):
-        if app.name in editor_names:
+    for a in ui.apps(background=False):
+        if a.name in editor_names:
             add_tag("user.draft_editor_app_running")
             return
     remove_tag("user.draft_editor_app_running")

--- a/plugin/talon_draft_window/draft_talon_helpers.py
+++ b/plugin/talon_draft_window/draft_talon_helpers.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from talon import Context, Module, actions, app, ui
+from talon import Context, Module, actions, app, cron, ui
 
 from .draft_ui import DraftManager
 
@@ -94,9 +94,6 @@ class EditActions:
             result = area[area.sel.left : area.sel.right]
             return result
         return ""
-
-
-from talon import cron
 
 
 class UndoWorkaround:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
-    "I" # isort
+    "I", # isort
 ]
 ignore = ["E722", "E741"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,17 @@
-[tool.black]
-target-version = ['py310']
-
-[tool.isort]
-profile = 'black'
-
 [tool.pytest.ini_options]
 pythonpath = [
     ".",
     "test/stubs",
 ]
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "I" # isort
+]
+ignore = ["E722", "E741"]
 
 [tool.pyright]
 reportSelfClsParameterName = false

--- a/tags/browser/browser_mac.py
+++ b/tags/browser/browser_mac.py
@@ -1,4 +1,4 @@
-from talon import Context, actions, app, ui
+from talon import Context, actions, ui
 
 ctx = Context()
 ctx.matches = r"""

--- a/test/test_code_modified_function.py
+++ b/test/test_code_modified_function.py
@@ -7,7 +7,7 @@ if hasattr(talon, "test_mode"):
 
     def setup_function():
         # Load our code under test (register code_* actions)
-        import lang.tags.functions  # isort:skip
+        import lang.tags.functions  # noqa: F401
 
         actions.reset_test_actions()
 

--- a/test/test_create_spoken_forms.py
+++ b/test/test_create_spoken_forms.py
@@ -4,7 +4,7 @@ if hasattr(talon, "test_mode"):
     # Only include this when we're running tests
 
     import itertools
-    from typing import IO, Callable
+    from typing import Callable
 
     from talon import actions
 


### PR DESCRIPTION
From the Community Backlog session — we are using a combination of pre-commit hooks which are no longer supported, no longer relevant, slow or have newer/better alternatives.

```
  - repo: https://github.com/pre-commit/mirrors-prettier
    rev: "v4.0.0-alpha.8"
    hooks:
      - id: prettier
```
this is in use for JavaScript, CSS, JSON, etc. — probably for JSON/YAML/Markdown. The repository above is archived and we should find an alternative. @AndreasArvidsson recommends we give [oxc](https://oxc.rs) a look.

```
  - repo: https://github.com/ikamensh/flynt
    rev: "1.0.6"
    hooks:
      - id: flynt
```
I think we can remove this entirely as it's there to support migration to Python 3.6 string formatting.

```
  - repo: https://github.com/pycqa/isort
    rev: 8.0.1
    hooks:
      - id: isort
  - repo: https://github.com/psf/black-pre-commit-mirror
    rev: 26.3.1
    hooks:
      - id: black
```
these two can be replaced by [Ruff](https://docs.astral.sh/ruff/), as in this PR.