### PR TITLE
Improve correctness of explaining why we should not sleep in a cron thread

### DIFF
--- a/PRACTICES.md
+++ b/PRACTICES.md
@@ -123,7 +123,7 @@ Our voice commands using the clipboard usually have `paste` or `clip` in their s
 ## Sleep Practices
 
 - Use the `sleep` action instead of the Python `time.sleep` function.
-- Avoid sleeping inside a `cron` callback because public Talon runs all such callbacks in a single thread.
+- Avoid sleeping or blocking inside a `cron` callback because that would affect other `cron` jobs.
 - Avoid command or action implementations that sleep for more than a total of ~200 ms. Talon is unresponsive to commands while sleeping; long delays also trigger watchdog warnings in the Talon log. Consider using `cron` to schedule actions requiring a longer delay.
 - Sleep duration settings should be a `float`-typed number of seconds to sleep unless you have a good reason to do otherwise. Note that the `sleep` action interprets a `float` argument as seconds.
 


### PR DESCRIPTION
Based on discussion in the slack with Aegis, it does not seem to be quite correct that these callbacks are all run in a single thread but blocking nonetheless does affect the other cron jobs.