### PR TITLE
Remove inappropriate/unneeded type annotations identified by Talon 1389.

### DIFF
--- a/apps/emacs/emacs.py
+++ b/apps/emacs/emacs.py
@@ -285,7 +285,7 @@ class EditActions:
     def jump_line(n):
         actions.user.emacs("goto-line", n)
 
-    def select_line(n: int = None):
+    def select_line(n=None):
         if n is not None:
             actions.edit.jump_line(n)
         else:
@@ -315,7 +315,7 @@ class EditActions:
 
     # Some modes override ctrl-s/r to do something other than isearch-forward, so we
     # deliberately don't use actions.user.emacs.
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-s")
         if text:
             actions.insert(text)

--- a/apps/gnome_terminal/gnome_terminal.py
+++ b/apps/gnome_terminal/gnome_terminal.py
@@ -79,7 +79,7 @@ class EditActions:
     def copy():
         actions.key("ctrl-shift-c")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-shift-f")
         if text:
             actions.insert(text)

--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -232,7 +232,7 @@ class EditActions:
     def find_previous():
         actions.user.idea("action FindPrevious")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.user.idea("action Find")
         if text:
             actions.insert(text)
@@ -252,7 +252,7 @@ class EditActions:
     def indent_less():
         actions.user.idea("action EditorUnindentSelection")
 
-    def select_line(n: int = None):
+    def select_line(n=None):
         actions.user.idea("action EditorSelectLine")
 
     def select_word():

--- a/apps/kde_konsole/kde_konsole.py
+++ b/apps/kde_konsole/kde_konsole.py
@@ -53,7 +53,7 @@ class EditActions:
     def copy():
         actions.key("ctrl-shift-c")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-shift-f")
         if str:
             actions.insert(text)

--- a/apps/obsidian/obsidian.py
+++ b/apps/obsidian/obsidian.py
@@ -432,7 +432,7 @@ class EditActions:
     def save():
         actions.user.obsidian("editor:save-file")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.sleep("50ms")
         actions.user.obsidian("editor:open-search")
         if text:

--- a/apps/terminator/terminator_linux.py
+++ b/apps/terminator/terminator_linux.py
@@ -109,7 +109,7 @@ class EditActions:
     def copy():
         actions.key("ctrl-shift-c")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-shift-f")
         if text:
             actions.insert(text)

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -130,7 +130,7 @@ class EditorEditActions:
     def paste():
         actions.user.vscode("editor.action.clipboardPasteAction")
 
-    def find(text: str = None):
+    def find(text=None):
         if text:
             actions.user.run_rpc_command(
                 "editor.actions.findWithArgs", {"searchString": text}
@@ -227,7 +227,7 @@ class Actions:
 
 @mac_ctx.action_class("edit")
 class MacEditActions:
-    def find(text: str = None):
+    def find(text=None):
         actions.key("cmd-f")
         if text:
             actions.insert(text)

--- a/apps/windows_terminal/windows_terminal.py
+++ b/apps/windows_terminal/windows_terminal.py
@@ -24,7 +24,7 @@ class EditActions:
     def copy():
         actions.key("ctrl-shift-c")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-shift-f")
         if text:
             actions.insert(text)

--- a/apps/xfce4_terminal/xfce4_terminal.py
+++ b/apps/xfce4_terminal/xfce4_terminal.py
@@ -59,7 +59,7 @@ class EditActions:
     def file_start():
         actions.key("shift-home")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-shift-f")
         if text:
             actions.insert(text)

--- a/core/edit/edit_linux.py
+++ b/core/edit/edit_linux.py
@@ -91,7 +91,7 @@ class EditActions:
     def file_start():
         actions.key("ctrl-home")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-f")
         if text:
             actions.insert(text)
@@ -161,7 +161,7 @@ class EditActions:
     def select_all():
         actions.key("ctrl-a")
 
-    def select_line(n: int = None):
+    def select_line(n=None):
         if n is not None:
             actions.edit.jump_line(n)
         actions.key("end shift-home")

--- a/core/edit/edit_mac.py
+++ b/core/edit/edit_mac.py
@@ -89,7 +89,7 @@ class EditActions:
     def file_start():
         actions.key("cmd-up")
 
-    def find(text: str = None):
+    def find(text=None):
         if text is not None:
             clip.set_text(text, mode="find")
         actions.key("cmd-f")
@@ -161,7 +161,7 @@ class EditActions:
     def select_all():
         actions.key("cmd-a")
 
-    def select_line(n: int = None):
+    def select_line(n=None):
         if n is not None:
             actions.edit.jump_line(n)
         actions.key("cmd-right cmd-shift-left")

--- a/core/edit/edit_win.py
+++ b/core/edit/edit_win.py
@@ -91,7 +91,7 @@ class EditActions:
     def file_start():
         actions.key("ctrl-home")
 
-    def find(text: str = None):
+    def find(text=None):
         actions.key("ctrl-f")
         if text:
             actions.insert(text)
@@ -161,7 +161,7 @@ class EditActions:
     def select_all():
         actions.key("ctrl-a")
 
-    def select_line(n: int = None):
+    def select_line(n=None):
         if n is not None:
             actions.edit.jump_line(n)
         actions.key("end shift-home")


### PR DESCRIPTION
Many action parameters are `str = None`, but `None` is not a `str`. Talon 1389 cares about this; for backwards compatibility with Talon 0.4 we use `Optional[str]` rather than `str | None`.

Action implementations (as opposed to declarations) do not require type annotations; they can't differ from the declarations and Talon doesn't type check them anyway, so remove them.