### PR TITLE
Fix startup error

### DIFF
--- a/apps/dolphin/dolphin.py
+++ b/apps/dolphin/dolphin.py
@@ -40,7 +40,7 @@ class UserActions:
         actions.insert(path)
         actions.key("enter")
 
-    def file_manager_new_folder(name: Optional[str] = None):
+    def file_manager_new_folder(name: str = None):
         actions.key("ctrl-shift-n")
         if name:
             actions.insert(name)


### PR DESCRIPTION
Optional was not imported, which creates an error. Importing Optional currently creates another error because it makes the signature inconsistent with the base action. I am submitting the quickest fix for now. We can fix the type signatures to use Optional later.