### PR TITLE
Document browser.host matcher anchoring practice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Each of the principles is numbered for easy referencing. The body is formatted a
 # Voice command principles
 
 - P01 - Prefer [object][verb] rather than [verb][object] for new commands. For example 'file save' is better than 'save file'. It may not sound as natural, but it helps for grouping related commands in lists and avoiding conflicting names.
-- P02 - Use `browser.host` matcher for web apps. Though this matcher requires a [browser extension](https://github.com/talonhub/community/blob/main/apps/README.md) on some operating systems it is the only unambiguous way of referring to a web app.
+- P02 - Use `browser.host` matcher for web apps. Though this matcher requires a [browser extension](https://github.com/talonhub/community/blob/main/apps/README.md) on some operating systems it is the only unambiguous way of referring to a web app. Prefer exact host strings such as `browser.host: github.com` when possible. When a regex is needed, anchor it because `browser.host` is already matched against the host portion of the URL, for example `browser.host: /^(.+\.)?example\.com$/`.
 
 # Coding principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Each of the principles is numbered for easy referencing. The body is formatted a
 # Voice command principles
 
 - P01 - Prefer [object][verb] rather than [verb][object] for new commands. For example 'file save' is better than 'save file'. It may not sound as natural, but it helps for grouping related commands in lists and avoiding conflicting names.
-- P02 - Use `browser.host` matcher for web apps. Though this matcher requires a [browser extension](https://github.com/talonhub/community/blob/main/apps/README.md) on some operating systems it is the only unambiguous way of referring to a web app. Prefer exact host strings such as `browser.host: github.com` when possible. When a regex is needed, anchor it because `browser.host` is already matched against the host portion of the URL, for example `browser.host: /^(.+\.)?example\.com$/`.
+- P02 - Use `browser.host` matcher for web apps. Though this matcher requires a [browser extension](https://github.com/talonhub/community/blob/main/apps/README.md) on some operating systems it is the only unambiguous way of referring to a web app. Prefer exact host strings such as `browser.host: github.com` when possible. When a regex is needed to match subdomains or related domains, anchor it because `browser.host` is the host portion of the URL, for example `browser.host: /^(.+\.)?example\.com$/`.
 
 # Coding principles
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,7 +4,7 @@ Some of the Talon files for web apps (e.g. `apps/github/github_web.talon`) use a
 
 `community` is set up so that if a URL is found in the titlebar of an application matching the 'browser' tag it will be used to populate the browser.host matcher (see `code/browser.py`). This probably means that you will need an extension to make the browser.host based scripts work.
 
-When adding a web app, prefer an exact `browser.host` match such as `browser.host: github.com` if the host is fixed. If you need a regex for subdomains or multiple related domains, anchor it because `browser.host` already receives the host portion of the URL. For example, use `browser.host: /^(.+\.)?example\.com$/` rather than matching an unanchored fragment.
+When adding a web app, see recommendation P02 in [CONTRIBUTING.md](https://github.com/talonhub/community/blob/main/CONTRIBUTING.md#voice-command-principles).
 
 Browser extensions that can add the protocol and hostname or even the entire URL to the window title:
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,6 +4,8 @@ Some of the Talon files for web apps (e.g. `apps/github/github_web.talon`) use a
 
 `community` is set up so that if a URL is found in the titlebar of an application matching the 'browser' tag it will be used to populate the browser.host matcher (see `code/browser.py`). This probably means that you will need an extension to make the browser.host based scripts work.
 
+When adding a web app, prefer an exact `browser.host` match such as `browser.host: github.com` if the host is fixed. If you need a regex for subdomains or multiple related domains, anchor it because `browser.host` already receives the host portion of the URL. For example, use `browser.host: /^(.+\.)?example\.com$/` rather than matching an unanchored fragment.
+
 Browser extensions that can add the protocol and hostname or even the entire URL to the window title:
 
 Firefox:


### PR DESCRIPTION
## Summary

Adds a short note documenting the preferred `browser.host` matching style for web apps.

- Prefer exact host strings when the host is fixed.
- Anchor regex matchers when regex is needed, since `browser.host` already receives the host portion of the URL.
- Added the guidance in both the contributor principles and the web app README.

Fixes #2222.
