### PR TITLE
Make context sensitive dictation work for Atlassian web apps

### DIFF
--- a/apps/atlassian/atlassian.talon
+++ b/apps/atlassian/atlassian.talon
@@ -1,0 +1,6 @@
+tag: browser
+browser.host: /atlassian\.(com|net|cloud)/
+-
+
+settings():
+	user.context_sensitive_dictation_peek_character = "."

--- a/apps/atlassian/atlassian.talon
+++ b/apps/atlassian/atlassian.talon
@@ -1,5 +1,5 @@
 tag: browser
-browser.host: /atlassian\.(com|net|cloud)/
+browser.host: /atlassian\.(com|net|cloud)$/
 -
 
 settings():

--- a/apps/atlassian/atlassian.talon
+++ b/apps/atlassian/atlassian.talon
@@ -3,4 +3,4 @@ browser.host: /atlassian\.(com|net|cloud)/
 -
 
 settings():
-	user.context_sensitive_dictation_peek_character = "."
+    user.context_sensitive_dictation_peek_character = "."


### PR DESCRIPTION
Using space as the peek character for context dictation is not working, so this uses a different character.