### PR TITLE
Document sleep settings practice

### DIFF
--- a/PRACTICES.md
+++ b/PRACTICES.md
@@ -120,4 +120,4 @@ This approach allows reusing the same commands in multiple contexts and helps pr
 - Use the `sleep` action instead of the Python `time.sleep` function.
 - Avoid sleeping inside a `cron` callback because public Talon runs all such callbacks in a single thread.
 - Avoid command or action implementations that sleep for more than a total of ~200 ms. Talon is unresponsive to commands while sleeping; long delays also trigger watchdog warnings in the Talon log. Consider using `cron` to schedule actions requiring a longer delay.
-- Make a setting for a sleep's duration a float determining the number of seconds to sleep unless you have a good reason to do otherwise. Note that the sleep action interprets a float argument as representing a number of seconds already.
+- Sleep duration settings should be a `float`-typed number of seconds to sleep unless you have a good reason to do otherwise. Note that the `sleep` action interprets a `float` argument as seconds.

--- a/PRACTICES.md
+++ b/PRACTICES.md
@@ -120,3 +120,4 @@ This approach allows reusing the same commands in multiple contexts and helps pr
 - Use the `sleep` action instead of the Python `time.sleep` function.
 - Avoid sleeping inside a `cron` callback because public Talon runs all such callbacks in a single thread.
 - Avoid command or action implementations that sleep for more than a total of ~200 ms. Talon is unresponsive to commands while sleeping; long delays also trigger watchdog warnings in the Talon log. Consider using `cron` to schedule actions requiring a longer delay.
+- Make a setting for a sleep's duration a float determining the number of seconds to sleep unless you have a good reason to do otherwise. Note that the sleep action interprets a float argument as representing a number of seconds already.


### PR DESCRIPTION
Document that a sleep setting should be a float representing time in seconds unless there is a good reason to do otherwise.