### PR TITLE
Add clipboard link commands

### DIFF
--- a/lang/markdown/markdown.py
+++ b/lang/markdown/markdown.py
@@ -1,4 +1,6 @@
-from talon import Context, Module
+from talon import Context, Module, actions
+
+from typing import Optional
 
 mod = Module()
 ctx = Context()
@@ -19,3 +21,17 @@ ctx.lists["user.markdown_code_block_language"] = {
     "are": "r",
     "markdown": "markdown",
 }
+
+@mod.action_class
+class Actions:
+    def markdown_insert_link(url: str, description: Optional[str]=None):
+        """Inserts a markdown link filling in the url and optionally filling in the description"""
+        substitutions = {"0": url}
+        if description is not None:
+            substitutions["1"] = description
+        actions.user.insert_snippet_by_name("link", substitutions)
+
+    def markdown_wrap_selection_with_link(url: str):
+        """Wraps the selection with a markdown link pointing to the specified url"""
+        description = actions.edit.selected_text()
+        actions.user.markdown_insert_link(url, description)

--- a/lang/markdown/markdown.py
+++ b/lang/markdown/markdown.py
@@ -1,6 +1,6 @@
-from talon import Context, Module, actions
-
 from typing import Optional
+
+from talon import Context, Module, actions
 
 mod = Module()
 ctx = Context()
@@ -22,9 +22,10 @@ ctx.lists["user.markdown_code_block_language"] = {
     "markdown": "markdown",
 }
 
+
 @mod.action_class
 class Actions:
-    def markdown_insert_link(url: str, description: Optional[str]=None):
+    def markdown_insert_link(url: str, description: Optional[str] = None):
         """Inserts a markdown link filling in the url and optionally filling in the description"""
         substitutions = {"0": url}
         if description is not None:

--- a/lang/markdown/markdown.py
+++ b/lang/markdown/markdown.py
@@ -32,6 +32,6 @@ class Actions:
         actions.user.insert_snippet_by_name("link", substitutions)
 
     def markdown_wrap_selection_with_link(url: str):
-        """Wraps the selection with a markdown link pointing to the specified url"""
+        """Wraps the selection with a markdown link for the specified url"""
         description = actions.edit.selected_text()
         actions.user.markdown_insert_link(url, description)

--- a/lang/markdown/markdown.talon
+++ b/lang/markdown/markdown.talon
@@ -43,3 +43,5 @@ list six:
     user.insert_snippet("```{markdown_code_block_language}\n$0\n```")
 
 link: user.insert_snippet_by_name("link")
+link paste: user.markdown_insert_link(clip.text())
+link wrap paste: user.markdown_wrap_selection_with_link(clip.text())

--- a/lang/markdown/markdown.talon
+++ b/lang/markdown/markdown.talon
@@ -43,5 +43,5 @@ list six:
     user.insert_snippet("```{markdown_code_block_language}\n$0\n```")
 
 link: user.insert_snippet_by_name("link")
-link paste: user.markdown_insert_link(clip.text())
-link wrap paste: user.markdown_wrap_selection_with_link(clip.text())
+link clip: user.markdown_insert_link(clip.text())
+link wrap clip: user.markdown_wrap_selection_with_link(clip.text())


### PR DESCRIPTION
closes #2202. I used `paste` instead of `clip` to be consistent with commands that actually insert the clipboard text.