### PR TITLE
never paste into the terminal

### DIFF
--- a/settings.talon
+++ b/settings.talon
@@ -86,6 +86,7 @@ settings():
 
     # Uncomment to insert text longer than 10 characters (customizable) by pasting from
     # the clipboard. This is often faster than typing.
+    # Note: some contexts (e.g. the terminal tag) may override this global setting.
     # user.paste_to_insert_threshold = 10
 
     # Uncomment to enable context-sensitive dictation. This determines how to format

--- a/tags/terminal/terminal.talon
+++ b/tags/terminal/terminal.talon
@@ -1,5 +1,7 @@
 tag: terminal
 -
+settings():
+      user.paste_to_insert_threshold = -1
 
 # tags should be activated for each specific terminal in the respective talon file
 

--- a/tags/terminal/terminal.talon
+++ b/tags/terminal/terminal.talon
@@ -1,7 +1,8 @@
 tag: terminal
 -
+
 settings():
-      user.paste_to_insert_threshold = -1
+    user.paste_to_insert_threshold = -1
 
 # tags should be activated for each specific terminal in the respective talon file
 

--- a/tags/terminal/terminal.talon
+++ b/tags/terminal/terminal.talon
@@ -2,6 +2,7 @@ tag: terminal
 -
 
 settings():
+    # pasting into terminal emulators may trigger "executable code" warnings
     user.paste_to_insert_threshold = -1
 
 # tags should be activated for each specific terminal in the respective talon file


### PR DESCRIPTION
Most terminal emulators on Linux have a safeguard that will check pasted text and require user interaction if that pasted text appears to execute code. Disabling the `paste_to_insert_threshold`, even if it is enabled in the global configuration, sidesteps this issue.