### PR TITLE
Add lowercase 'code' to Linux VS Code app names

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -27,6 +27,8 @@ mod.apps.vscode = """
 os: linux
 and app.name: Code
 os: linux
+and app.name: code
+os: linux
 and app.name: code-oss
 os: linux
 and app.name: code-insiders


### PR DESCRIPTION
I'm on Ubuntu 25.10 using i3 and VSCode identifies as lowercase "code", so I'm adding that to make talon recognize it properly.

$ xprop
_NET_WM_DESKTOP(CARDINAL) = 1
_NET_WM_STATE(ATOM) = _NET_WM_STATE_MAXIMIZED_VERT
WM_STATE(WM_STATE):
		window state: Normal
		icon window: 0x0
_NET_WM_USER_TIME(CARDINAL) = 5291424
WM_NORMAL_HINTS(WM_SIZE_HINTS):
		program specified location: 0, 54
		program specified minimum size: 600 by 405
		window gravity: Static
_NET_WM_ICON(CARDINAL) = 
_NET_WM_OPAQUE_REGION(CARDINAL) = 0, 54, 1920, 2070
_MOTIF_WM_HINTS(_MOTIF_WM_HINTS) = 0x2, 0x0, 0x0, 0x0, 0x0
XdndAware(ATOM) = BITMAP
_NET_WM_BYPASS_COMPOSITOR(CARDINAL) = 2
_NET_WM_SYNC_REQUEST_COUNTER(CARDINAL) = 109051909
_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED(CARDINAL) = 1
WM_NAME(UTF8_STRING) = "● 00_fix_stdout.py - extension - Visual Studio Code"
_NET_WM_NAME(UTF8_STRING) = "● 00_fix_stdout.py - extension - Visual Studio Code"
WM_WINDOW_ROLE(STRING) = "browser-window"
WM_CLASS(STRING) = "code", "code"
_NET_WM_WINDOW_TYPE(ATOM) = _NET_WM_WINDOW_TYPE_NORMAL
_NET_WM_PID(CARDINAL) = 20763
WM_CLIENT_MACHINE(STRING) = <omitted>
WM_PROTOCOLS(ATOM): protocols  WM_DELETE_WINDOW, _NET_WM_PING, _NET_WM_SYNC_REQUEST
